### PR TITLE
Remove use of release event in CI jobs

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -5,6 +5,14 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - '*.bazel'
+      - '.bazelrc'
+      - '.github/workflows/**.yml'
+      - 'PACE'
+      - 'VERSION'
+      - 'bazel/**'
+      - 'pkg/**'
 
 jobs:
   urbit:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,7 +1,6 @@
 name: Push to develop
 
 on:
-  release: null
   push:
     branches:
       - develop

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,6 @@
 name: Push to master
 
 on:
-  release: null
   push:
     branches:
       - master

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5,6 +5,15 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '*.bazel'
+      - '.bazelrc'
+      - '.github/workflows/**.yml'
+      - 'PACE'
+      - 'VERSION'
+      - 'bazel/**'
+      - 'pkg/**'
+
 
 jobs:
   urbit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
   push:
     branches:
       - release
+    paths:
+      - '*.bazel'
+      - '.bazelrc'
+      - '.github/workflows/**.yml'
+      - 'PACE'
+      - 'VERSION'
+      - 'bazel/**'
+      - 'pkg/**'
 
 jobs:
   urbit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Push to release
 
 on:
-  release: null
   push:
     branches:
       - release


### PR DESCRIPTION
## Description

Resolves #106. Note that in addition to removing the `release` trigger, this PR also adds a `path` trigger to explicitly declare the paths CI jobs should run in response to changes to.