### PR TITLE
Enable native `linux-aarch64` build

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -33,7 +33,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { target: linux-aarch64, runner: ubuntu-22.04 }
+          # GitHub doesn't provide AArch64 Linux machines, so we self-host a
+          # runner instead.
+          - { target: linux-aarch64, runner: [self-hosted, Linux, ARM64] }
           - { target: linux-x86_64, runner: ubuntu-22.04 }
           # GitHub doesn't provide M1 macOS machines, so we self-host a runner
           # instead.
@@ -49,9 +51,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: chown /usr/local
-        if: ${{ matrix.target == 'linux-aarch64' || matrix.target == 'linux-x86_64' }}
+        if: ${{ matrix.target == 'linux-x86_64' }}
         run: |
-          # See https://github.com/actions/cache/issues/845.
+          # See https://github.com/actions/cache/issues/845. Note we don't run
+          # this on linux-aarch64 because we run on a self-hosted GitHub Actions
+          # runner for which `/usr/local` has already been `chown`d to the user
+          # running the GitHub Actions runner.
           sudo chown -R $(whoami) /usr/local
 
       - name: Set up build cache
@@ -94,7 +99,7 @@ jobs:
           echo "${{ inputs.pace }}" > ./PACE
           case "${{ matrix.target }}" in
             "linux-aarch64")
-              bazel build --platforms=//:linux-aarch64 :urbit
+              bazel build :urbit
               ;;
             "linux-x86_64")
               bazel build :urbit
@@ -108,9 +113,6 @@ jobs:
           esac
 
       - name: Run unit tests
-        # We have no way of running the linux-aarch64 tests on a linux-x86_64
-        # machine.
-        if: ${{ matrix.target != 'linux-aarch64' }}
         run: |
           if [[ "${{ matrix.target }}" == "macos-x86_64" ]]; then
             bazel test --build_tests_only --clang_version=14.0.6 --extra_toolchains=//bazel/toolchain:brew-clang-macos-x86_64-toolchain  ...

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ run:
 ----------------------------------
  Host Platform  | Target Platform
 ----------------------------------
- `linux-x86_64` | `linux-aarch64`
+ `linux-aarch64 | `linux-aarch64`
  `linux-x86_64` | `linux-x86_64`
  `macos-aarch64`  | `macos-aarch64`
  `macos-x86_64` | `macos-x86_64`
@@ -51,17 +51,9 @@ This will take a few minutes.
 
 ## Build Commands
 
-Once you install the prerequisites, you're ready to build. If you're performing
-a native build (i.e. one in which the host platform and target platform are the
-same), run:
+Once you install the prerequisites, you're ready to build:
 ```console
-$ bazel build //pkg/...
-```
-
-If you're performing a cross-platform build, you need to specify the target
-platform in the build command:
-```console
-$ bazel build --platforms=//:<target-platform> //pkg/...
+$ bazel build :urbit
 ```
 
 The default optimization level is `-O3`, but if you want to specify a different

--- a/bazel/toolchain/BUILD.bazel
+++ b/bazel/toolchain/BUILD.bazel
@@ -85,7 +85,7 @@ toolchain(
     name = "gcc-linux-aarch64-toolchain",
     exec_compatible_with = [
         "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
+        "@platforms//cpu:aarch64",
     ],
     target_compatible_with = [
         "@platforms//os:linux",


### PR DESCRIPTION
## Description

Resolves #113. As a side effect, this also disables the ability to cross compile from `linux-x86_64` to `linux-aarch64`. With this change, we no longer support any sort of cross compilation, although that support could be added back in the future should it become high enough priority.

## Testing

Ran the following on an Arch Linux AArch64 VM:
```console
$ bazel test --build_tests_only ...
$ bazel build :urbit
$ ln -s bazel-bin/pkg/vere/urbit urbit
$ ./urbit -F zod -u https://bootstrap.urbit.org/urbit-v1.16.pill
<ctrl-d>
$ ./urbit zod
``` 