### PR TITLE
build: fix broken import for macos-x86_64

### DIFF
--- a/pkg/ent/ent.c
+++ b/pkg/ent/ent.c
@@ -12,6 +12,8 @@ int ent_getentropy(void* buf, size_t len) {
 
 #elif defined(ENT_GETENTROPY_SYSRANDOM)
 #include <stddef.h>
+// See https://www.mail-archive.com/bug-gnulib@gnu.org/msg38583.html.
+#include <stdlib.h>
 #include <sys/random.h>
 int ent_getentropy(void* buf, size_t len) {
   return getentropy(buf, len);


### PR DESCRIPTION
These were the most minimal set of changes that allowed me to build vere on macOS x86-64. See #131 for context. To build, I ran `bazel build --clang_version="12.0.0" :urbit`.