### PR TITLE
Add debug configuration to build system

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,9 +42,5 @@ build --host_copt='-DU3_MEMORY_DEBUG'
 build:dbg --copt='-O0'
 build:dbg --copt='-g3'
 
-# Turn on CPU and memory debug for debug config.
-build:dbg --copt='-DU3_CPU_DEBUG'
-build:dbg --copt='-DU3_MEMORY_DEBUG'
-
 # Any personal configuration should go in .user.bazelrc.
 try-import %workspace%/.user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# Enable configurations specific to the host platform.
+common --enable_platform_specific_config
+
 # Disallow empty `glob()`s.
 build --incompatible_disallow_empty_glob
 
@@ -17,9 +20,11 @@ build --@io_bazel_rules_docker//transitions:enable=false
 build --flag_alias=clang_version=//:clang_version
 build --flag_alias=gcc_version=//:gcc_version
 
-# Always include source-level debug info.
-build --copt='-g'
-build --host_copt='-g'
+# Don't include source level debug info on macOS. See
+# https://github.com/urbit/urbit/issues/5561 and
+# https://github.com/urbit/vere/issues/131.
+build:linux --copt='-g'
+build:linux --host_copt='-g'
 build --strip=never
 
 # Use -O3 as the default optimization level.

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,5 +31,15 @@ build --host_copt='-O3'
 build --host_copt='-DU3_CPU_DEBUG'
 build --host_copt='-DU3_MEMORY_DEBUG'
 
+# Enable maximum debug info and disable optimizations for debug config. It's
+# important that these lines come after setting the default debug and
+# optimization level flags above.
+build:dbg --copt='-O0'
+build:dbg --copt='-g3'
+
+# Turn on CPU and memory debug for debug config.
+build:dbg --copt='-DU3_CPU_DEBUG'
+build:dbg --copt='-DU3_MEMORY_DEBUG'
+
 # Any personal configuration should go in .user.bazelrc.
 try-import %workspace%/.user.bazelrc

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,14 +60,21 @@ bazel build :urbit
 ```
 
 If you want a debug build, which changes the optimization level from `-O3` to
-`-O0` and turns on CPU and memory debugging via the `U3_CPU_DEBUG` and
-`U3_MEMORY_DEBUG` macros, respectively, specify the `dbg` configuration:
+`-O0` and includes more debugging information, specify the `dbg` configuration:
 ```console
-$ bazel build --config=dbg :urbit
+bazel build --config=dbg :urbit
 ```
 Note that you cannot change the optimization level for third party
 dependencies--those targets specified in `bazel/third_party`--from the command
 line.
+
+You can turn on CPU and memory debugging by defining `U3_CPU_DEBUG` and
+`U3_MEMORY_DEBUG`, respectively:
+```console
+bazel build --copt='-DU3_CPU_DEBUG' --copt='-DU3_MEMORY_DEBUG' :urbit
+```
+Note that defining these two debug symbols will produce ships that are
+incompatible with binaries without these two debug symbols defined.
 
 If you need to specify arbitrary C compiler or linker options, use
 [`--copt`][copt] or [`--linkopt`][linkopt], respectively:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,6 +65,9 @@ If you want a debug build, which changes the optimization level from `-O3` to
 ```console
 $ bazel build --config=dbg :urbit
 ```
+Note that you cannot change the optimization level for third party
+dependencies--those targets specified in `bazel/third_party`--from the command
+line.
 
 If you need to specify arbitrary C compiler or linker options, use
 [`--copt`][copt] or [`--linkopt`][linkopt], respectively:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,8 +59,15 @@ Once you install the prerequisites, you're ready to build:
 bazel build :urbit
 ```
 
-The default optimization level is `-O3`, but if you want to specify a different
-optimization level, use [`--copt`][copt]:
+If you want a debug build, which changes the optimization level from `-O3` to
+`-O0` and turns on CPU and memory debugging via the `U3_CPU_DEBUG` and
+`U3_MEMORY_DEBUG` macros, respectively, specify the `dbg` configuration:
+```console
+$ bazel build --config=dbg :urbit
+```
+
+If you need to specify arbitrary C compiler or linker options, use
+[`--copt`][copt] or [`--linkopt`][linkopt], respectively:
 ```console
 bazel build --copt='-O0' :urbit
 ```
@@ -115,4 +122,5 @@ run `clang --version` and pass the version number via
 [bazel-install]: https://bazel.build/install
 [copt]: https://bazel.build/docs/user-manual#copt
 [glibc]: https://www.gnu.org/software/libc
+[linkopt]: https://bazel.build/docs/user-manual#linkopt
 [musl libc]: https://musl.libc.org

--- a/bazel/third_party/aes_siv/aes_siv.BUILD
+++ b/bazel/third_party/aes_siv/aes_siv.BUILD
@@ -14,6 +14,7 @@ cc_library(
         "config.h",
     ],
     hdrs = ["aes_siv.h"],
+    copts = ["-O3"],
     includes = ["."],
     visibility = ["//visibility:public"],
     deps = ["@openssl"],

--- a/bazel/third_party/curl/curl.BUILD
+++ b/bazel/third_party/curl/curl.BUILD
@@ -56,6 +56,7 @@ configure_make(
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),
+    copts = ["-O3"],
     env = {
         "URBIT_RUNTIME_OPENSSL": "$$PWD/$(GENDIR)/external/openssl/openssl",
     },

--- a/bazel/third_party/ed25519/ed25519.BUILD
+++ b/bazel/third_party/ed25519/ed25519.BUILD
@@ -8,6 +8,7 @@ cc_library(
         exclude = ["src/ed25519.h"],
     ),
     hdrs = ["src/ed25519.h"],
+    copts = ["-O3"],
     includes = ["src"],
     visibility = ["//visibility:public"],
 )

--- a/bazel/third_party/gmp/gmp.BUILD
+++ b/bazel/third_party/gmp/gmp.BUILD
@@ -21,6 +21,7 @@ configure_make(
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),
+    copts = ["-O3"],
     lib_source = ":all",
     out_static_libs = ["libgmp.a"],
     visibility = ["//visibility:public"],

--- a/bazel/third_party/h2o/h2o.BUILD
+++ b/bazel/third_party/h2o/h2o.BUILD
@@ -21,6 +21,7 @@ cc_library(
     name = "cloexec",
     srcs = ["deps/cloexec/cloexec.c"],
     hdrs = ["deps/cloexec/cloexec.h"],
+    copts = ["-O3"],
     includes = ["deps/cloexec"],
     linkstatic = True,
     visibility = ["//visibility:private"],
@@ -30,6 +31,7 @@ cc_library(
 cc_library(
     name = "golombset",
     hdrs = ["deps/golombset/golombset.h"],
+    copts = ["-O3"],
     includes = ["deps/golombset"],
     linkstatic = True,
     visibility = ["//visibility:private"],
@@ -40,6 +42,7 @@ cc_library(
     name = "klib",
     srcs = glob(["deps/klib/*.c"]),
     hdrs = glob(["deps/klib/*.h"]),
+    copts = ["-O3"],
     includes = ["deps/klib"],
     linkstatic = True,
     local_defines = select({
@@ -61,6 +64,7 @@ cc_library(
     name = "libgkc",
     srcs = ["deps/libgkc/gkc.c"],
     hdrs = ["deps/libgkc/gkc.h"],
+    copts = ["-O3"],
     includes = ["deps/libgkc"],
     linkstatic = True,
     visibility = ["//visibility:private"],
@@ -96,6 +100,7 @@ cc_library(
     name = "picohttpparser",
     srcs = ["deps/picohttpparser/picohttpparser.c"],
     hdrs = ["deps/picohttpparser/picohttpparser.h"],
+    copts = ["-O3"],
     includes = ["deps/picohttpparser"],
     linkstatic = True,
     local_defines = select({
@@ -148,6 +153,7 @@ cc_library(
 cc_library(
     name = "ssl_conservatory",
     hdrs = ["deps/ssl-conservatory/openssl/openssl_hostname_validation.h"],
+    copts = ["-O3"],
     includes = ["deps/ssl-conservatory/openssl"],
     linkstatic = True,
     textual_hdrs = ["deps/ssl-conservatory/openssl/openssl_hostname_validation.c"],
@@ -158,6 +164,7 @@ cc_library(
 cc_library(
     name = "yoml",
     hdrs = glob(["deps/yoml/*.h"]),
+    copts = ["-O3"],
     includes = ["deps/yoml"],
     linkstatic = True,
     visibility = ["//visibility:private"],
@@ -208,6 +215,7 @@ cc_library(
             "deps/picotls/deps/cifra/src/ext/*.h",
         ],
     ),
+    copts = ["-O3"],
     includes = [
         "deps/picotls/deps/cifra/src",
         "deps/picotls/deps/cifra/src/ext",
@@ -226,6 +234,7 @@ cc_library(
         "deps/picotls/deps/micro-ecc/uECC_vli.h",
     ],
     hdrs = ["deps/picotls/deps/micro-ecc/uECC.h"],
+    copts = ["-O3"],
     includes = ["deps/picotls/deps/micro-ecc"],
     textual_hdrs = [
         "deps/picotls/deps/micro-ecc/asm_arm.inc",

--- a/bazel/third_party/keccak_tiny/keccak_tiny.BUILD
+++ b/bazel/third_party/keccak_tiny/keccak_tiny.BUILD
@@ -5,6 +5,7 @@ cc_library(
         "keccak-tiny.c",
     ],
     hdrs = ["keccak-tiny.h"],
+    copts = ["-O3"],
     includes = ["."],
     local_defines = select({
         # TODO: confirm which platforms have memset_s().

--- a/bazel/third_party/openssl/openssl.BUILD
+++ b/bazel/third_party/openssl/openssl.BUILD
@@ -29,6 +29,7 @@ configure_make(
         ],
         "//conditions:default": [],
     }),
+    copts = ["-O3"],
     lib_source = ":all",
     out_static_libs = [
         "libssl.a",

--- a/bazel/third_party/secp256k1/secp256k1.BUILD
+++ b/bazel/third_party/secp256k1/secp256k1.BUILD
@@ -23,6 +23,7 @@ configure_make(
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),
+    copts = ["-O3"],
     lib_source = ":all",
     out_static_libs = ["libsecp256k1.a"],
     visibility = ["//visibility:public"],

--- a/bazel/third_party/sigsegv/sigsegv.BUILD
+++ b/bazel/third_party/sigsegv/sigsegv.BUILD
@@ -24,6 +24,7 @@ configure_make(
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),
+    copts = ["-O3"],
     lib_source = ":all",
     out_static_libs = ["libsigsegv.a"],
     visibility = ["//visibility:public"],

--- a/bazel/third_party/sse2neon/sse2neon.BUILD
+++ b/bazel/third_party/sse2neon/sse2neon.BUILD
@@ -1,6 +1,7 @@
 cc_library(
     name = "sse2neon",
     hdrs = ["sse2neon.h"],
+    copts = ["-O3"],
     linkstatic = True,
     visibility = ["//visibility:public"],
 )

--- a/bazel/third_party/uv/uv.BUILD
+++ b/bazel/third_party/uv/uv.BUILD
@@ -20,6 +20,7 @@ configure_make(
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
         "//conditions:default": [],
     }),
+    copts = ["-O3"],
     lib_source = ":all",
     out_static_libs = ["libuv.a"],
     targets = ["install"],

--- a/bazel/third_party/whereami/whereami.BUILD
+++ b/bazel/third_party/whereami/whereami.BUILD
@@ -2,6 +2,7 @@ cc_library(
     name = "whereami",
     srcs = ["src/whereami.c"],
     hdrs = ["src/whereami.h"],
+    copts = ["-O3"],
     includes = ["src"],
     visibility = ["//visibility:public"],
 )

--- a/bazel/third_party/zlib/zlib.BUILD
+++ b/bazel/third_party/zlib/zlib.BUILD
@@ -12,6 +12,7 @@ configure_make(
         "//conditions:default": ["--jobs=`nproc`"],
     }),
     configure_options = ["--static"],
+    copts = ["-O3"],
     lib_source = ":all",
     out_static_libs = ["libz.a"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Description

Resolves #83.

## Testing

```console
$ bazel build :urbitdbg
```
When running the resulting binary under `gdb`, no arguments are optimized out, as expected with an optimization level of `-O0` (set by the debug configuration).

```console
$ gdb ./urbit
GNU gdb (GDB) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./urbit...
(gdb) list pkg/noun/allocate.h:310
305                                  ? (c3_w)(r->mat_p - r->cap_p) \
306                                  : (c3_w)(r->cap_p - r->mat_p) )
307
308     #     define  u3a_north_is_senior(r, dog) \
309                     __((u3a_to_off(dog) < r->rut_p) ||  \
310                            (u3a_to_off(dog) >= r->mat_p))
311
312     #     define  u3a_north_is_junior(r, dog) \
313                     __((u3a_to_off(dog) >= r->cap_p) && \
314                            (u3a_to_off(dog) < r->mat_p))
(gdb) list pkg/noun/urth.c:371
366     /* _cu_realloc(): hash-cons roots off-loom, reallocate on loom.
367     */
368     static ur_nref
369     _cu_realloc(FILE* fil_u, ur_root_t** tor_u, ur_nvec_t* doc_u)
370     {
371     #ifdef U3_MEMORY_DEBUG
372       c3_assert(0);
373     #endif
374
375       //  bypassing page tracking as an optimization
(gdb) set args zod
(gdb) r
Starting program: /home/tlon/code/gh/urbit/vere/urbit zod

This GDB supports auto-downloading debuginfo from the following URLs:
https://debuginfod.archlinux.org
Enable debuginfod for this session? (y or [n]) n
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
~
urbit 1.18-4e89526eb1
boot: home is /home/tlon/code/gh/urbit/vere/zod
loom: mapped 2048MB
lite: arvo formula 2a2274c9
lite: core 4bb376f0
lite: final state 4bb376f0
[Detaching after fork from child process 1438063]
loom: mapped 2048MB
boot: protected loom
live: logical boot
boot: installed 351 jets
---------------- playback starting ----------------
pier: replaying events 1-16

Program received signal SIGINT, Interrupt.
                                          _me_lose_north (dog=3247830431) at pkg/noun/allocate.c:1374
1374        if ( box_u->use_w > 1 ) {
(gdb) bt
#0  _me_lose_north (dog=3247830431) at pkg/noun/allocate.c:1374
#1  0x0000000000436277 in u3a_lose (som=3247830431) at pkg/noun/allocate.c:1470
#2  0x000000000043ca1e in _ch_free_node (han_u=0x20439ad2c, lef_w=10) at pkg/noun/hashtable.c:692
#3  0x000000000043ca66 in _ch_free_node (han_u=0x207c09eac, lef_w=15) at pkg/noun/hashtable.c:700
#4  0x000000000043ca66 in _ch_free_node (han_u=0x206318b04, lef_w=20) at pkg/noun/hashtable.c:700
#5  0x000000000043cb1c in u3h_free (har_p=15708796) at pkg/noun/hashtable.c:724
#6  0x000000000044d2b1 in _cr_sing (a=3230144997, b=3223017927) at pkg/noun/retrieve.c:562
#7  0x000000000044d33d in u3r_sing (a=3227066632, b=3227884839) at pkg/noun/retrieve.c:580
#8  0x000000000043c749 in _ch_node_git (han_u=0x208225bd4, lef_w=10, rem_w=916, key=3227066632) at pkg/noun/hashtable.c:598
#9  0x000000000043c7e6 in _ch_node_git (han_u=0x2081a08e0, lef_w=15, rem_w=16276, key=3227066632) at pkg/noun/hashtable.c:611
#10 0x000000000043c7e6 in _ch_node_git (han_u=0x20840a524, lef_w=20, rem_w=737172, key=3227066632) at pkg/noun/hashtable.c:611
#11 0x000000000043c949 in u3h_git (har_p=15708722, key=3227066632) at pkg/noun/hashtable.c:646
#12 0x00000000004509cb in _cs_jam_xeno_cell (a=3227066632, ptr_v=0x7fffffffe0c0) at pkg/noun/serial.c:254
#13 0x000000000043862c in u3a_walk_fore (a=3227066632, ptr_v=0x7fffffffe0c0, pat_f=0x4508c5 <_cs_jam_xeno_atom>, cel_f=0x450996 <_cs_jam_xeno_cell>) at pkg/noun/allocate.c:2607
#14 0x0000000000450ab9 in u3s_jam_xeno (a=3241480374, len_d=0x7fffffffe130, byt_y=0x7fffffffe128) at pkg/noun/serial.c:276
#15 0x000000000043212a in _lord_writ_send (god_u=0x7ffff7cd10e0, wit_u=0x7ffff7ff70d0) at pkg/vere/lord.c:841
#16 0x00000000004322d7 in _lord_writ_plan (god_u=0x7ffff7cd10e0, wit_u=0x7ffff7ff70d0) at pkg/vere/lord.c:869
#17 0x0000000000432531 in u3_lord_play (god_u=0x7ffff7cd10e0, fon_u=...) at pkg/vere/lord.c:924
#18 0x0000000000417ded in _pier_play_send (pay_u=0x7ffff7ff7e10) at pkg/vere/pier.c:968
#19 0x000000000041802c in _pier_play (pay_u=0x7ffff7ff7e10) at pkg/vere/pier.c:1055
#20 0x0000000000418694 in _pier_on_disk_read_done (ptr_v=0x7ffff7ff7380, fon_u=...) at pkg/vere/pier.c:1218
#21 0x00000000004074d2 in _disk_read_done_cb (tim_u=0x7ffff7cd1840) at pkg/vere/disk.c:357
#22 0x000000000058e377 in uv__run_timers (loop=0xdc0a60 <default_loop_struct>) at src/timer.c:178
#23 0x000000000059297d in uv_run (loop=0xdc0a60 <default_loop_struct>, mode=UV_RUN_DEFAULT) at src/unix/core.c:393
#24 0x0000000000413d57 in u3_king_commence () at pkg/vere/king.c:925
#25 0x00000000004057cf in main (argc=2, argv=0x7fffffffe4c8) at pkg/vere/main.c:2249
```