### PR TITLE
Correctly cast `hun_y` when trimming newlines in `u3_king_next()` 

### DIFF
--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -391,7 +391,7 @@ u3_king_next(c3_c* pac_c, c3_c** out_c)
   hun_y = c3_realloc(hun_y, 1 + len_w);
   hun_y[len_w] = 0;
   c3_c* newline_c;
-  while ( (newline_c = strrchr(hun_y, '\n')) ) {
+  while ( (newline_c = strrchr((c3_c*)hun_y, '\n')) ) {
     *newline_c = 0;
   }
 


### PR DESCRIPTION
## Description

Resolves #81.

## Testing

```console
$ bazel build :urbit
```