### PR TITLE
Self-host M1 macOS GitHub Actions runner

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -81,6 +81,10 @@ jobs:
             "linux-x86_64")
               bazel run //bazel/toolchain:x86_64-linux-musl-gcc
               ;;
+            "macos-arm64")
+              # Switch Xcode path to match the path specified in our bazel toolchain.
+              sudo xcode-select --switch /Library/Developer/CommandLineTools
+              ;;
             "macos-x86_64")
               # Switch Xcode path to match the path specified in our bazel toolchain.
               sudo xcode-select --switch /Library/Developer/CommandLineTools


### PR DESCRIPTION
## Description
Resolves #45. In the future, we probably want to replace the `macos-arm64` runner hosted on my Mac Mini with a Tlon-owned VM, which is tracked in #44. 