### PR TITLE
Add functions to read static global variables in trace.c

### DIFF
--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -549,6 +549,18 @@ u3t_init(void)
   u3T.euq_o = c3n;
 }
 
+c3_w
+u3t_trace_cnt(void)
+{
+  return _trace_cnt_w;
+}
+
+c3_w
+u3t_file_cnt(void)
+{
+  return _file_cnt_w;
+}
+
 /* u3t_boot(): turn sampling on.
 */
 void

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -47,6 +47,14 @@
       void
       u3t_init(void);
 
+      /// @return  Number of entries written to the JSON trace file.
+      c3_w
+      u3t_trace_cnt(void);
+
+      /// @return  Number of times u3t_trace_close() has been called.
+      c3_w
+      u3t_file_cnt(void);
+
     /* u3t_push(): push on trace stack.
     */
       void

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -852,10 +852,11 @@ static void
 _cw_serf_step_trace(void)
 {
   if ( u3C.wag_w & u3o_trace ) {
-    if ( u3_Host.tra_u.con_w == 0  && u3_Host.tra_u.fun_w == 0 ) {
+    c3_w trace_cnt_w = u3t_trace_cnt();
+    if ( trace_cnt_w == 0  && u3t_file_cnt() == 0 ) {
       u3t_trace_open(u3V.dir_c);
     }
-    else if ( u3_Host.tra_u.con_w >= 100000 ) {
+    else if ( trace_cnt_w >= 100000 ) {
       u3t_trace_close();
       u3t_trace_open(u3V.dir_c);
     }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1046,7 +1046,6 @@ _cw_serf_commence(c3_i argc, c3_c* argv[])
   _cw_init_io(lup_u);
 
   memset(&u3V, 0, sizeof(u3V));
-  memset(&u3_Host.tra_u, 0, sizeof(u3_Host.tra_u));
 
   //  load passkey
   //
@@ -2209,10 +2208,6 @@ main(c3_i   argc,
       */
       if ( _(u3_Host.ops_u.tra) ) {
         u3C.wag_w |= u3o_trace;
-        u3_Host.tra_u.nid_w = 0;
-        u3_Host.tra_u.fil_u = NULL;
-        u3_Host.tra_u.con_w = 0;
-        u3_Host.tra_u.fun_w = 0;
       }
     }
 

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -258,15 +258,6 @@
         struct _u3_auto* car_u;             //  driver hack
       } u3_utty;
 
-    /* u3_trac: tracing information.
-    */
-      typedef struct _u3_trac {
-        c3_w   nid_w;                       //  nock pid
-        FILE*  fil_u;                       //  trace file (json)
-        c3_w   con_w;                       //  trace counter
-        c3_w   fun_w;                       //  file counter
-      } u3_trac;
-
     /* u3_opts: command line configuration.
     */
       typedef struct _u3_opts {
@@ -334,7 +325,6 @@
         u3_opts    ops_u;                   //  commandline options
         c3_o       pep_o;                   //  prep for upgrade
         c3_i       xit_i;                   //  exit code for shutdown
-        u3_trac    tra_u;                   //  tracing information
         void     (*bot_f)();                //  call when chis is up
       } u3_host;                            //  host == computer == process
 


### PR DESCRIPTION
## Description
Resolves #104.

## Testing
```console
$ bazel build :urbit
$ ./urbit -j zod
dojo> -time ~s2
dojo> |exit
$ cat zod/.urb/put/trace/0.json
```
[0.json](https://github.com/urbit/vere/files/10406450/0.txt)