### PR TITLE
Replace `arm64` with `aarch64` as canonical identifier for 64-bit ARM architecture

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -34,11 +34,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { target: linux-arm64, runner: ubuntu-22.04 }
+          - { target: linux-aarch64, runner: ubuntu-22.04 }
           - { target: linux-x86_64, runner: ubuntu-22.04 }
           # GitHub doesn't provide M1 macOS machines, so we run on
           # @mcevoypeter's M1 Mac Mini instead.
-          - { target: macos-arm64, runner: [self-hosted, macos, ARM64] }
+          - { target: macos-aarch64, runner: [self-hosted, macos, ARM64] }
           - { target: macos-x86_64, runner: macos-12 }
 
     runs-on: ${{ matrix.runner }}
@@ -78,7 +78,7 @@ jobs:
           echo "${{ inputs.pace }}" > ./pkg/vere/PACE
           params=()
           case "${{ matrix.target }}" in
-            "linux-arm64")
+            "linux-aarch64")
               bazel run //bazel/toolchain:aarch64-linux-musl-gcc
               params+=(
                 --platforms=//:linux-arm64
@@ -87,7 +87,7 @@ jobs:
             "linux-x86_64")
               bazel run //bazel/toolchain:x86_64-linux-musl-gcc
               ;;
-            "macos-arm64")
+            "macos-aarch64")
               ;;
             "macos-x86_64")
               # Switch Xcode path to match the path specified in our bazel toolchain.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,10 +7,10 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 #
 
 config_setting(
-    name = "linux_arm64",
+    name = "linux_aarch64",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
 )
 
@@ -23,10 +23,10 @@ config_setting(
 )
 
 config_setting(
-    name = "macos_arm64",
+    name = "macos_aarch64",
     constraint_values = [
         "@platforms//os:macos",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
 )
 
@@ -71,12 +71,12 @@ string_flag(
 # A platform takes one of two formats: `<compiler>-<os>-<cpu>` or `<os>-<cpu>`
 # if the compiler is unspecified.
 
-# Linux arm64 platform with unspecified compiler.
+# Linux aarch64 platform with unspecified compiler.
 platform(
-    name = "linux-arm64",
+    name = "linux-aarch64",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
 )
 
@@ -100,19 +100,19 @@ platform(
 )
 
 platform(
-    name = "macos-arm64",
+    name = "macos-aarch64",
     constraint_values = [
         "@platforms//os:macos",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
 )
 
 platform(
-    name = "clang-macos-arm64",
+    name = "clang-macos-aarch64",
     constraint_values = [
         ":clang",
         "@platforms//os:macos",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
 )
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,9 +8,9 @@ run:
 ----------------------------------
  Host Platform  | Target Platform
 ----------------------------------
- `linux-x86_64` | `linux-arm64`
+ `linux-x86_64` | `linux-aarch64`
  `linux-x86_64` | `linux-x86_64`
- `macos-arm64`  | `macos-arm64`
+ `macos-aarch64`  | `macos-aarch64`
  `macos-x86_64` | `macos-x86_64`
 
 ## Prerequisites

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -80,14 +80,14 @@ va.b.c pill.
 
 Release binaries:
 
-(linux-arm64)
-https://bootstrap.urbit.org/urbit-vx.y-linux-arm64.tgz
+(linux-aarch64)
+https://bootstrap.urbit.org/urbit-vx.y-linux-aarch64.tgz
 
 (linux-x86_64)
 https://bootstrap.urbit.org/urbit-vx.y-linux-x86_64.tgz
 
-(macos-arm64)
-https://bootstrap.urbit.org/urbit-vx.y-macos-arm64.tgz
+(macos-aarch64)
+https://bootstrap.urbit.org/urbit-vx.y-macos-aarch64.tgz
 
 (macos-x86_64)
 https://bootstrap.urbit.org/urbit-vx.y-macos-x86_64.tgz

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -47,7 +47,7 @@
 #     platform-specific, wrap it in the appropriate URBIT_RUNTIME_* macro.
 #     We "gate" source patches with these macros so that we only ever need
 #     at most one patch per dependency.
-#     (a) CPU architecture macros: `URBIT_RUNTIME_CPU_{X86_64,ARM64}`.
+#     (a) CPU architecture macros: `URBIT_RUNTIME_CPU_{X86_64,AARCH64}`.
 #     (b) OS macros: `URBIT_RUNTIME_OS_{LINUX,DARWIN,BSD,MINGW}`.
 # (2) Generate a patch file named <dependency_version>.patch and save it in
 #     `bazel/third_party/<dependency>`.
@@ -93,8 +93,8 @@ versioned_http_archive(
 
 # Use the toolchains we've configured.
 register_toolchains(
-    "//bazel/toolchain:gcc-linux-arm64-toolchain",
-    "//bazel/toolchain:clang-macos-arm64-toolchain",
+    "//bazel/toolchain:gcc-linux-aarch64-toolchain",
+    "//bazel/toolchain:clang-macos-aarch64-toolchain",
     "//bazel/toolchain:clang-macos-x86_64-toolchain",
     "//bazel/toolchain:gcc-linux-x86_64-toolchain",
 )

--- a/bazel/third_party/curl/curl.BUILD
+++ b/bazel/third_party/curl/curl.BUILD
@@ -53,7 +53,7 @@ configure_make(
         "--without-zlib",
         "--without-zstd",
     ] + select({
-        "@//:linux_arm64": ["--host=aarch64-linux-musl"],
+        "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),

--- a/bazel/third_party/gmp/gmp.BUILD
+++ b/bazel/third_party/gmp/gmp.BUILD
@@ -18,7 +18,7 @@ configure_make(
         # but we leave it in for all builds as a precaution.
         "--with-pic",
     ] + select({
-        "@//:linux_arm64": ["--host=aarch64-linux-musl"],
+        "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),

--- a/bazel/third_party/h2o/2.2.6.patch
+++ b/bazel/third_party/h2o/2.2.6.patch
@@ -6,7 +6,7 @@ index 742fec90b..9a11a21bd 100644
  
  #include <stdlib.h>
  #include <stdint.h>
-+#if defined(URBIT_RUNTIME_CPU_ARM64)
++#if defined(URBIT_RUNTIME_CPU_AARCH64)
 +#include "sse2neon.h"
 +#else
  #include <emmintrin.h>
@@ -22,7 +22,7 @@ index 3ae3bd309..7db05a186 100644
  #include <stdlib.h>
  #include <stdio.h>
  #include <time.h>
-+#if defined(URBIT_RUNTIME_CPU_ARM64)
++#if defined(URBIT_RUNTIME_CPU_AARCH64)
 +#include "sse2neon.h"
 +#else
  #include <emmintrin.h>
@@ -39,7 +39,7 @@ index a707070d1..714850f64 100644
  #include <string.h>
  #ifdef __SSE4_2__
 -#ifdef _MSC_VER
-+#if defined(URBIT_RUNTIME_CPU_ARM64)
++#if defined(URBIT_RUNTIME_CPU_AARCH64)
 +#include "sse2neon.h"
 +#elif defined(_MSC_VER)
  #include <nmmintrin.h>

--- a/bazel/third_party/h2o/h2o.BUILD
+++ b/bazel/third_party/h2o/h2o.BUILD
@@ -43,7 +43,7 @@ cc_library(
     includes = ["deps/klib"],
     linkstatic = True,
     local_defines = select({
-        "@platforms//cpu:arm64": ["URBIT_RUNTIME_CPU_ARM64"],
+        "@platforms//cpu:aarch64": ["URBIT_RUNTIME_CPU_AARCH64"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],
@@ -51,7 +51,7 @@ cc_library(
         "@curl",
         "@zlib",
     ] + select({
-        "@platforms//cpu:arm64": ["@sse2neon"],
+        "@platforms//cpu:aarch64": ["@sse2neon"],
         "//conditions:default": [],
     }),
 )
@@ -99,12 +99,12 @@ cc_library(
     includes = ["deps/picohttpparser"],
     linkstatic = True,
     local_defines = select({
-        "@platforms//cpu:arm64": ["URBIT_RUNTIME_CPU_ARM64"],
+        "@platforms//cpu:aarch64": ["URBIT_RUNTIME_CPU_AARCH64"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],
     deps = select({
-        "@platforms//cpu:arm64": ["@sse2neon"],
+        "@platforms//cpu:aarch64": ["@sse2neon"],
         "//conditions:default": [],
     }),
 )
@@ -130,7 +130,7 @@ cc_library(
     ],
     linkstatic = True,
     local_defines = select({
-        "@platforms//cpu:arm64": ["URBIT_RUNTIME_CPU_ARM64"],
+        "@platforms//cpu:aarch64": ["URBIT_RUNTIME_CPU_AARCH64"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],
@@ -139,7 +139,7 @@ cc_library(
         ":micro_ecc",
         "@openssl",
     ] + select({
-        "@platforms//cpu:arm64": ["@sse2neon"],
+        "@platforms//cpu:aarch64": ["@sse2neon"],
         "//conditions:default": [],
     }),
 )

--- a/bazel/third_party/openssl/openssl.BUILD
+++ b/bazel/third_party/openssl/openssl.BUILD
@@ -13,15 +13,15 @@ configure_make(
         "//conditions:default": ["--jobs=`nproc`"],
     }),
     configure_command = select({
-        "@//:linux_arm64": "Configure",
+        "@//:linux_aarch64": "Configure",
         "//conditions:default": "config",
     }),
     configure_options = [
         "no-shared",
     ] + select({
-        "@//:linux_arm64": [
+        "@//:linux_aarch64": [
             "linux-aarch64",
-            # Native compilation on linux-arm64 isn't supported. The prefix is
+            # Native compilation on linux-aarch64 isn't supported. The prefix is
             # empty because the configure script detects an absolute path to the
             # aarch64-linux-gnu-gcc instead of just the binary name. This is
             # presumably because of the Bazel toolchain configuration but is not

--- a/bazel/third_party/secp256k1/secp256k1.BUILD
+++ b/bazel/third_party/secp256k1/secp256k1.BUILD
@@ -19,7 +19,7 @@ configure_make(
         "--enable-module-schnorrsig",
         "--enable-static",
     ] + select({
-        "@//:linux_arm64": ["--host=aarch64-linux-musl"],
+        "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),

--- a/bazel/third_party/sigsegv/sigsegv.BUILD
+++ b/bazel/third_party/sigsegv/sigsegv.BUILD
@@ -20,7 +20,7 @@ configure_make(
         "@platforms//os:linux": ["--disable-stackvma"],
         "//conditions:default": [],
     }) + select({
-        "@//:linux_arm64": ["--host=aarch64-linux-musl"],
+        "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),

--- a/bazel/third_party/softfloat/softfloat.BUILD
+++ b/bazel/third_party/softfloat/softfloat.BUILD
@@ -9,14 +9,14 @@ cc_library(
     name = "softfloat",
     visibility = ["//visibility:public"],
     deps = select({
-        "@platforms//cpu:arm64": [":softfloat_arm64"],
+        "@platforms//cpu:aarch64": [":softfloat_aarch64"],
         "@platforms//cpu:x86_64": [":softfloat_x86_64"],
         "//conditions:default": [],
     }),
 )
 
 cc_library(
-    name = "softfloat_arm64",
+    name = "softfloat_aarch64",
     srcs = [
         # See `OBJS_PRIMITIVES` in `build/Linux-ARM-VFPv2-GCC/Makefile` in the
         # `softfloat` repo.

--- a/bazel/third_party/uv/uv.BUILD
+++ b/bazel/third_party/uv/uv.BUILD
@@ -17,7 +17,7 @@ configure_make(
     configure_options = [
         "--disable-shared",
     ] + select({
-        "@//:linux_arm64": ["--host=aarch64-linux-musl"],
+        "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),

--- a/bazel/toolchain/BUILD.bazel
+++ b/bazel/toolchain/BUILD.bazel
@@ -46,10 +46,10 @@ alias(
 #
 
 # Toolchain identifier.
-_arm64_gcc = "toolchain-gcc-linux-arm64"
+_aarch64_gcc = "toolchain-gcc-linux-aarch64"
 
 cc_toolchain_config(
-    name = "gcc-linux-arm64-config",
+    name = "gcc-linux-aarch64-config",
     ar = "{}/aarch64-linux-musl/bin/aarch64-linux-musl-ar".format(_install_prefix),
     cc = "{}/aarch64-linux-musl/bin/aarch64-linux-musl-gcc".format(_install_prefix),
     cc_flags = [
@@ -64,12 +64,12 @@ cc_toolchain_config(
         "{}/aarch64-linux-musl/aarch64-linux-musl/include".format(_install_prefix),
         "{}/aarch64-linux-musl/lib/gcc/aarch64-linux-musl/{{compiler_version}}/include".format(_install_prefix),
     ],
-    target_cpu = "arm64",
-    toolchain_identifier = _arm64_gcc,
+    target_cpu = "aarch64",
+    toolchain_identifier = _aarch64_gcc,
 )
 
 cc_toolchain(
-    name = "gcc-linux-arm64",
+    name = "gcc-linux-aarch64",
     all_files = ":empty",
     compiler_files = ":empty",
     dwp_files = ":empty",
@@ -77,21 +77,21 @@ cc_toolchain(
     objcopy_files = ":empty",
     strip_files = ":empty",
     supports_param_files = 0,
-    toolchain_config = ":gcc-linux-arm64-config",
-    toolchain_identifier = _arm64_gcc,
+    toolchain_config = ":gcc-linux-aarch64-config",
+    toolchain_identifier = _aarch64_gcc,
 )
 
 toolchain(
-    name = "gcc-linux-arm64-toolchain",
+    name = "gcc-linux-aarch64-toolchain",
     exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
     target_compatible_with = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
-    toolchain = ":gcc-linux-arm64",
+    toolchain = ":gcc-linux-aarch64",
     toolchain_type = ":toolchain_type",
 )
 
@@ -150,14 +150,14 @@ toolchain(
 )
 
 #
-# clang-macos-arm64
+# clang-macos-aarch64
 #
 
 # Toolchain identifier.
-_macos_arm64_clang = "toolchain-clang-macos-arm64"
+_macos_aarch64_clang = "toolchain-clang-macos-aarch64"
 
 cc_toolchain_config(
-    name = "clang-macos-arm64-config",
+    name = "clang-macos-aarch64-config",
     # NOTE: building with `libtool` does not work on macOS due to lack of
     # support in the `configure_make` rule provided by `rules_foreign_cc`.
     # Therefore, we require setting `ar` as the archiver tool on macOS.
@@ -177,12 +177,12 @@ cc_toolchain_config(
         "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include",
         "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/{compiler_version}/include",
     ],
-    target_cpu = "arm64",
-    toolchain_identifier = _macos_arm64_clang,
+    target_cpu = "aarch64",
+    toolchain_identifier = _macos_aarch64_clang,
 )
 
 cc_toolchain(
-    name = "clang-macos-arm64",
+    name = "clang-macos-aarch64",
     all_files = ":empty",
     compiler_files = ":empty",
     dwp_files = ":empty",
@@ -190,21 +190,21 @@ cc_toolchain(
     objcopy_files = ":empty",
     strip_files = ":empty",
     supports_param_files = 0,
-    toolchain_config = ":clang-macos-arm64-config",
-    toolchain_identifier = _macos_arm64_clang,
+    toolchain_config = ":clang-macos-aarch64-config",
+    toolchain_identifier = _macos_aarch64_clang,
 )
 
 toolchain(
-    name = "clang-macos-arm64-toolchain",
+    name = "clang-macos-aarch64-toolchain",
     exec_compatible_with = [
         "@platforms//os:macos",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
     target_compatible_with = [
         "@platforms//os:macos",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
-    toolchain = ":clang-macos-arm64",
+    toolchain = ":clang-macos-aarch64",
     toolchain_type = ":toolchain_type",
 )
 


### PR DESCRIPTION
## Description

Resolves #51.