### PR TITLE
Run fake ship tests with optimized binary under memory and CPU debug

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,5 +26,10 @@ build --strip=never
 build --copt='-O3'
 build --host_copt='-O3'
 
+# Turn on CPU and memory debug for exec config, which we only use to run the
+# fake ship tests.
+build --host_copt='-DU3_CPU_DEBUG'
+build --host_copt='-DU3_MEMORY_DEBUG'
+
 # Any personal configuration should go in .user.bazelrc.
 try-import %workspace%/.user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,10 +19,12 @@ build --flag_alias=gcc_version=//:gcc_version
 
 # Always include source-level debug info.
 build --copt='-g'
+build --host_copt='-g'
 build --strip=never
 
 # Use -O3 as the default optimization level.
 build --copt='-O3'
+build --host_copt='-O3'
 
 # Any personal configuration should go in .user.bazelrc.
 try-import %workspace%/.user.bazelrc

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -12,6 +12,10 @@
 
 u3_road* u3a_Road;
 
+#ifdef U3_MEMORY_DEBUG
+c3_w u3_Code;
+#endif
+
 //  declarations of inline functions
 //
 void

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -362,7 +362,7 @@
     /* u3_Code: memory code.
     */
 #ifdef U3_MEMORY_DEBUG
-      c3_global c3_w u3_Code;
+      extern c3_w u3_Code;
 #endif
 
 #   define u3_Loom      ((c3_w *)(void *)U3_OS_LoomBase)

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -6,6 +6,10 @@
 #include "c3.h"
 #include "types.h"
 
+#ifdef U3_CPU_DEBUG
+# include "options.h"
+#endif
+
   /** Data structures.
   **/
     /* u3t_trace: fast execution flags.


### PR DESCRIPTION
## Description
Resolves #140. Note that debug symbols are still not included in the exec configuration build despite `--host_copt='-g'` being set in [.bazelrc](https://github.com/urbit/vere/tree/0d7f0c636fa247ebc63dba63fff4c8c8bd5405cb/.bazelrc). It's unclear why this remains the case and may warrant further investigation if we deem it necessary.

## Testing
Ran `bazel build --subcommands //pkg/vere:test-fake-ship` on both `linux-x86_64` and `macos-aarch64` machines and confirmed compiler invocations on both platforms included `-g -O3 -DU3_MEMORY_DEBUG -DU3_CPU_DEBUG`. The `linux-x86_64` build ran successfully, and the `macos-aarch64` build failed due to an existing issue (#40).