### PR TITLE
Fix musl libc toolchain cache access

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: chown /usr/local
         run: |
-          if [[ "${{ matrix.target }}" == "linux-x86_64" ]]; then
+          if [[ "${{ matrix.target }}" == "linux-arm64" || "${{ matrix.target }}" == "linux-x86_64" ]]; then
             # See https://github.com/actions/cache/issues/845.
             sudo chown -R $(whoami) /usr/local
           fi


### PR DESCRIPTION
## Description

Actually resolves #49 since the fix introduced in #50 didn't work.