### PR TITLE
Eval improvements

### DIFF
--- a/pkg/noun/vortex.c
+++ b/pkg/noun/vortex.c
@@ -120,6 +120,31 @@ _cv_nock_wish(u3_noun txt)
   return pro;
 }
 
+/* u3v_wish_n(): text expression with cache.
+*/
+u3_noun
+u3v_wish_n(u3_noun txt)
+{
+  u3t_event_trace("u3v_wish", 'b');
+  u3_weak exp = u3kdb_get(u3k(u3A->yot), u3k(txt));
+
+  if ( u3_none == exp ) {
+    exp = _cv_nock_wish(u3k(txt));
+
+    //  It's probably not a good idea to use u3v_wish()
+    //  outside the top level... (as the result is uncached)
+    //
+    if ( u3R == &u3H->rod_u ) {
+      u3A->yot = u3kdb_put(u3A->yot, u3k(txt), u3k(exp));
+    }
+  }
+
+  u3t_event_trace("u3v_wish", 'e');
+
+  u3z(txt);
+  return exp;
+}
+
 /* u3v_wish(): text expression with cache.
 */
 u3_noun

--- a/pkg/noun/vortex.c
+++ b/pkg/noun/vortex.c
@@ -120,7 +120,7 @@ _cv_nock_wish(u3_noun txt)
   return pro;
 }
 
-/* u3v_wish_n(): text expression with cache.
+/* u3v_wish_n(): text expression with cache. with the input as a u3_noun.
 */
 u3_noun
 u3v_wish_n(u3_noun txt)

--- a/pkg/noun/vortex.h
+++ b/pkg/noun/vortex.h
@@ -56,6 +56,11 @@
       c3_o
       u3v_boot_lite(u3_noun lit);
 
+    /* u3v_wish_n(): text expression with cache.
+    */
+      u3_noun
+      u3v_wish_n(const u3_noun txt);
+
     /* u3v_do(): use a kernel function.
     */
       u3_noun

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1246,39 +1246,42 @@ _cw_eval(c3_i argc, c3_c* argv[])
     u3z(gat);
   } else {
     u3_noun sam = u3i_string(evl_c);
-    u3_noun res = u3v_wish_n(sam);
+    u3_noun res = u3m_soft(0, u3v_wish_n, sam);
     c3_d bits = 0;
     c3_d len_d = 0;
     c3_y* byt_y;
-    bits = u3s_jam_xeno(res, &len_d, &byt_y);
-    if ( c3n == kan_o ) {
-      fprintf(stderr,"jammed noun: ");
-      for ( size_t p=0; p < len_d; p++ ){
-        fprintf(stdout,"\\x%2x", byt_y[p++]);
+    if ( 0 == u3h(res) ) {  //  successful execution, print output
+      bits = u3s_jam_xeno(u3t(res), &len_d, &byt_y);
+      if ( c3n == kan_o ) {
+        fprintf(stderr,"jammed noun: ");
+        for ( size_t p=0; p < len_d; p++ ){
+          fprintf(stdout,"\\x%2x", byt_y[p++]);
+        }
+        fprintf(stderr,"\n");
+      } else {
+         fprintf(stderr,"khan jammed noun: ");
+         c3_y out_y[5];
+         out_y[0] = 0x0;
+         out_y[1] = ( len_d        & 0xff);
+         out_y[2] = ((len_d >>  8) & 0xff);
+         out_y[3] = ((len_d >> 16) & 0xff);
+         out_y[4] = ((len_d >> 24) & 0xff);
+         fwrite(out_y, 1, 5, stdout);
+         if( ferror(stdout) ) {
+           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+           exit(1);
+         }
+         fwrite(byt_y, 1, len_d, stdout);
+         if( ferror(stdout) ) {
+           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+           exit(1);
+         }
+         fprintf(stderr, "\n");
       }
-      fprintf(stderr,"\n");
-    } else {
-       fprintf(stderr,"khan jammed noun: ");
-       c3_y out_y[5];
-       out_y[0] = 0x0;
-       out_y[1] = ( len_d        & 0xff);
-       out_y[2] = ((len_d >>  8) & 0xff);
-       out_y[3] = ((len_d >> 16) & 0xff);
-       out_y[4] = ((len_d >> 24) & 0xff);
-       fwrite(out_y, 1, 5, stdout);
-       if( ferror(stdout) ) {
-         fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
-         exit(1);
-       }
-       fwrite(byt_y, 1, len_d, stdout);
-       if( ferror(stdout) ) {
-         fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
-         exit(1);
-       }
-       fprintf(stderr, "\n");
+    } else {                  //  error, print stack trace
+       u3_pier_punt_goof("eval", u3k(res));
     }
     u3z(res);
-    u3z(sam);
   }
   free(evl_c);
 }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1274,7 +1274,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
         {
            fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
            exit(1);
-        }  
+        }
         fprintf(stderr, "\n");
       }
     u3z(res);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -628,6 +628,7 @@ _cw_usage(c3_c* bin_c)
     "utilities:\n",
     "  %s cram %.*s              jam state:\n",
     "  %s dock %.*s              copy binary:\n",
+    "  %s eval                      evaluate hoon from stdin:\n",
     "  %s grab %.*s              measure memory usage:\n",
     "  %s info %.*s              print pier info:\n",
     "  %s meld %.*s              deduplicate snapshot:\n",
@@ -1159,7 +1160,8 @@ _cw_eval(c3_i argc, c3_c* argv[])
 {
   c3_i ch_i, lid_i;
   c3_w arg_w;
-  c3_o jam_l, khan_l;
+  c3_o jam_l = c3n;
+  c3_o khan_l = c3n;
 
   static struct option lop_u[] = {
     { "loom", required_argument, NULL, c3__loom },

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1181,14 +1181,17 @@ _cw_eval(c3_i argc, c3_c* argv[])
         }
         u3_Host.ops_u.lom_y = lom_w;
       } break;
+
       case 'j': {
         jam_o = c3y;
         kan_o = c3n;
       } break;
+
       case 'k': {
         jam_o = c3y;
         kan_o = c3y;
       } break;
+
       case '?': {
         fprintf(stderr, "invalid argument\r\n");
         exit(1);
@@ -1236,8 +1239,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
     }
     if ( 0 == u3h(res) ) {  //  successful execution, print output
       u3_pier_tank(0, 0, u3k(u3t(res)));
-    }
-    else {                  //  error, print stack trace
+    } else {                  //  error, print stack trace
        u3_pier_punt_goof("eval", u3k(res));
     }
     u3z(res);
@@ -1264,14 +1266,12 @@ _cw_eval(c3_i argc, c3_c* argv[])
        out_y[3] = ((len_d >> 16) & 0xff);
        out_y[4] = ((len_d >> 24) & 0xff);
        fwrite(out_y, 1, 5, stdout);
-       if( ferror(stdout))
-       {
+       if( ferror(stdout) ) {
          fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
          exit(1);
        }
        fwrite(byt_y, 1, len_d, stdout);
-       if( ferror(stdout))
-       {
+       if( ferror(stdout) ) {
          fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
          exit(1);
        }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1175,8 +1175,8 @@ _cw_eval(c3_i argc, c3_c* argv[])
       case c3__loom: {
         c3_w lom_w;
         c3_o res_o = _main_readw(optarg, u3a_bits + 3, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %u\r\n", u3a_bits + 2);
+        if ( (c3n == res_o) || (lom_w < 24) ) {
+          fprintf(stderr, "error: --loom must be >= 24 and <= %u\r\n", u3a_bits + 2);
           exit(1);
         }
         u3_Host.ops_u.lom_y = lom_w;

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1160,8 +1160,8 @@ _cw_eval(c3_i argc, c3_c* argv[])
 {
   c3_i ch_i, lid_i;
   c3_w arg_w;
-  c3_o jam_l = c3n;
-  c3_o khan_l = c3n;
+  c3_o jam_o = c3n;
+  c3_o kan_o = c3n;
 
   static struct option lop_u[] = {
     { "loom", required_argument, NULL, c3__loom },
@@ -1182,12 +1182,12 @@ _cw_eval(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.lom_y = lom_w;
       } break;
       case 'j': {
-        jam_l = c3y;
-        khan_l = c3n;
+        jam_o = c3y;
+        kan_o = c3n;
       } break;
       case 'k': {
-        jam_l = c3y;
-        khan_l = c3y;
+        jam_o = c3y;
+        kan_o = c3y;
       } break;
       case '?': {
         fprintf(stderr, "invalid argument\r\n");
@@ -1224,7 +1224,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
     }
   }
   fprintf(stderr, "eval:\n");
-  if ( c3n == jam_l ) {
+  if ( c3n == jam_o ) {
     //  +wish for an eval gate (virtualized twice for pretty-printing)
     //
     u3_noun gat = u3v_wish("|=(a=@t (sell (slap !>(+>.$) (rain /eval a))))");
@@ -1249,34 +1249,34 @@ _cw_eval(c3_i argc, c3_c* argv[])
     c3_d len_d = 0;
     c3_y* byt_y;
     bits = u3s_jam_xeno(res, &len_d, &byt_y);
-    if ( c3n == khan_l ) {
+    if ( c3n == kan_o ) {
       fprintf(stderr,"jammed noun: ");
       for ( size_t p=0; p < len_d; p++ ){
         fprintf(stdout,"\\x%2x", byt_y[p++]);
       }
       fprintf(stderr,"\n");
     } else {
-        fprintf(stderr,"khan jammed noun: ");
-        c3_y out_y[5];
-        out_y[0] = 0x0;
-        out_y[1] = ( len_d        & 0xff);
-        out_y[2] = ((len_d >>  8) & 0xff);
-        out_y[3] = ((len_d >> 16) & 0xff);
-        out_y[4] = ((len_d >> 24) & 0xff);
-        fwrite(out_y, 1, 5, stdout);
-        if( ferror(stdout))
-        {
-           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
-           exit(1);
-        }
-        fwrite(byt_y, 1, len_d, stdout);
-        if( ferror(stdout))
-        {
-           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
-           exit(1);
-        }
-        fprintf(stderr, "\n");
-      }
+       fprintf(stderr,"khan jammed noun: ");
+       c3_y out_y[5];
+       out_y[0] = 0x0;
+       out_y[1] = ( len_d        & 0xff);
+       out_y[2] = ((len_d >>  8) & 0xff);
+       out_y[3] = ((len_d >> 16) & 0xff);
+       out_y[4] = ((len_d >> 24) & 0xff);
+       fwrite(out_y, 1, 5, stdout);
+       if( ferror(stdout))
+       {
+         fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+         exit(1);
+       }
+       fwrite(byt_y, 1, len_d, stdout);
+       if( ferror(stdout))
+       {
+         fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+         exit(1);
+       }
+       fprintf(stderr, "\n");
+    }
     u3z(res);
     u3z(sam);
   }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1185,13 +1185,11 @@ _cw_eval(c3_i argc, c3_c* argv[])
       case 'j': {
         jam_l = c3y;
         khan_l = c3n;
-        fprintf(stderr, "j flag\r\n");
       } break;
 
       case 'k': {
         jam_l = c3y;
         khan_l = c3y;
-        fprintf(stderr, "jk flag\r\n");
       } break;
 
       case '?': {

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1181,34 +1181,27 @@ _cw_eval(c3_i argc, c3_c* argv[])
         }
         u3_Host.ops_u.lom_y = lom_w;
       } break;
-
       case 'j': {
         jam_l = c3y;
         khan_l = c3n;
       } break;
-
       case 'k': {
         jam_l = c3y;
         khan_l = c3y;
       } break;
-
       case '?': {
         fprintf(stderr, "invalid argument\r\n");
         exit(1);
       } break;
     }
   }
-
   //  argv[optind] is always "eval"
   //
-
   if ( optind + 1 != argc ) {
     fprintf(stderr, "invalid command\r\n");
     exit(1);
   }
-
   c3_c* evl_c = _cw_eval_get_input(stdin, 10);
-
   //  initialize the Loom and load the Ivory Pill
   //
   {
@@ -1230,11 +1223,8 @@ _cw_eval(c3_i argc, c3_c* argv[])
       exit(1);
     }
   }
-
   fprintf(stderr, "eval:\n");
-
   if ( c3n == jam_l ) {
-
     //  +wish for an eval gate (virtualized twice for pretty-printing)
     //
     u3_noun gat = u3v_wish("|=(a=@t (sell (slap !>(+>.$) (rain /eval a))))");
@@ -1244,44 +1234,35 @@ _cw_eval(c3_i argc, c3_c* argv[])
       u3_noun cor = u3nc(u3k(u3h(gat)), u3nc(sam, u3k(u3t(u3t(gat)))));
       res = u3m_soft(0, u3n_kick_on, cor);
     }
-  
-  
     if ( 0 == u3h(res) ) {  //  successful execution, print output
       u3_pier_tank(0, 0, u3k(u3t(res)));
     }
     else {                  //  error, print stack trace
        u3_pier_punt_goof("eval", u3k(res));
     }
-
     u3z(res);
     u3z(gat);
   } else {
     u3_noun sam = u3i_string(evl_c);
     u3_noun res = u3v_wish_n(sam);
-
     c3_d bits = 0;
     c3_d len_d = 0;
     c3_y* byt_y;
-
     bits = u3s_jam_xeno(res, &len_d, &byt_y);
-
     if ( c3n == khan_l ) {
       fprintf(stderr,"jammed noun: ");
-       
       for ( size_t p=0; p < len_d; p++ ){
         fprintf(stdout,"\\x%2x", byt_y[p++]);
       }
       fprintf(stderr,"\n");
     } else {
         fprintf(stderr,"khan jammed noun: ");
-         
         c3_y out_y[5];
         out_y[0] = 0x0;
         out_y[1] = ( len_d        & 0xff);
         out_y[2] = ((len_d >>  8) & 0xff);
         out_y[3] = ((len_d >> 16) & 0xff);
         out_y[4] = ((len_d >> 24) & 0xff);
-         
         fwrite(out_y, 1, 5, stdout);
         if( ferror(stdout))
         {

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -626,9 +626,9 @@ _cw_usage(c3_c* bin_c)
 {
   c3_c *use_c[] = {
     "utilities:\n",
+    "  %s eval                      evaluate hoon from stdin:\n",
     "  %s cram %.*s              jam state:\n",
     "  %s dock %.*s              copy binary:\n",
-    "  %s eval                      evaluate hoon from stdin:\n",
     "  %s grab %.*s              measure memory usage:\n",
     "  %s info %.*s              print pier info:\n",
     "  %s meld %.*s              deduplicate snapshot:\n",
@@ -1165,8 +1165,8 @@ _cw_eval(c3_i argc, c3_c* argv[])
 
   static struct option lop_u[] = {
     { "loom", required_argument, NULL, c3__loom },
-    { "j", no_argument, NULL, 'j' },
-    { "jk", no_argument, NULL, 'k' },
+    { "jam", no_argument, NULL, 'j' },
+    { "jamkhan", no_argument, NULL, 'k' },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1268,12 +1268,11 @@ _cw_eval(c3_i argc, c3_c* argv[])
     if ( c3n == khan_l ) {
       fprintf(stderr,"jammed noun: ");
        
-      int p=0;
-      while (p < len_d ){
+      for ( size_t p=0; p < len_d; p++ ){
         fprintf(stdout,"\\x%2x", byt_y[p++]);
       }
-        fprintf(stderr,"\n");
-      } else {
+      fprintf(stderr,"\n");
+    } else {
         fprintf(stderr,"khan jammed noun: ");
          
         c3_y out_y[5];

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1159,9 +1159,12 @@ _cw_eval(c3_i argc, c3_c* argv[])
 {
   c3_i ch_i, lid_i;
   c3_w arg_w;
+  c3_o jam_l, khan_l;
 
   static struct option lop_u[] = {
     { "loom", required_argument, NULL, c3__loom },
+    { "j", no_argument, NULL, 'j' },
+    { "jk", no_argument, NULL, 'k' },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1175,6 +1178,18 @@ _cw_eval(c3_i argc, c3_c* argv[])
           exit(1);
         }
         u3_Host.ops_u.lom_y = lom_w;
+      } break;
+
+      case 'j': {
+        jam_l = c3y;
+        khan_l = c3n;
+        fprintf(stderr, "j flag\r\n");
+      } break;
+
+      case 'k': {
+        jam_l = c3y;
+        khan_l = c3y;
+        fprintf(stderr, "jk flag\r\n");
       } break;
 
       case '?': {
@@ -1206,7 +1221,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
     u3m_boot_lite((size_t)1 << u3_Host.ops_u.lom_y);
     sil_u = u3s_cue_xeno_init_with(ur_fib27, ur_fib28);
     if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) {
-      printf("lite: unable to cue ivory pill\r\n");
+      fprintf(stderr, "lite: unable to cue ivory pill\r\n");
       exit(1);
     }
     u3s_cue_xeno_done(sil_u);
@@ -1216,28 +1231,75 @@ _cw_eval(c3_i argc, c3_c* argv[])
     }
   }
 
-  printf("eval:\n");
+  fprintf(stderr, "eval:\n");
 
-  //  +wish for an eval gate (virtualized twice for pretty-printing)
-  //
-  u3_noun gat = u3v_wish("|=(a=@t (sell (slap !>(+>.$) (rain /eval a))))");
-  u3_noun res;
-  {
+  if ( c3n == jam_l ) {
+
+    //  +wish for an eval gate (virtualized twice for pretty-printing)
+    //
+    u3_noun gat = u3v_wish("|=(a=@t (sell (slap !>(+>.$) (rain /eval a))))");
+    u3_noun res;
+    {
+      u3_noun sam = u3i_string(evl_c);
+      u3_noun cor = u3nc(u3k(u3h(gat)), u3nc(sam, u3k(u3t(u3t(gat)))));
+      res = u3m_soft(0, u3n_kick_on, cor);
+    }
+  
+  
+    if ( 0 == u3h(res) ) {  //  successful execution, print output
+      u3_pier_tank(0, 0, u3k(u3t(res)));
+    }
+    else {                  //  error, print stack trace
+       u3_pier_punt_goof("eval", u3k(res));
+    }
+
+    u3z(res);
+    u3z(gat);
+  } else {
     u3_noun sam = u3i_string(evl_c);
-    u3_noun cor = u3nc(u3k(u3h(gat)), u3nc(sam, u3k(u3t(u3t(gat)))));
-    res = u3m_soft(0, u3n_kick_on, cor);
-  }
+    u3_noun res = u3v_wish_n(sam);
 
+    c3_d bits = 0;
+    c3_d len_d = 0;
+    c3_y* byt_y;
 
-  if ( 0 == u3h(res) ) {  //  successful execution, print output
-     u3_pier_tank(0, 0, u3k(u3t(res)));
-  }
-  else {                  //  error, print stack trace
-     u3_pier_punt_goof("eval", u3k(res));
-  }
+    bits = u3s_jam_xeno(res, &len_d, &byt_y);
 
-  u3z(res);
-  u3z(gat);
+    if ( c3n == khan_l ) {
+      fprintf(stderr,"jammed noun: ");
+       
+      int p=0;
+      while (p < len_d ){
+        fprintf(stdout,"\\x%2x", byt_y[p++]);
+      }
+        fprintf(stderr,"\n");
+      } else {
+        fprintf(stderr,"khan jammed noun: ");
+         
+        c3_y out_y[5];
+        out_y[0] = 0x0;
+        out_y[1] = ( len_d        & 0xff);
+        out_y[2] = ((len_d >>  8) & 0xff);
+        out_y[3] = ((len_d >> 16) & 0xff);
+        out_y[4] = ((len_d >> 24) & 0xff);
+         
+        fwrite(out_y, 1, 5, stdout);
+        if( ferror(stdout))
+        {
+           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+           exit(1);
+        }
+        fwrite(byt_y, 1, len_d, stdout);
+        if( ferror(stdout))
+        {
+           fprintf(stderr, "Write Failed : %s\n",strerror(errno) );
+           exit(1);
+        }  
+        fprintf(stderr, "\n");
+      }
+    u3z(res);
+    u3z(sam);
+  }
   free(evl_c);
 }
 


### PR DESCRIPTION
I added the ability for the user pick two flags to pass to the eval subroutine. 

The first is the `--jam` flag. This takes the result from the inputted hoon code , `+jam`'s it and outputs it as a hexadecimal string. 

The second is the `--jamkhan` flag. This takes the result from the inputted hoon code, `+jam`'s it and outputs the noun wrapped in the proper `%khan` header (leading zero, noun size, noun) as binary data.

The proper use of the eval is as follows:
`echo "(add 2 2)" | vere eval --jamkhan > test.jam`

You can directly inject a `|meld` command to a running pier as follows:
`echo "[1 %urth %meld]" | ./vere  eval --jamkhan | nc -U ~/urbit/zod/.urb/conn.sock`

This should be the easiest way to `+jam` a noun for `%khan` use

This is a clone commit of [#6048](https://github.com/urbit/urbit/pull/6048) on urbit/urbit 
