### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# For more information on how CODEOWNERS work, see
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.
+
+# Default owner for everything in the repo. Matches farther down in the file
+# will override this default.
+* @urbit/runtime

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,11 @@
 # Default owner for everything in the repo. Matches farther down in the file
 # will override this default.
 * @urbit/runtime
+
+# Build system
+/.github/ @mcevoypeter
+/bazel/   @mcevoypeter
+*.bazel   @mcevoypeter
+*.bzl     @mcevoypeter
+/PACE     @mcevoypeter
+/VERSION  @mcevoypeter


### PR DESCRIPTION
## Description

Resolves #124 by defining the [Urbit runtime team](https://github.com/orgs/urbit/teams/runtime) as the default owners of all files in this repo.