### PR TITLE
chop: offline event log truncation

### DIFF
--- a/pkg/c3/defs.h
+++ b/pkg/c3/defs.h
@@ -156,5 +156,7 @@
         unlink(a);})
 #     define c3_fopen(a, b) ({                                  \
         fopen(a, b);})
+#     define c3_remove(a) ({                                    \
+        remove(a);})
 
 #endif /* ifndef C3_DEFS_H */

--- a/pkg/c3/defs.h
+++ b/pkg/c3/defs.h
@@ -158,5 +158,7 @@
         fopen(a, b);})
 #     define c3_remove(a) ({                                    \
         remove(a);})
+#     define c3_rename(a, b) ({                                 \
+        rename(a, b);})
 
 #endif /* ifndef C3_DEFS_H */

--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -201,6 +201,7 @@
 #   define c3__chew   c3_s4('c','h','e','w')
 #   define c3__chis   c3_s4('c','h','i','s')
 #   define c3__chob   c3_s4('c','h','o','b')
+#   define c3__chop   c3_s4('c','h','o','p')
 #   define c3__chug   c3_s4('c','h','u','g')
 #   define c3__claf   c3_s4('c','l','a','f')
 #   define c3__clam   c3_s4('c','l','a','m')

--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -838,6 +838,7 @@
 #   define c3__or     c3_s2('o','r')
 #   define c3__ord    c3_s3('o','r','d')
 #   define c3__orth   c3_s4('o','r','t','h')
+#   define c3__out    c3_s3('o','u','t')
 #   define c3__outd   c3_s4('o','u','t','d')
 #   define c3__ov     c3_s2('o','v')
 #   define c3__over   c3_s4('o','v','e','r')

--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -837,7 +837,6 @@
 #   define c3__or     c3_s2('o','r')
 #   define c3__ord    c3_s3('o','r','d')
 #   define c3__orth   c3_s4('o','r','t','h')
-#   define c3__out    c3_s3('o','u','t')
 #   define c3__outd   c3_s4('o','u','t','d')
 #   define c3__ov     c3_s2('o','v')
 #   define c3__over   c3_s4('o','v','e','r')

--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -626,6 +626,7 @@
 #   define c3__king   c3_s4('k','i','n','g')
 #   define c3__kit    c3_s3('k','i','t')
 #   define c3__klr    c3_s3('k','l','r')
+#   define c3__knit   c3_s4('k','n','i','t')
 #   define c3__kno    c3_s3('k','n','o')
 #   define c3__ktbc   c3_s4('k','t','b','c')
 #   define c3__ktbn   c3_s4('k','t','b','n')

--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -626,7 +626,6 @@
 #   define c3__king   c3_s4('k','i','n','g')
 #   define c3__kit    c3_s3('k','i','t')
 #   define c3__klr    c3_s3('k','l','r')
-#   define c3__knit   c3_s4('k','n','i','t')
 #   define c3__kno    c3_s3('k','n','o')
 #   define c3__ktbc   c3_s4('k','t','b','c')
 #   define c3__ktbn   c3_s4('k','t','b','n')

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1103,7 +1103,7 @@ u3e_save(void)
   _ce_patch_free(pat_u);
   _ce_patch_delete();
 
-  _ce_backup();
+  u3e_backup();
 }
 
 /* u3e_live(): start the checkpointing system.

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1041,6 +1041,12 @@ u3e_backup(c3_o ovw_o)
   fprintf(stderr, "loom: image backup complete\r\n");
 }
 
+c3_o
+u3e_curr(void)
+{
+  return __(0 == _ce_patch_open());
+}
+
 /*
   u3e_save(): save current changes.
 

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1044,7 +1044,12 @@ u3e_backup(c3_o ovw_o)
 c3_o
 u3e_curr(void)
 {
-  return __(0 == _ce_patch_open());
+  u3_ce_patch* pat_u = _ce_patch_open();
+  if ( 0 != pat_u ) {
+    _ce_patch_free(pat_u);
+    return c3n;
+  }
+  return c3y;
 }
 
 /*

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -992,10 +992,10 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
   return c3y;
 }
 
-/* u3e_backup();
+/* _ce_backup();
 */
 void
-u3e_backup(void)
+u3e_backup(c3_o ovw_o)
 {
   u3e_image nop_u = { .nam_c = "north", .pgs_w = 0 };
   u3e_image sop_u = { .nam_c = "south", .pgs_w = 0 };
@@ -1004,7 +1004,7 @@ u3e_backup(void)
 
   snprintf(ful_c, 8192, "%s/.urb/bhk", u3P.dir_c);
 
-  if ( c3_mkdir(ful_c, 0700) ) {
+  if ( (c3n == ovw_o) && c3_mkdir(ful_c, 0700) ) {
     if ( EEXIST != errno ) {
       fprintf(stderr, "loom: image backup: %s\r\n", strerror(errno));
     }
@@ -1038,6 +1038,7 @@ u3e_backup(void)
 
   close(nop_u.fid_i);
   close(sop_u.fid_i);
+  fprintf(stderr, "loom: image backup complete\r\n");
 }
 
 /*
@@ -1103,7 +1104,7 @@ u3e_save(void)
   _ce_patch_free(pat_u);
   _ce_patch_delete();
 
-  u3e_backup();
+  u3e_backup(c3n);
 }
 
 /* u3e_live(): start the checkpointing system.

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -994,7 +994,7 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
 
 /* _ce_backup();
 */
-void
+c3_o
 u3e_backup(c3_o ovw_o)
 {
   u3e_image nop_u = { .nam_c = "north", .pgs_w = 0 };
@@ -1007,22 +1007,25 @@ u3e_backup(c3_o ovw_o)
   if ( (c3n == ovw_o) && c3_mkdir(ful_c, 0700) ) {
     if ( EEXIST != errno ) {
       fprintf(stderr, "loom: image backup: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: image backup failed\r\n");
+      return c3n;
     }
-    return;
   }
 
   snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, nop_u.nam_c);
 
   if ( -1 == (nop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
-    return;
+    fprintf(stderr, "loom: image backup failed\r\n");
+    return c3n;
   }
 
   snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, sop_u.nam_c);
 
   if ( -1 == (sop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
-    return;
+    fprintf(stderr, "loom: image backup failed\r\n");
+    return c3n;
   }
 
   if (  (c3n == _ce_image_copy(&u3P.nor_u, &nop_u))
@@ -1034,11 +1037,14 @@ u3e_backup(c3_o ovw_o)
     c3_unlink(ful_c);
     snprintf(ful_c, 8192, "%s/.urb/bhk", u3P.dir_c);
     c3_rmdir(ful_c);
+    fprintf(stderr, "loom: image backup failed\r\n");
+    return c3n;
   }
 
   close(nop_u.fid_i);
   close(sop_u.fid_i);
   fprintf(stderr, "loom: image backup complete\r\n");
+  return c3y;
 }
 
 /*

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -992,10 +992,10 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
   return c3y;
 }
 
-/* _ce_backup();
+/* u3e_backup();
 */
-static void
-_ce_backup(void)
+void
+u3e_backup(void)
 {
   u3e_image nop_u = { .nam_c = "north", .pgs_w = 0 };
   u3e_image sop_u = { .nam_c = "south", .pgs_w = 0 };

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1041,17 +1041,6 @@ u3e_backup(c3_o ovw_o)
   fprintf(stderr, "loom: image backup complete\r\n");
 }
 
-c3_o
-u3e_curr(void)
-{
-  u3_ce_patch* pat_u = _ce_patch_open();
-  if ( 0 != pat_u ) {
-    _ce_patch_free(pat_u);
-    return c3n;
-  }
-  return c3y;
-}
-
 /*
   u3e_save(): save current changes.
 

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -992,7 +992,7 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
   return c3y;
 }
 
-/* _ce_backup();
+/* u3e_backup();
 */
 c3_o
 u3e_backup(c3_o ovw_o)
@@ -1007,16 +1007,14 @@ u3e_backup(c3_o ovw_o)
   if ( (c3n == ovw_o) && c3_mkdir(ful_c, 0700) ) {
     if ( EEXIST != errno ) {
       fprintf(stderr, "loom: image backup: %s\r\n", strerror(errno));
-      fprintf(stderr, "loom: image backup failed\r\n");
-      return c3n;
     }
+    return c3n;
   }
 
   snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, nop_u.nam_c);
 
   if ( -1 == (nop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
-    fprintf(stderr, "loom: image backup failed\r\n");
     return c3n;
   }
 
@@ -1024,7 +1022,6 @@ u3e_backup(c3_o ovw_o)
 
   if ( -1 == (sop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
-    fprintf(stderr, "loom: image backup failed\r\n");
     return c3n;
   }
 

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -64,6 +64,11 @@
 
   /** Functions.
   **/
+    /* u3e_backup(): copy the snapshot from chk to bhk. 
+    */
+      void
+      u3e_backup(void);
+
     /* u3e_fault(): handle a memory event with libsigsegv protocol.
     */
       c3_i

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -66,7 +66,7 @@
   **/
     /* u3e_backup(): copy the snapshot from chk to bhk. 
     */
-      void
+      c3_o 
       u3e_backup(c3_o ovw_o);
 
     /* u3e_fault(): handle a memory event with libsigsegv protocol.

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -69,11 +69,6 @@
       void
       u3e_backup(c3_o ovw_o);
 
-    /* u3e_curr(): check if snapshot is current.
-    */
-      c3_o
-      u3e_curr(void);
-
     /* u3e_fault(): handle a memory event with libsigsegv protocol.
     */
       c3_i

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -69,6 +69,11 @@
       void
       u3e_backup(c3_o ovw_o);
 
+    /* u3e_curr(): check if snapshot is current.
+    */
+      c3_o
+      u3e_curr(void);
+
     /* u3e_fault(): handle a memory event with libsigsegv protocol.
     */
       c3_i

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -67,7 +67,7 @@
     /* u3e_backup(): copy the snapshot from chk to bhk. 
     */
       void
-      u3e_backup(void);
+      u3e_backup(c3_o ovw_o);
 
     /* u3e_fault(): handle a memory event with libsigsegv protocol.
     */

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -386,50 +386,6 @@ u3_lmdb_read_one(MDB_env* env_u,
   }
 }
 
-/* u3_lmdb_read_meta_one(): load [key_c] into [val_u].
-*/
-c3_o
-u3_lmdb_read_meta_one(MDB_env*    env_u,
-                      MDB_val*    val_u,
-                      const c3_c* key_c)
-{
-  MDB_txn* txn_u;
-  MDB_dbi  mdb_u;
-  c3_w     ret_w;
-
-  //  create a read transaction
-  //
-  if ( (ret_w = mdb_txn_begin(env_u, 0, MDB_RDONLY, &txn_u)) ) {
-    mdb_logerror(stderr, ret_w, "lmdb: meta read one: txn_begin fail");
-    return c3n;
-  }
-
-  //  open the database in the transaction
-  //
-  if ( (ret_w =  mdb_dbi_open(txn_u, "META", 0, &mdb_u)) ) {
-    mdb_logerror(stderr, ret_w, "lmdb: meta read one: dbi_open fail");
-    mdb_txn_abort(txn_u);
-    return c3n;
-  }
-
-  //  read by string key
-  {
-    MDB_val key_u = { .mv_size = strlen(key_c), .mv_data = (void*)key_c };
-
-    if ( (ret_w = mdb_get(txn_u, mdb_u, &key_u, val_u)) ) {
-      mdb_logerror(stderr, ret_w, "lmdb: meta read one failed");
-      mdb_txn_abort(txn_u);
-      return c3n;
-    }
-    else {
-      //  read-only transactions are aborted when complete
-      //
-      mdb_txn_abort(txn_u);
-      return c3y;
-    }
-  }
-}
-
 /* u3_lmdb_save(): save [len_d] events starting at [eve_d].
 */
 c3_o
@@ -538,6 +494,50 @@ u3_lmdb_read_meta(MDB_env*    env_u,
       //  read-only transactions are aborted when complete
       //
       mdb_txn_abort(txn_u);
+    }
+  }
+}
+
+/* u3_lmdb_read_meta_one(): load [key_c] into [val_u].
+*/
+c3_o
+u3_lmdb_read_meta_one(MDB_env*    env_u,
+                      MDB_val*    val_u,
+                      const c3_c* key_c)
+{
+  MDB_txn* txn_u;
+  MDB_dbi  mdb_u;
+  c3_w     ret_w;
+
+  //  create a read transaction
+  //
+  if ( (ret_w = mdb_txn_begin(env_u, 0, MDB_RDONLY, &txn_u)) ) {
+    mdb_logerror(stderr, ret_w, "lmdb: meta read one: txn_begin fail");
+    return c3n;
+  }
+
+  //  open the database in the transaction
+  //
+  if ( (ret_w =  mdb_dbi_open(txn_u, "META", 0, &mdb_u)) ) {
+    mdb_logerror(stderr, ret_w, "lmdb: meta read one: dbi_open fail");
+    mdb_txn_abort(txn_u);
+    return c3n;
+  }
+
+  //  read by string key
+  {
+    MDB_val key_u = { .mv_size = strlen(key_c), .mv_data = (void*)key_c };
+
+    if ( (ret_w = mdb_get(txn_u, mdb_u, &key_u, val_u)) ) {
+      mdb_logerror(stderr, ret_w, "lmdb: meta read one failed");
+      mdb_txn_abort(txn_u);
+      return c3n;
+    }
+    else {
+      //  read-only transactions are aborted when complete
+      //
+      mdb_txn_abort(txn_u);
+      return c3y;
     }
   }
 }

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -98,8 +98,8 @@ u3_lmdb_init(const c3_c* pax_c, size_t siz_i)
 */
 c3_o u3_lmdb_delete(MDB_env* env_u)
 {
-  c3_c pax_c[8193];
-  if ( 0 != mdb_env_get_path(env_u, pax_c) ) {
+  const char *pax_c;
+  if ( 0 != mdb_env_get_path(env_u, &pax_c) ) {
     fprintf(stderr, "lmdb: failed to get path");
     return c3n;
   }

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -29,10 +29,23 @@ intmax_t mdb_get_filesize(mdb_filehandle_t han_u);
 //    supported operations are as follows
 //
 //      - open/close an environment
+//      - backup an environment
+//      - delete an environment
 //      - read/save metadata
 //      - read the first and last event numbers
 //      - read/save ranges of events
 //
+
+/* u3_lmdb_backup(): backup the lmdb environment.
+*/
+c3_o u3_lmdb_backup(MDB_env* env_u, const c3_c* pax_c)
+{
+  if ( 0 != mdb_env_copy(env_u, pax_c) ) {
+    return c3n;
+  }
+
+  return c3y;
+}
 
 /* u3_lmdb_init(): open lmdb at [pax_c], mmap up to [siz_i].
 */
@@ -79,6 +92,26 @@ u3_lmdb_init(const c3_c* pax_c, size_t siz_i)
   }
 
   return env_u;
+}
+
+/* u3_lmdb_delete(): delete lmdb environment at [pax_c].
+*/
+c3_o u3_lmdb_delete(MDB_env* env_u)
+{
+  c3_c pax_c[8193];
+  if ( 0 != mdb_env_get_path(env_u, pax_c) ) {
+    fprintf(stderr, "lmdb: failed to get path");
+    return c3n;
+  }
+
+  u3_lmdb_exit(env_u);
+
+  if ( 0 != c3_remove(pax_c) ) {
+    fprintf(stderr, "lmdb: failed to remove file");
+    return c3n;
+  }
+
+  return c3y;
 }
 
 /* u3_lmdb_exit(): close lmdb.

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -592,6 +592,112 @@ u3_lmdb_save_meta(MDB_env*    env_u,
   return c3y;
 }
 
+/* u3_lmdb_walk_init(): initialize db iterator.
+*/
+c3_o
+u3_lmdb_walk_init(MDB_env*      env_u,
+                  u3_lmdb_walk* itr_u,
+                  c3_d          nex_d,
+                  c3_d          las_d)
+{
+  //  XX assumes little-endian
+  //
+  MDB_val key_u = { .mv_size = sizeof(c3_d), .mv_data = &nex_d };
+  MDB_val val_u;
+  c3_w    ops_w, ret_w;
+
+  itr_u->red_o = c3n;
+  itr_u->nex_d = nex_d;
+  itr_u->las_d = las_d;
+
+  //  create a read-only transaction.
+  //
+  ops_w = MDB_RDONLY;
+  if ( (ret_w = mdb_txn_begin(env_u, 0, ops_w, &itr_u->txn_u)) ) {
+    mdb_logerror(stderr, ret_w, "lmdb: read txn_begin fail");
+    return c3n;
+  }
+  //  open the database in the transaction
+  //
+  ops_w = MDB_CREATE | MDB_INTEGERKEY;
+  if ( (ret_w = mdb_dbi_open(itr_u->txn_u, "EVENTS", ops_w, &itr_u->mdb_u)) ) {
+    mdb_logerror(stderr, ret_w, "lmdb: read: dbi_open fail");
+    //  XX confirm
+    //
+    mdb_txn_abort(itr_u->txn_u);
+    return c3n;
+  }
+
+  //  creates a cursor to iterate over keys starting at [eve_d]
+  //
+  if ( (ret_w = mdb_cursor_open(itr_u->txn_u, itr_u->mdb_u, &itr_u->cur_u)) ) {
+    mdb_logerror(stderr, ret_w, "lmdb: read: cursor_open fail");
+    //  XX confirm
+    //
+    mdb_txn_abort(itr_u->txn_u);
+    return c3n;
+  }
+
+  //  set the cursor to the position of [eve_d]
+  //
+  ops_w = MDB_SET_KEY;
+  if ( (ret_w = mdb_cursor_get(itr_u->cur_u, &key_u, &val_u, ops_w)) ) {
+    mdb_logerror(stderr, ret_w, "lmdb: read: initial cursor_get failed");
+    fprintf(stderr, "    at %" PRIu64 "\r\n", nex_d);
+    mdb_cursor_close(itr_u->cur_u);
+    //  XX confirm
+    //
+    mdb_txn_abort(itr_u->txn_u);
+    return c3n;
+  }
+
+  return c3y;
+}
+
+/* u3_lmdb_walk_next(): synchronously read next event from iterator.
+*/
+c3_o
+u3_lmdb_walk_next(u3_lmdb_walk* itr_u, size_t* len_i, void** buf_v)
+{
+  MDB_val key_u, val_u;
+  c3_w    ret_w, ops_w;
+
+  c3_assert( itr_u->nex_d <= itr_u->las_d );
+
+  ops_w = ( c3y == itr_u->red_o ) ? MDB_NEXT : MDB_GET_CURRENT;
+  if ( (ret_w = mdb_cursor_get(itr_u->cur_u, &key_u, &val_u, ops_w)) ) {
+    mdb_logerror(stderr, ret_w, "lmdb: walk error");
+    return c3n;
+  }
+
+  //  sanity check: ensure contiguous event numbers
+  //
+  if ( *(c3_d*)key_u.mv_data != itr_u->nex_d ) {
+    fprintf(stderr, "lmdb: read gap: expected %" PRIu64
+                    ", received %" PRIu64 "\r\n",
+                    itr_u->nex_d,
+                    *(c3_d*)key_u.mv_data);
+    return c3n;
+  }
+
+  *len_i = val_u.mv_size;
+  *buf_v = val_u.mv_data;
+
+  itr_u->nex_d++;
+  itr_u->red_o = c3y;
+
+  return c3y;
+}
+
+/* u3_lmdb_walk_done(): close iterator.
+*/
+void
+u3_lmdb_walk_done(u3_lmdb_walk* itr_u)
+{
+  mdb_cursor_close(itr_u->cur_u);
+  mdb_txn_abort(itr_u->txn_u);
+}
+
 /* mdb_logerror(): writes an error message and lmdb error code to f.
 */
 void mdb_logerror(FILE* f, int err, const char* fmt, ...)

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -342,50 +342,6 @@ u3_lmdb_read(MDB_env* env_u,
   }
 }
 
-/* u3_lmdb_read_one(): load [eve_d] into [val_u].
-*/
-c3_o
-u3_lmdb_read_one(MDB_env* env_u,
-                 MDB_val* val_u,
-                 c3_d     eve_d)
-{
-  MDB_txn* txn_u;
-  MDB_dbi  mdb_u;
-  c3_w     ret_w;
-
-  //  create a read transaction
-  //
-  if ( (ret_w = mdb_txn_begin(env_u, 0, MDB_RDONLY, &txn_u)) ) {
-    mdb_logerror(stderr, ret_w, "lmdb: read one: txn_begin fail");
-    return c3n;
-  }
-
-  //  open the database in the transaction
-  //
-  if ( (ret_w =  mdb_dbi_open(txn_u, "EVENTS", 0, &mdb_u)) ) {
-    mdb_logerror(stderr, ret_w, "lmdb: read one: dbi_open fail");
-    mdb_txn_abort(txn_u);
-    return c3n;
-  }
-
-  //  set the key to [eve_d]
-  {
-    MDB_val key_u = { .mv_size = sizeof(c3_d), .mv_data = &eve_d };
-
-    if ( (ret_w = mdb_get(txn_u, mdb_u, &key_u, val_u)) ) {
-      mdb_logerror(stderr, ret_w, "lmdb: read one failed");
-      mdb_txn_abort(txn_u);
-      return c3n;
-    }
-    else {
-      //  read-only transactions are aborted when complete
-      //
-      mdb_txn_abort(txn_u);
-      return c3y;
-    }
-  }
-}
-
 /* u3_lmdb_save(): save [len_d] events starting at [eve_d].
 */
 c3_o
@@ -494,50 +450,6 @@ u3_lmdb_read_meta(MDB_env*    env_u,
       //  read-only transactions are aborted when complete
       //
       mdb_txn_abort(txn_u);
-    }
-  }
-}
-
-/* u3_lmdb_read_meta_one(): load [key_c] into [val_u].
-*/
-c3_o
-u3_lmdb_read_meta_one(MDB_env*    env_u,
-                      MDB_val*    val_u,
-                      const c3_c* key_c)
-{
-  MDB_txn* txn_u;
-  MDB_dbi  mdb_u;
-  c3_w     ret_w;
-
-  //  create a read transaction
-  //
-  if ( (ret_w = mdb_txn_begin(env_u, 0, MDB_RDONLY, &txn_u)) ) {
-    mdb_logerror(stderr, ret_w, "lmdb: meta read one: txn_begin fail");
-    return c3n;
-  }
-
-  //  open the database in the transaction
-  //
-  if ( (ret_w =  mdb_dbi_open(txn_u, "META", 0, &mdb_u)) ) {
-    mdb_logerror(stderr, ret_w, "lmdb: meta read one: dbi_open fail");
-    mdb_txn_abort(txn_u);
-    return c3n;
-  }
-
-  //  read by string key
-  {
-    MDB_val key_u = { .mv_size = strlen(key_c), .mv_data = (void*)key_c };
-
-    if ( (ret_w = mdb_get(txn_u, mdb_u, &key_u, val_u)) ) {
-      mdb_logerror(stderr, ret_w, "lmdb: meta read one failed");
-      mdb_txn_abort(txn_u);
-      return c3n;
-    }
-    else {
-      //  read-only transactions are aborted when complete
-      //
-      mdb_txn_abort(txn_u);
-      return c3y;
     }
   }
 }

--- a/pkg/vere/db/lmdb.h
+++ b/pkg/vere/db/lmdb.h
@@ -29,7 +29,6 @@
       void
       u3_lmdb_exit(MDB_env* env_u);
 
-
     /* u3_lmdb_stat(): print env stats.
     */
       void
@@ -48,13 +47,6 @@
                    c3_d     eve_d,
                    c3_d     len_d,
                    c3_o  (*read_f)(void*, c3_d, size_t  , void*));
-
-    /* u3_lmdb_read_one(): read one by string from the META db.
-    */
-      c3_o
-      u3_lmdb_read_one(MDB_env* env_u,
-                       MDB_val* val_u,
-                       c3_d     eve_d);
 
     /* u3_lmdb_save(): save [len_d] events starting at [eve_d].
     */

--- a/pkg/vere/db/lmdb.h
+++ b/pkg/vere/db/lmdb.h
@@ -8,6 +8,16 @@
 
   /* lmdb api wrapper
   */
+    /* u3_lmdb_walk: event iterator
+    */
+    typedef struct _u3_lmdb_walk {
+      MDB_txn*    txn_u;  //  transaction handle
+      MDB_dbi     mdb_u;  //  db handle
+      MDB_cursor* cur_u;  //  db cursor
+      c3_o        red_o;  //  have we read from this yet?
+      c3_d        nex_d;  //  next event number
+      c3_d        las_d;  //  final event number, inclusive
+    } u3_lmdb_walk;
 
     /* u3_lmdb_init(): open lmdb at [pax_c], mmap up to [siz_i].
     */
@@ -63,13 +73,6 @@
                         const c3_c* key_c,
                         void     (*read_f)(void*, size_t, void*));
 
-    /* u3_lmdb_read_meta_one(): read one by string from the META db.
-    */
-      c3_o
-      u3_lmdb_read_meta_one(MDB_env*    env_u,
-                            MDB_val*    val_u,
-                            const c3_c* key_c);
-
     /* u3_lmdb_save_meta(): save by string into the META db.
     */
       c3_o
@@ -77,5 +80,23 @@
                         const c3_c* key_c,
                         size_t      val_i,
                         void*       val_p);
+
+    /* u3_lmdb_walk_init(): initialize db iterator.
+    */
+      c3_o
+      u3_lmdb_walk_init(MDB_env*      env_u,
+                        u3_lmdb_walk* itr_u,
+                        c3_d          nex_d,
+                        c3_d          las_d);
+
+    /* u3_lmdb_walk_next(): synchronously read next event from iterator.
+    */
+      c3_o
+      u3_lmdb_walk_next(u3_lmdb_walk* itr_u, size_t* len_i, void** buf_v);
+
+    /* u3_lmdb_walk_done(): close iterator.
+    */
+      void
+      u3_lmdb_walk_done(u3_lmdb_walk* itr_u);
 
 #endif /* ifndef U3_VERE_DB_LMDB_H */

--- a/pkg/vere/db/lmdb.h
+++ b/pkg/vere/db/lmdb.h
@@ -9,10 +9,20 @@
   /* lmdb api wrapper
   */
 
+    /* u3_lmdb_backup(): backup the lmdb environment.
+    */
+      c3_o
+      u3_lmdb_backup(MDB_env* env_u, const c3_c* pax_c);
+
     /* u3_lmdb_init(): open lmdb at [pax_c], mmap up to [siz_i].
     */
       MDB_env*
       u3_lmdb_init(const c3_c* pax_c, size_t siz_i);
+
+    /* u3_lmdb_delete(): delete lmdb environment at [pax_c].
+    */
+      c3_o
+      u3_lmdb_delete(MDB_env* env_u);
 
     /* u3_lmdb_exit(): close lmdb.
     */

--- a/pkg/vere/db/lmdb.h
+++ b/pkg/vere/db/lmdb.h
@@ -9,20 +9,10 @@
   /* lmdb api wrapper
   */
 
-    /* u3_lmdb_backup(): backup the lmdb environment.
-    */
-      c3_o
-      u3_lmdb_backup(MDB_env* env_u, const c3_c* pax_c);
-
     /* u3_lmdb_init(): open lmdb at [pax_c], mmap up to [siz_i].
     */
       MDB_env*
       u3_lmdb_init(const c3_c* pax_c, size_t siz_i);
-
-    /* u3_lmdb_delete(): delete lmdb environment at [pax_c].
-    */
-      c3_o
-      u3_lmdb_delete(MDB_env* env_u);
 
     /* u3_lmdb_exit(): close lmdb.
     */
@@ -49,6 +39,13 @@
                    c3_d     len_d,
                    c3_o  (*read_f)(void*, c3_d, size_t  , void*));
 
+    /* u3_lmdb_read_one(): read one by string from the META db.
+    */
+      c3_o
+      u3_lmdb_read_one(MDB_env* env_u,
+                       MDB_val* val_u,
+                       c3_d     eve_d);
+
     /* u3_lmdb_save(): save [len_d] events starting at [eve_d].
     */
       c3_o
@@ -65,6 +62,13 @@
                         void*       ptr_v,
                         const c3_c* key_c,
                         void     (*read_f)(void*, size_t, void*));
+
+    /* u3_lmdb_read_meta_one(): read one by string from the META db.
+    */
+      c3_o
+      u3_lmdb_read_meta_one(MDB_env*    env_u,
+                            MDB_val*    val_u,
+                            const c3_c* key_c);
 
     /* u3_lmdb_save_meta(): save by string into the META db.
     */

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -464,14 +464,14 @@ u3_disk_read(u3_disk* log_u, c3_d eve_d, c3_d len_d)
 /* _disk_save_meta(): serialize atom, save as metadata at [key_c].
 */
 static c3_o
-_disk_save_meta(u3_disk* log_u, const c3_c* key_c, u3_atom dat)
+_disk_save_meta(MDB_env* mdb_u, const c3_c* key_c, u3_atom dat)
 {
   c3_w  len_w = u3r_met(3, dat);
   c3_y* byt_y = c3_malloc(len_w);
   u3r_bytes(0, len_w, byt_y, dat);
 
   {
-    c3_o ret_o = u3_lmdb_save_meta(log_u->mdb_u, key_c, len_w, byt_y);
+    c3_o ret_o = u3_lmdb_save_meta(mdb_u, key_c, len_w, byt_y);
     c3_free(byt_y);
     return ret_o;
   }
@@ -480,17 +480,17 @@ _disk_save_meta(u3_disk* log_u, const c3_c* key_c, u3_atom dat)
 /* u3_disk_save_meta(): save metadata.
 */
 c3_o
-u3_disk_save_meta(u3_disk* log_u,
+u3_disk_save_meta(MDB_env* mdb_u,
                   c3_d     who_d[2],
                   c3_o     fak_o,
                   c3_w     lif_w)
 {
   c3_assert( c3y == u3a_is_cat(lif_w) );
 
-  if (  (c3n == _disk_save_meta(log_u, "version", 1))
-     || (c3n == _disk_save_meta(log_u, "who", u3i_chubs(2, who_d)))
-     || (c3n == _disk_save_meta(log_u, "fake", fak_o))
-     || (c3n == _disk_save_meta(log_u, "life", lif_w)) )
+  if (  (c3n == _disk_save_meta(mdb_u, "version", 1))
+     || (c3n == _disk_save_meta(mdb_u, "who", u3i_chubs(2, who_d)))
+     || (c3n == _disk_save_meta(mdb_u, "fake", fak_o))
+     || (c3n == _disk_save_meta(mdb_u, "life", lif_w)) )
   {
     return c3n;
   }
@@ -513,36 +513,36 @@ _disk_meta_read_cb(void* ptr_v, size_t val_i, void* val_p)
 /* _disk_read_meta(): read metadata at [key_c], deserialize.
 */
 static u3_weak
-_disk_read_meta(u3_disk* log_u, const c3_c* key_c)
+_disk_read_meta(MDB_env* mdb_u, const c3_c* key_c)
 {
   u3_weak dat = u3_none;
-  u3_lmdb_read_meta(log_u->mdb_u, &dat, key_c, _disk_meta_read_cb);
+  u3_lmdb_read_meta(mdb_u, &dat, key_c, _disk_meta_read_cb);
   return dat;
 }
 
 /* u3_disk_read_meta(): read metadata.
 */
 c3_o
-u3_disk_read_meta(u3_disk* log_u,
+u3_disk_read_meta(MDB_env* mdb_u,
                   c3_d*    who_d,
                   c3_o*    fak_o,
                   c3_w*    lif_w)
 {
   u3_weak ver, who, fak, lif;
 
-  if ( u3_none == (ver = _disk_read_meta(log_u, "version")) ) {
+  if ( u3_none == (ver = _disk_read_meta(mdb_u, "version")) ) {
     fprintf(stderr, "disk: read meta: no version\r\n");
     return c3n;
   }
-  if ( u3_none == (who = _disk_read_meta(log_u, "who")) ) {
+  if ( u3_none == (who = _disk_read_meta(mdb_u, "who")) ) {
     fprintf(stderr, "disk: read meta: no indentity\r\n");
     return c3n;
   }
-  if ( u3_none == (fak = _disk_read_meta(log_u, "fake")) ) {
+  if ( u3_none == (fak = _disk_read_meta(mdb_u, "fake")) ) {
     fprintf(stderr, "disk: read meta: no fake bit\r\n");
     return c3n;
   }
-  if ( u3_none == (lif = _disk_read_meta(log_u, "life")) ) {
+  if ( u3_none == (lif = _disk_read_meta(mdb_u, "life")) ) {
     fprintf(stderr, "disk: read meta: no lifecycle length\r\n");
     return c3n;
   }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1896,11 +1896,9 @@ _cw_chop(c3_i argc, c3_c* argv[])
   // success
   fprintf(stderr, "chop: event log truncation complete\r\n");
   fprintf(stderr, "      event log backup written to %s\r\n", bak_c);
-  fprintf(stderr, "      WARNING: ENSURE YOU CAN RESTART YOUR SHIP\r\n"
-                  "      BEFORE DELETING YOUR EVENT LOG BACKUP FILE!\r\n");
+  fprintf(stderr, "      WARNING: ENSURE YOU CAN RESTART YOUR SHIP BEFORE DELETING YOUR EVENT LOG BACKUP FILE!\r\n");
   fprintf(stderr, "      if you can't, restore your log by running:\r\n");
-  fprintf(stderr, "      mv %s %s\r\n", bak_c, dat_c);
-  fprintf(stderr, "      then try again\r\n");
+  fprintf(stderr, "      `mv %s %s\r\n` then try again", bak_c, dat_c);
 }
 
 /* _cw_vere(): download vere

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1898,7 +1898,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   fprintf(stderr, "      event log backup written to %s\r\n", bak_c);
   fprintf(stderr, "      WARNING: ENSURE YOU CAN RESTART YOUR SHIP BEFORE DELETING YOUR EVENT LOG BACKUP FILE!\r\n");
   fprintf(stderr, "      if you can't, restore your log by running:\r\n");
-  fprintf(stderr, "      `mv %s %s\r\n` then try again", bak_c, dat_c);
+  fprintf(stderr, "      `mv %s %s` then try again\r\n", bak_c, dat_c);
 }
 
 /* _cw_vere(): download vere

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1789,7 +1789,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   u3m_stop();
 
   // make sure snapshot in chk/*.bin is completely written
-  // (no patch files)
+  // (i.e., no patch files)
   if ( c3n == u3e_curr() ) {
     fprintf(stderr, "chop: incomplete snapshot\r\n");
     exit(1);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1803,6 +1803,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
 
   // get the metadata
   MDB_val ver, who, fak, lif;
+  u3_noun ver_n, who_n, fak_n, lif_n;
   if ( c3y != u3_lmdb_read_meta_one(env_u, &ver, "version") ) {
     fprintf(stderr, "king: failed to read ver\r\n");
     u3_king_bail();
@@ -1819,13 +1820,24 @@ _cw_chop(c3_i argc, c3_c* argv[])
     fprintf(stderr, "king: failed to read lif\r\n");
     u3_king_bail();
   }
+  ver_n = u3i_bytes(ver.mv_size, ver.mv_data);
+  ver.mv_data = &ver_n;
+  who_n = u3i_bytes(who.mv_size, who.mv_data);
+  who.mv_data = &who_n;
+  fak_n = u3i_bytes(fak.mv_size, fak.mv_data);
+  fak.mv_data = &fak_n;
+  lif_n = u3i_bytes(lif.mv_size, lif.mv_data);
+  lif.mv_data = &lif_n;
 
   // get the last event
   MDB_val val_u;
+  u3_noun val_n;
   if ( c3y != u3_lmdb_read_one(env_u, &val_u, hig_d) ) {
     fprintf(stderr, "king: failed to read last event\r\n");
     u3_king_bail();
   }
+  val_n = u3i_bytes(val_u.mv_size, val_u.mv_data);
+  val_u.mv_data = &val_n;
 
   // close the lmdb environment
   u3_lmdb_exit(env_u);
@@ -1834,7 +1846,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   c3_c dat_c[8193], bak_c[8193];
   snprintf(dat_c, 8192, "%s/.urb/log/data.mdb", u3_Host.dir_c);
   snprintf(bak_c, 8192, "%s.bak", dat_c);
-  rename(dat_c, bak_c);
+  c3_rename(dat_c, bak_c);
 
   // initialize a fresh lmdb environment
   env_u = u3_lmdb_init(log_c, siz_i);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1832,7 +1832,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   }
   u3_lmdb_walk_done(&itr_u);
 
-  // initialize a fresh lmdb environment in the "chop" subfolder
+  // initialize a fresh lmdb environment in the "chop" subdir
   c3_c cho_c[8193];
   snprintf(cho_c, sizeof(cho_c), "%s/chop", log_c);
   c3_mkdir(cho_c, 0700);
@@ -1855,7 +1855,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   c3_c dat_c[8193], bak_c[8193];
   snprintf(dat_c, sizeof(dat_c), "%s/data.mdb", log_c);
   // "data_<first>-<last>.mdb.bak"
-  snprintf(bak_c, sizeof(bak_c), "%s/data_%" PRIu64 "-%" PRIu64 ".mdb.bak", log_c, fir_d, las_d);
+  snprintf(bak_c, sizeof(bak_c), "%s/data_%" PRIu64 "-%" PRIu64 ".mdb.bak", cho_c, fir_d, las_d);
   c3_rename(dat_c, bak_c);
 
   // rename new database file to be official
@@ -1868,7 +1868,8 @@ _cw_chop(c3_i argc, c3_c* argv[])
   u3_lmdb_exit(new_u);
 
   // success
-  fprintf(stderr, "chop: chopped data.mdb to data_%" PRIu64 "-%" PRIu64 ".mdb.bak\r\n", fir_d, las_d);
+  fprintf(stderr, "chop: event log truncation complete\r\n");
+  fprintf(stderr, "chop: event log backup written to %s\r\n", bak_c);
 }
 
 /* _cw_vere(): download vere

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1781,14 +1781,19 @@ _cw_chop(c3_i argc, c3_c* argv[])
     exit(1);
   }
 
-  // TODO: make sure current snapshot exists
-
   // gracefully shutdown the pier if it's running
   u3_disk* old_u = _cw_disk_init(u3_Host.dir_c);
 
   u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
   u3e_backup(c3y);  //  backup snapshot
   u3m_stop();
+
+  // make sure snapshot in chk/*.bin is completely written
+  // (no patch files)
+  if ( c3n == u3e_curr() ) {
+    fprintf(stderr, "chop: incomplete snapshot\r\n");
+    exit(1);
+  }
 
   // initialize the lmdb environment
   // see disk.c:885

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1845,9 +1845,11 @@ _cw_chop(c3_i argc, c3_c* argv[])
   // initialize a fresh lmdb environment in the "chop" subdir
   c3_c cho_c[8193];
   snprintf(cho_c, sizeof(cho_c), "%s/chop", log_c);
-  if ( 0 != c3_mkdir(cho_c, 0700) ) {
-    fprintf(stderr, "chop: failed to create chop directory\r\n");
-    exit(1);
+  if ( 0 != access(cho_c, F_OK) ) {
+    if ( 0 != c3_mkdir(cho_c, 0700) ) {
+      fprintf(stderr, "chop: failed to create chop directory\r\n");
+      exit(1);
+    }
   }
   MDB_env* new_u = u3_lmdb_init(cho_c, siz_i);
   if ( !new_u ) {
@@ -1893,13 +1895,12 @@ _cw_chop(c3_i argc, c3_c* argv[])
 
   // success
   fprintf(stderr, "chop: event log truncation complete\r\n");
-  fprintf(stderr, "chop: event log backup written to %s\r\n", bak_c);
-  fprintf(stderr, "chop: WARNING: ENSURE YOU CAN RESTART YOUR SHIP "
-                  "BEFORE DELETING YOUR EVENT LOG BACKUP FILE!\r\n");
-  fprintf(stderr, "chop: if you can't restart your ship, restore your "
-                  "event log backup file with the following command:\r\n"); 
-  fprintf(stderr, "chop: mv %s %s\r\n", bak_c, dat_c);
-  fprintf(stderr, "chop: then restart your ship\r\n");
+  fprintf(stderr, "      event log backup written to %s\r\n", bak_c);
+  fprintf(stderr, "      WARNING: ENSURE YOU CAN RESTART YOUR SHIP\r\n"
+                  "      BEFORE DELETING YOUR EVENT LOG BACKUP FILE!\r\n");
+  fprintf(stderr, "      if you can't, restore your log by running:\r\n");
+  fprintf(stderr, "      mv %s %s\r\n", bak_c, dat_c);
+  fprintf(stderr, "      then try again\r\n");
 }
 
 /* _cw_vere(): download vere

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -636,7 +636,6 @@ _cw_usage(c3_c* bin_c)
     "  %s next %.*s              request upgrade:\n",
     "  %s queu %.*s<at-event>    cue state:\n",
     "  %s chop %.*s              truncate event log:\n",
-    "  %s knit %.*s<in files>    merge chopped event logs:\n",
     "  %s vere ARGS <output dir>    download binary:\n",
     "\n  run as a 'serf':\n",
     "    %s serf <pier> <key> <flags> <cache-size> <at-event>"
@@ -1894,73 +1893,6 @@ _cw_chop(c3_i argc, c3_c* argv[])
   u3_lmdb_exit(env_u);
 }
 
-/* _cw_knit(): unify chopped event log
-*/
-static void
-_cw_knit(c3_i argc, c3_c* argv[])
-{
-  // TODO: enable compatibility with .run usage
-
-  if ( 3 > argc ) {
-    fprintf(stderr, "knit: missing args\n");
-    exit(1);
-  }
-
-  c3_d   log_d = argc - 3;
-  c3_c** inp_c = malloc(sizeof(c3_c*) * log_d);
-  c3_w   i_w;
-  for ( i_w = 0; i_w < log_d; i_w++ ) {
-    // read filenames from command line into an array
-    *(inp_c + (8193 * (i_w - 3))) = argv[i_w];
-    fprintf(stderr, "knit: argv[%d] = %s\r\n", i_w, argv[i_w]);
-    fprintf(stderr, "knit: inp_c[%d] = %s\r\n", i_w - 3, *(inp_c + (8193 * (i_w - 3))));
-  }
-
-  u3_Host.dir_c = _main_pier_run(argv[0]);
-
-  //  argv[optind] is always "knit"
-  //
-
-  if ( !u3_Host.dir_c ) {
-    if ( optind + 1 < argc ) {
-      u3_Host.dir_c = argv[optind + 1];
-    }
-    else {
-      fprintf(stderr, "invalid command, pier required\r\n");
-      exit(1);
-    }
-
-    optind++;
-  }
-
-  // validate all input files exist and are readable
-  for ( i_w = 0; i_w < log_d; i_w++ ) {
-    c3_c* fil_c = *(inp_c + (8193 * (i_w - 3))); // TODO: check
-    if ( 0 == access(fil_c, F_OK) ) {
-      if ( 0 != access(fil_c, R_OK) ) {
-        fprintf("knit: file %s is not readable\r\n", fil_c);
-        exit(1);
-      }
-    } else {
-      fprintf("knit: file %s does not exist\r\n", fil_c);
-    }
-  }
-
-  // check that the operation will result in a valid event log
-  // (i.e. monotically increasing integer keys starting from 1)
-
-  // stream events from in files into a temp lmdb database file
-  //   on success...
-  //     copy metadata from the pier's database file
-  //     backup the pier's existing database file
-  //     move/rename the temp db file to <pier>/.urb/log/data.mdb
-  //   on failure, abort and cleanup
-
-  // print some helpful stats (like how many events were written)
-
-  // cleanup
-}
-
 /* _cw_vere(): download vere
 */
 static void
@@ -2226,7 +2158,6 @@ _cw_utils(c3_i argc, c3_c* argv[])
     case c3__prep: _cw_prep(argc, argv); return 2; // continue on
     case c3__queu: _cw_queu(argc, argv); return 1;
     case c3__chop: _cw_chop(argc, argv); return 1;
-    case c3__knit: _cw_knit(argc, argv); return 1;
     case c3__vere: _cw_vere(argc, argv); return 1;
     case c3__vile: _cw_vile(argc, argv); return 1;
 

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1878,8 +1878,12 @@ _cw_chop(c3_i argc, c3_c* argv[])
   // success
   fprintf(stderr, "chop: event log truncation complete\r\n");
   fprintf(stderr, "chop: event log backup written to %s\r\n", bak_c);
-  fprintf(stderr, "CHOP: WARNING: ENSURE YOU CAN RESTART YOUR SHIP "
-                  "BEFORE DELETING YOUR EVENT LOG BACKUP FILE\r\n");
+  fprintf(stderr, "chop: WARNING: ENSURE YOU CAN RESTART YOUR SHIP "
+                  "BEFORE DELETING YOUR EVENT LOG BACKUP FILE!\r\n");
+  fprintf(stderr, "chop: if you can't restart your ship, restore your "
+                  "event log backup file with the following command:\r\n"); 
+  fprintf(stderr, "chop: mv %s %s\r\n", bak_c, dat_c);
+  fprintf(stderr, "chop: then restart your ship\r\n");
 }
 
 /* _cw_vere(): download vere

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1875,6 +1875,8 @@ _cw_chop(c3_i argc, c3_c* argv[])
   // success
   fprintf(stderr, "chop: event log truncation complete\r\n");
   fprintf(stderr, "chop: event log backup written to %s\r\n", bak_c);
+  fprintf(stderr, "chop: warning: ensure you can restart your ship "
+                  "before deleting your event log backup file\r\n");
 }
 
 /* _cw_vere(): download vere

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1811,36 +1811,41 @@ _cw_chop(c3_i argc, c3_c* argv[])
 
 
   // get the metadata
-  MDB_val ver, who, fak, lif;
+  MDB_val ver;
   if ( c3y != u3_lmdb_read_meta_one(env_u, &ver, "version") ) {
     fprintf(stderr, "king: failed to read ver\r\n");
     u3_king_bail();
   }
+  c3_d ver_d = *(c3_d*)ver.mv_data;
+
+  MDB_val who;
   if ( c3y != u3_lmdb_read_meta_one(env_u, &who, "who") ) {
     fprintf(stderr, "king: failed to read who\r\n");
     u3_king_bail();
   }
+  c3_d who_d = *(c3_d*)who.mv_data;
+
+  MDB_val fak;
   if ( c3y != u3_lmdb_read_meta_one(env_u, &fak, "fake") ) {
     fprintf(stderr, "king: failed to read fak\r\n");
     u3_king_bail();
   }
+  c3_d fak_o = *(c3_d*)fak.mv_data;
+
+  MDB_val lif;
   if ( c3y != u3_lmdb_read_meta_one(env_u, &lif, "life") ) {
     fprintf(stderr, "king: failed to read lif\r\n");
     u3_king_bail();
   }
-  c3_d ver_d = *(c3_d*)ver.mv_data;
-  c3_d who_d = *(c3_d*)who.mv_data;
-  c3_o fak_o = *(c3_o*)fak.mv_data;
-  c3_w lif_w = *(c3_w*)lif.mv_data;
+  c3_d lif_w = *(c3_d*)lif.mv_data;
 
   // get the last event
   MDB_val val_u;
-  u3_atom val_n;
   if ( c3y != u3_lmdb_read_one(env_u, &val_u, las_d) ) {
     fprintf(stderr, "king: failed to read last event\r\n");
     u3_king_bail();
   }
-  val_n = u3i_bytes(val_u.mv_size, val_u.mv_data);
+  u3_atom val_n = u3i_bytes(val_u.mv_size, val_u.mv_data);
   val_u.mv_data = &val_n;
 
   // close the lmdb environment
@@ -1857,7 +1862,6 @@ _cw_chop(c3_i argc, c3_c* argv[])
   env_u = u3_lmdb_init(log_c, siz_i);
 
   // write the metadata to the database
-  fprintf(stderr, "meta attempt\r\n");
   if ( c3y != u3_lmdb_save_meta(env_u, "version", ver.mv_size, &ver_d) ) {
     fprintf(stderr, "king: failed to write version\r\n");
     u3_king_bail();
@@ -1876,8 +1880,6 @@ _cw_chop(c3_i argc, c3_c* argv[])
   }
 
   // write the last event to the database
-  // FIXME by copying values from MDB_vals to our own variables
-  fprintf(stderr, "attempt\r\n");
   size_t syz_i = val_u.mv_size; 
   void* byt_p = val_u.mv_data;
   if ( c3y != u3_lmdb_save(env_u, las_d, 1, &byt_p, &syz_i) ) { 

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1692,8 +1692,8 @@ u3_pier_stay(c3_w wag_w, u3_noun pax)
     return 0;
   }
 
-  if ( c3n == u3_disk_read_meta(pir_u->log_u,  pir_u->who_d,
-                               &pir_u->fak_o, &pir_u->lif_w) )
+  if ( c3n == u3_disk_read_meta(pir_u->log_u->mdb_u,  pir_u->who_d,
+                               &pir_u->fak_o,        &pir_u->lif_w) )
   {
     fprintf(stderr, "pier: disk read meta fail\r\n");
     //  XX dispose
@@ -1889,8 +1889,8 @@ _pier_boot_plan(u3_pier* pir_u,
     pir_u->lif_w = u3qb_lent(bot_u.bot);
   }
 
-  if ( c3n == u3_disk_save_meta(pir_u->log_u, pir_u->who_d,
-                                pir_u->fak_o, pir_u->lif_w) )
+  if ( c3n == u3_disk_save_meta(pir_u->log_u->mdb_u, pir_u->who_d,
+                                pir_u->fak_o,        pir_u->lif_w) )
   {
     //  XX dispose bot_u
     //

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -4,6 +4,7 @@
 #define U3_VERE_H
 
 #include "c3.h"
+#include "db/lmdb.h"
 #include "noun.h"
 #include "serf.h"
 #include "uv.h"
@@ -943,7 +944,7 @@
       /* u3_disk_read_meta(): read metadata.
       */
         c3_o
-        u3_disk_read_meta(u3_disk* log_u,
+        u3_disk_read_meta(MDB_env* mdb_u,
                           c3_d*    who_d,
                           c3_o*    fak_o,
                           c3_w*    lif_w);
@@ -951,7 +952,7 @@
       /* u3_disk_save_meta(): save metadata.
       */
         c3_o
-        u3_disk_save_meta(u3_disk* log_u,
+        u3_disk_save_meta(MDB_env* mdb_u,
                           c3_d     who_d[2],
                           c3_o     fak_o,
                           c3_w     lif_w);


### PR DESCRIPTION
## `chop`

`urbit chop <pier>` implements a simple, offline **event log truncation**[^1] tool.

`chop` gracefully stops the given pier (if running), backs up the current snapshot to `<pier>/.urb/bhk`, makes sure a current snapshot exists (i.e., is fully written to disk in `chk/*.bin` with no existing patch files), reads the metadata and the last event from the pier's event log, initializes a fresh event log in the `<pier>/.urb/log/chop` directory,  writes the metadata and last event from the original log into the fresh one, renames the original event log to `<pier>/.urb/log/chop/data_<first>_<last>.mdb.bak` where `first` and `last` are the first and last event numbers from the event log, and exits. 

Pilots are then free to move, archive, or delete their `.bak` event log file, resume normal operation of their ship, and enjoy the many benefits of lowered disk pressure and any reductions in associated hosting costs.

I've tested `chop` successfully on my own planet `~mastyr-bottec` (multiple times), three different comets (all fresh), and multitudes of fake galaxies.

Resolves #122.

Note: `knit`, which is the "undo" button for `chop`, is being implemented in its own PR #184.

[^1]: https://roadmap.urbit.org/project/event-log-truncation