### PR TITLE
Make release pipeline resilient to newline in pkg/vere/VERSION

### DIFF
--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -390,6 +390,10 @@ u3_king_next(c3_c* pac_c, c3_c** out_c)
   //
   hun_y = c3_realloc(hun_y, 1 + len_w);
   hun_y[len_w] = 0;
+  c3_c* newline_c;
+  while ( (newline_c = strrchr(hun_y, '\n')) ) {
+    *newline_c = 0;
+  }
 
   ver_c = (c3_c*)hun_y;
 


### PR DESCRIPTION
## Description
Resolves #70. This change means that `pkg/vere/VERSION` can contain an arbitrary number of trailing newlines and still not affect the binary upgrade system.