### PR TITLE
term: make printfs render with 50% grayscale

### DIFF
--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -2349,7 +2349,7 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
         case 3: fprintf(fil_u, "\033[31m>>> "); break;
         case 2: fprintf(fil_u, "\033[33m>>  "); break;
         case 1: fprintf(fil_u, "\033[32m>   "); break;
-        case 0: fprintf(fil_u, "\033[90m"    ); break;
+        case 0: fprintf(fil_u, "\033[38;5;244m"); break;
     }
   }
   else {


### PR DESCRIPTION
As opposed to the color code for "bright black", which may cause legibility issues in dark color schemes.

Fixes #138.