### PR TITLE
Correctly specify `--host` in third party dependency configure scripts 

### DIFF
--- a/bazel/third_party/curl/curl.BUILD
+++ b/bazel/third_party/curl/curl.BUILD
@@ -5,7 +5,6 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-# TODO: check windows build.
 configure_make(
     name = "curl",
     args = select({
@@ -53,8 +52,18 @@ configure_make(
         "--without-zlib",
         "--without-zstd",
     ] + select({
-        "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
-        "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
+        # The "Cross compile" section of docs/INSTALL.md in the curl repo makes
+        # it clear that `--host` specifies the system on which the compilation
+        # occurs and `--build` specifies the system on which the resulting code
+        # will run.
+        "@//:linux_aarch64": [
+            "--host=x86_64-linux",
+            "--build=aarch64-linux-musl",
+        ],
+        "@//:linux_x86_64": [
+            "--host=x86_64-linux",
+            "--build=x86_64-linux-musl",
+        ],
         "//conditions:default": [],
     }),
     env = {

--- a/bazel/third_party/gmp/gmp.BUILD
+++ b/bazel/third_party/gmp/gmp.BUILD
@@ -5,7 +5,6 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-# TODO: check windows build.
 configure_make(
     name = "gmp",
     args = select({
@@ -18,6 +17,10 @@ configure_make(
         # but we leave it in for all builds as a precaution.
         "--with-pic",
     ] + select({
+        # From INSTALL in the gmp repo: "If you want to *use* a cross compiler
+        # that generates code for a platform different from the build platform,
+        # you should specify the 'host' platform (i.e., that on which the
+        # generated programs will eventually run) with `--host=TYPE`."
         "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],

--- a/bazel/third_party/secp256k1/secp256k1.BUILD
+++ b/bazel/third_party/secp256k1/secp256k1.BUILD
@@ -19,6 +19,17 @@ configure_make(
         "--enable-module-schnorrsig",
         "--enable-static",
     ] + select({
+        # The `--host` flag is not well-documented by the docs in the secp256k1
+        # repo, but the following commands produce an AArch64 library:
+        # ```
+        # $ CC=path/to/aarch64-linux-musl-gcc ./configure --prefix=/tmp --host=aarch64-linux-musl
+        # $ make install
+        # ```
+        #
+        # This can be verified with:
+        # ```
+        # $ path/to/aarch64-linux-musl-objdump -d /tmp/lib/libsecp256k1.a
+        # ```
         "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],

--- a/bazel/third_party/sigsegv/sigsegv.BUILD
+++ b/bazel/third_party/sigsegv/sigsegv.BUILD
@@ -20,7 +20,13 @@ configure_make(
         "@platforms//os:linux": ["--disable-stackvma"],
         "//conditions:default": [],
     }) + select({
-        "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
+        # To build for `linux-aarch64` on `linux-aarch64`, replace
+        # `--host=x86_64-linux --target=aarch64-linux-musl` below with
+        # `--host=aarch64-linux-musl`.
+        "@//:linux_aarch64": [
+            "--host=x86_64-linux",
+            "--target=aarch64-linux-musl",
+        ],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),

--- a/bazel/third_party/uv/uv.BUILD
+++ b/bazel/third_party/uv/uv.BUILD
@@ -5,7 +5,6 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-# TODO: check windows build.
 configure_make(
     name = "uv",
     args = select({
@@ -17,6 +16,17 @@ configure_make(
     configure_options = [
         "--disable-shared",
     ] + select({
+        # The `--host` flag is not well-documented by the docs in the libuv
+        # repo, but the following commands produce an AArch64 library:
+        # ```
+        # $ CC=path/to/aarch64-linux-musl-gcc ./configure --prefix=/tmp --host=aarch64-linux-musl
+        # $ make install
+        # ```
+        #
+        # This can be verified with:
+        # ```
+        # $ path/to/aarch64-linux-musl-objdump -d /tmp/lib/libuv.a
+        # ```
         "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],

--- a/bazel/toolchain/BUILD.bazel
+++ b/bazel/toolchain/BUILD.bazel
@@ -83,9 +83,12 @@ cc_toolchain(
 
 toolchain(
     name = "gcc-linux-aarch64-toolchain",
-    # To building for `linux-aarch64` on `linux-aarch64`, remove the x86_64 CPU
-    # constraint below, which will allow this toolchain to run on
-    # `linux-aarch64` platforms.
+    # To build for `linux-aarch64` on `linux-aarch64` (i.e. a `linux-aarch64`
+    # native build), remove the x86_64 CPU constraint below, which will allow
+    # this toolchain to run on `linux-aarch64` platforms. Note that at least
+    # some of the third party dependency build rules assume cross-compilation
+    # when the target platform is `linux-aarch64`, which means those build rules
+    # will need to be updated to enable a `linux-aarch64` native build.
     exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",

--- a/bazel/toolchain/BUILD.bazel
+++ b/bazel/toolchain/BUILD.bazel
@@ -83,6 +83,9 @@ cc_toolchain(
 
 toolchain(
     name = "gcc-linux-aarch64-toolchain",
+    # To building for `linux-aarch64` on `linux-aarch64`, remove the x86_64 CPU
+    # constraint below, which will allow this toolchain to run on
+    # `linux-aarch64` platforms.
     exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",


### PR DESCRIPTION
## Description

Resolves #113. Note this PR also addresses the incorrect usage of `--host` in the configuration of four other third party dependencies besides `libsigsegv`: `secp256k1`, `libuv`, `gmp`, and `curl`.