### PR TITLE
ci: add on-demand binary uploading flow

### DIFF
--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -1,0 +1,12 @@
+name: Deploy once
+
+on:
+  workflow_dispatch
+
+jobs:
+  urbit:
+    uses: ./.github/workflows/shared.yml
+    with:
+      pace: 'once'
+      upload: true
+    secrets: inherit


### PR DESCRIPTION
CI on urbit/urbit and elsewhere may need a vere binary from a feature branch, from which we don't upload binaries automatically. This action can be triggered manually, through Github's Actions UI, to build & upload a binary from the specified branch at the "once" pace.

...Not sure I can test this without getting it merged? We also may or may not want this to be more minimal than the existing action/flow, but running the tests probably good.

Closes #129.