### PR TITLE
Add support for the %meme debug hint to the vere runtime

### DIFF
--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1017,6 +1017,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
         return _n_comp(ops, nef, los_o, tel_o);
       }
       case c3__xray:
+      case c3__meme:
       case c3__nara:
       case c3__hela:
       case c3__bout: {
@@ -1054,6 +1055,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
             tot_w += _n_comp(ops, nef, los_o, tel_o);
           } break;
           case c3__xray:
+          case c3__meme:
           case c3__nara:
           case c3__hela:
           case c3__bout: {
@@ -1858,6 +1860,11 @@ _n_hilt_fore(u3_noun hin, u3_noun bus, u3_noun* out)
       *out = u3_nul;
     } break;
 
+    case c3__meme : {
+      u3t_slog(u3nc(0, u3t_etch_meme(0)));
+      *out = u3_nul;
+    } break;
+
     default: {
       *out = u3_nul;
     } break;
@@ -1937,6 +1944,17 @@ _n_hint_fore(u3_cell hin, u3_noun bus, u3_noun* clu)
       if ( c3y == u3r_cell(*clu, &pri, &tan) ) {
         c3_l pri_l = c3y == u3a_is_cat(pri) ? pri : 0;
         u3t_slog_cap(pri_l, u3k(tan), _cn_etch_bytecode(fol));
+      }
+      u3z(*clu);
+      *clu = u3_nul;
+    } break;
+
+    case c3__meme : {
+      u3_noun pri, tan;
+      if ( c3y == u3r_cell(*clu, &pri, &tan) ) {
+        c3_l mod_l = c3y == u3a_is_cat(pri) ? pri : 0;
+        // replace with better str fmt
+        u3t_slog_cap(1, u3k(tan), u3t_etch_meme(mod_l));
       }
       u3z(*clu);
       *clu = u3_nul;

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -669,7 +669,7 @@ u3t_slog_trace(c3_l pri_l, u3_noun tax)
   // render the stack
   // Note: ton is a reference to a data struct
   // we have just allocated
-  // lit is a used as a moving cursor pointer through
+  // lit is used as a moving cursor pointer through
   // that allocated struct
   // once we finish lit will be null, but ton will still
   // point to the whole valid allocated data structure
@@ -720,5 +720,434 @@ u3t_slog_hela(c3_l pri_l)
   }
 
   u3t_slog_trace(pri_l, tax);
+}
+
+
+/* _ct_roundf(): truncate a float to precision equivalent to %.2f */
+static float
+_ct_roundf(float per_f)
+{
+  // scale the percentage so that all siginificant digits
+  // would be retained when truncted to an int, then add 0.5
+  // to account for rounding without using round or roundf
+  float big_f = (per_f*10000)+0.5;
+  // truncate to int
+  c3_w big_w = (c3_w) big_f;
+  // convert to float and scale down such that
+  // our last two digits are right of the decimal
+  float tuc_f = (float) big_w/100.0;
+  return tuc_f;
+}
+
+
+/* _ct_meme_percent(): convert two ints into a percentage */
+static float
+_ct_meme_percent(c3_w lit_w, c3_w big_w)
+{
+  // get the percentage of our inputs as a float
+  float raw_f = (float) lit_w/big_w;
+  return _ct_roundf(raw_f);
+}
+
+
+/* _ct_all_heap_size(): return the size in bytes of ALL space on the Loom
+**                      over all roads, currently in use as heap.
+*/
+static c3_w
+_ct_all_heap_size(u3_road* r) {
+  if (r == &(u3H->rod_u)) {
+    return u3a_heap(r)*4;
+  } else {
+    // recurse
+    return (u3a_heap(r)*4) + _ct_all_heap_size(u3tn(u3_road, r->par_p));
+  }
+}
+
+
+/* These two structs, bar_item and bar_info, store the mutable data
+** to normalize measured Loom usage values into ints that will fit
+** into a fixed width ascii bar chart.
+*/
+struct
+bar_item {
+  // index
+  c3_w dex_w;
+  // lower bound
+  c3_w low_w;
+  // original value
+  float ori_f;
+  // difference
+  float dif_f;
+};
+
+
+struct
+bar_info {
+  struct bar_item s[6];
+};
+
+
+/* _ct_boost_small(): we want zero to be zero,
+**                    anything between zero and one to be one,
+**                    and all else to be whatever it is.
+*/
+static float
+_ct_boost_small(float num_f)
+{
+  return
+    0.0 >= num_f ? 0.0:
+    1.0 > num_f ? 1.0:
+    num_f;
+}
+
+
+/* _ct_global_difference(): each low_w represents the normalized integer value
+ *                          of its loom item, and ideally the sum of all loom low_w
+ *                          values should be 100. This function reports how far from
+ *                          the ideal bar_u is.
+*/
+static c3_ws
+_ct_global_difference(struct bar_info bar_u)
+{
+  c3_w low_w = 0;
+  for (c3_w i=0; i < 6; i++) {
+    low_w += bar_u.s[i].low_w;
+  }
+  return 100 - low_w;
+}
+
+
+/* _ct_compute_roundoff_error(): for each loom item in bar_u
+**                               compute the current difference between the int
+**                               size and the original float size.
+*/
+static struct bar_info
+_ct_compute_roundoff_error(struct bar_info bar_u)
+{
+  for (c3_w i=0; i < 6; i++) {
+    bar_u.s[i].dif_f = bar_u.s[i].ori_f - bar_u.s[i].low_w;
+  }
+  return bar_u;
+}
+
+
+/* _ct_sort_by_roundoff_error(): sort loom items from most mis-sized to least */
+static struct bar_info
+_ct_sort_by_roundoff_error(struct bar_info bar_u)
+{
+  struct bar_item tem_u;
+  for (c3_w i=1; i < 6; i++) {
+    for (c3_w j=0; j < 6-i; j++) {
+      if (bar_u.s[j+1].dif_f > bar_u.s[j].dif_f) {
+        tem_u = bar_u.s[j];
+        bar_u.s[j] = bar_u.s[j+1];
+        bar_u.s[j+1] = tem_u;
+      }
+    }
+  }
+  return bar_u;
+}
+
+
+/* _ct_sort_by_index(): sort loom items into loom order */
+static struct bar_info
+_ct_sort_by_index(struct bar_info bar_u)
+{
+  struct bar_item tem_u;
+  for (c3_w i=1; i < 6; i++) {
+    for (c3_w j=0; j < 6-i; j++) {
+      if (bar_u.s[j+1].dex_w < bar_u.s[j].dex_w) {
+        tem_u = bar_u.s[j];
+        bar_u.s[j] = bar_u.s[j+1];
+        bar_u.s[j+1] = tem_u;
+      }
+    }
+  }
+  return bar_u;
+}
+
+
+/* _ct_reduce_error(): reduce error by one int step
+ *                     making oversized things a bit smaller
+ *                     and undersized things a bit bigger
+*/
+static struct bar_info
+_ct_reduce_error(struct bar_info bar_u, c3_ws dif_s)
+{
+  for (c3_w i=0; i < 6; i++) {
+    if (bar_u.s[i].low_w == 0) continue;
+    if (bar_u.s[i].low_w == 1) continue;
+    if (dif_s > 0) {
+      bar_u.s[i].low_w++;
+      dif_s--;
+    }
+    if (dif_s < 0) {
+      bar_u.s[i].low_w--;
+      dif_s++;
+    }
+  }
+  return bar_u;
+}
+
+/* _ct_report_bargraph(): render all six raw loom elements into a fixed-size ascii bargraph */
+static void
+_ct_report_bargraph(
+    c3_c bar_c[105], float hip_f, float hep_f, float fre_f, float pen_f, float tak_f, float tik_f
+)
+{
+  float in[6];
+  in[0] = _ct_boost_small(hip_f);
+  in[1] = _ct_boost_small(hep_f);
+  in[2] = _ct_boost_small(fre_f);
+  in[3] = _ct_boost_small(pen_f);
+  in[4] = _ct_boost_small(tak_f);
+  in[5] = _ct_boost_small(tik_f);
+
+  // init the list of structs
+  struct bar_info bar_u;
+  for (c3_w i=0; i < 6; i++) {
+    bar_u.s[i].dex_w = i;
+    bar_u.s[i].ori_f = in[i];
+    bar_u.s[i].low_w = (c3_w) bar_u.s[i].ori_f;
+  }
+
+  // repeatedly adjust for roundoff error
+  // until it is elemenated or we go 100 cycles
+  c3_ws dif_s = 0;
+  for (c3_w x=0; x<100; x++) {
+    bar_u = _ct_compute_roundoff_error(bar_u);
+    dif_s = _ct_global_difference(bar_u);
+    if (dif_s == 0) break;
+    bar_u = _ct_sort_by_roundoff_error(bar_u);
+    bar_u = _ct_reduce_error(bar_u, dif_s);
+  }
+  bar_u = _ct_sort_by_index(bar_u);
+
+  for (c3_w x=1; x<104; x++) {
+    bar_c[x] = ' ';
+  }
+  bar_c[0] = '[';
+
+  // create our bar chart
+  const c3_c sym_c[6] = "=-%#+~";
+  c3_w x = 0, y = 0;
+  for (c3_w i=0; i < 6; i++) {
+    x++;
+    for (c3_w j=0; j < bar_u.s[i].low_w; j++) {
+      bar_c[x+j] = sym_c[i];
+      y = x+j;
+    }
+    if (y > 0) x = y;
+  }
+  bar_c[101] = ']';
+  bar_c[102] = 0;
+}
+
+
+/* _ct_size_prefix(): return the correct metric scalar prifix for a given int */
+static c3_c
+_ct_size_prefix(c3_d num_d)
+{
+  return
+    (num_d / 1000000000) ? 'G':
+    (num_d % 1000000000) / 1000000 ? 'M':
+    (num_d % 1000000) / 1000 ? 'K':
+    (num_d % 1000) ? ' ':
+    'X';
+}
+
+
+/* _ct_report_string(): convert a int into a string, adding a metric scale prefix letter*/
+static void
+_ct_report_string(c3_c rep_c[32], c3_d num_d)
+{
+  memset(rep_c, ' ', 31);
+
+  // add the G/M/K prefix
+  rep_c[24] = _ct_size_prefix(num_d);
+  // consume wor_w into a string one base-10 digit at a time
+  // including dot formatting
+  c3_w i = 0, j = 0;
+  while (num_d > 0) {
+    if (j == 3) {
+      rep_c[22-i] = '.';
+      i++;
+      j = 0;
+    } else {
+      rep_c[22-i] = (num_d%10)+'0';
+      num_d /= 10;
+      i++;
+      j++;
+    }
+  }
+}
+
+/*  _ct_etch_road_depth(): return a the current road depth as a fixed size string */
+static void
+ _ct_etch_road_depth(c3_c rep_c[32], u3_road* r, c3_w num_w) {
+  if (r == &(u3H->rod_u)) {
+    _ct_report_string(rep_c, num_w);
+    // this will be incorrectly indented, so we fix that here
+    c3_w i = 14;
+    while (i > 0) {
+      rep_c[i] = rep_c[i+16];
+      rep_c[i+16] = ' ';
+      i--;
+    }
+  } else {
+    _ct_etch_road_depth(rep_c, u3tn(u3_road, r->par_p), ++num_w);
+  }
+}
+
+
+/* _ct_etch_memory(): create a single line report of a given captioned item
+ *                    with a percentage of space used and the bytes used
+ *                    scaled by a metric scaling postfix (ie MB, GB, etc)
+*/
+static void
+_ct_etch_memory(c3_c rep_c[32], float per_f, c3_w num_w)
+{
+  // create the basic report string
+  _ct_report_string(rep_c, num_w);
+  // add the Bytes postfix to the size report
+  rep_c[25] = 'B';
+
+  // add the space-percentage into the report
+  rep_c[2] = '0', rep_c[3] = '.', rep_c[4] = '0', rep_c[5] = '0';
+  c3_w per_i = (c3_w) (per_f*100);
+  c3_w i = 0;
+  while (per_i > 0 && i < 6) {
+    if (i != 2) {
+      rep_c[5-i] = (per_i%10)+'0';
+      per_i /= 10;
+    }
+    i++;
+  }
+  // add the percent sign
+  rep_c[6] = '%';
+}
+
+
+/* _ct_etch_steps(): create a single line report of a given captioned item
+**                   scaled by a metric scaling postfix, but unitless.
+*/
+static void
+_ct_etch_steps(c3_c rep_c[32], c3_d sep_d)
+{
+  _ct_report_string(rep_c, sep_d);
+}
+
+
+
+/* u3t_etch_meme(): report memory stats at call time */
+u3_noun
+u3t_etch_meme(c3_l mod_l)
+{
+  u3a_road* lum_r;
+  lum_r = &(u3H->rod_u);
+  // this will need to switch to c3_d when we go to a 64 loom
+  c3_w top_w = u3a_full(lum_r)*4,
+       ful_w = u3a_full(u3R)*4,
+       fre_w = u3a_idle(u3R)*4,
+       tak_w = u3a_temp(u3R)*4,
+       hap_w = u3a_heap(u3R)*4,
+       pen_w = u3a_open(u3R)*4;
+
+  c3_w imu_w = top_w-ful_w;
+  c3_w hep_w = hap_w-fre_w;
+
+  c3_w inc_w = 0;
+  c3_w max_w = 0;
+  float max_f = 0.0;
+  c3_d cel_d = 0;
+  c3_d nox_d = 0;
+
+  float imu_f = _ct_meme_percent(imu_w, top_w),
+        hep_f = _ct_meme_percent(hep_w, top_w),
+        fre_f = _ct_meme_percent(fre_w, top_w),
+        pen_f = _ct_meme_percent(pen_w, top_w),
+        tak_f = _ct_meme_percent(tak_w, top_w);
+  float ful_f = hep_f + fre_f + pen_f + tak_f;
+
+  c3_w hip_w = _ct_all_heap_size(u3R) - hap_w;
+  c3_w tik_w = imu_w - hip_w;
+  float hip_f = _ct_meme_percent(hip_w, top_w),
+        tik_f = _ct_meme_percent(tik_w, top_w);
+
+#ifdef U3_CPU_DEBUG
+  /* iff we are using CPU_DEBUG env var
+  ** we can report more facts:
+  **  max_w: max allocated on the current road (not global, not including child roads)
+  **  cel_d: max cells allocated in current road (inc closed kids, but not parents)
+  **  nox_d: nock steps performed in current road
+  */
+  max_w = (u3R->all.max_w*4)+imu_w;
+  max_f = _ct_meme_percent(max_w, top_w);
+  cel_d = u3R->pro.cel_d;
+  nox_d = u3R->pro.nox_d;
+  // iff we have a max_f we will render it into the bar graph
+  // in other words iff we have max_f it will always replace something
+  inc_w = (max_f > hip_f+1.0) ? (c3_w) max_f+0.5 : (c3_w) hip_f+1.5;
+#endif
+
+  // warn if any sanity checks have failed
+  if (100.01 < (hip_f + hep_f + fre_f + pen_f + tak_f + tik_f))
+    u3t_slog_cap(2, u3i_string("warning"), u3i_string("loom sums over 100.01%"));
+  if ( 99.99 > (hip_f + hep_f + fre_f + pen_f + tak_f + tik_f))
+    u3t_slog_cap(2, u3i_string("warning"), u3i_string("loom sums under 99.99%"));
+
+  c3_c bar_c[105];
+  bar_c[0] = 0;
+  _ct_report_bargraph(bar_c, hip_f, hep_f, fre_f, pen_f, tak_f, tik_f);
+
+  c3_w dol = (c3_w) _ct_roundf(hip_f/100);
+  bar_c[dol] = '$';
+#ifdef U3_CPU_DEBUG
+  if (max_f > 0.0) {
+    bar_c[inc_w] = '|';
+  }
+#endif
+
+  c3_c dir_n[8];
+  dir_n[0] = 0;
+  if ( u3a_is_north(u3R) == c3y ) {
+    strcat(dir_n, "  North");
+  } else {
+    strcat(dir_n, "  South");
+  }
+
+  if (mod_l == 0) {
+    return u3i_string(bar_c);
+  }
+  else {
+    c3_c rep_c[32];
+    rep_c[31] = 0;
+    c3_c str_c[1024];
+    str_c[0] = 0;
+    // each report line is at most 54 chars long
+    strcat(str_c, "Legend | Report:");
+
+    strcat(str_c, "\n                loom: "); _ct_etch_memory(rep_c, 100.0, top_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n                road: "); _ct_etch_memory(rep_c, ful_f, ful_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n");
+    strcat(str_c, "\n  =  immutable  heap: "); _ct_etch_memory(rep_c, hip_f, hip_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n  -      solid  heap: "); _ct_etch_memory(rep_c, hep_f, hep_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n  %      freed  heap: "); _ct_etch_memory(rep_c, fre_f, fre_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n  #       open space: "); _ct_etch_memory(rep_c, pen_f, pen_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n  +            stack: "); _ct_etch_memory(rep_c, tak_f, tak_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n  ~  immutable stack: "); _ct_etch_memory(rep_c, tik_f, tik_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n");
+    strcat(str_c, "\n  $ allocation frame: "); _ct_etch_memory(rep_c, hip_f, hip_w); strcat(str_c, rep_c);
+#ifdef U3_CPU_DEBUG
+    strcat(str_c, "\n  |  road max memory: "); _ct_etch_memory(rep_c, max_f, max_w); strcat(str_c, rep_c);
+    strcat(str_c, "\n");
+    strcat(str_c, "\n     road cells made: "); _ct_etch_steps(rep_c, cel_d); strcat(str_c, rep_c);
+    strcat(str_c, "\n     road nocks made: "); _ct_etch_steps(rep_c, nox_d); strcat(str_c, rep_c);
+#endif
+    strcat(str_c, "\n      road direction: "); strcat(str_c, dir_n);
+    strcat(str_c, "\n          road depth: "); _ct_etch_road_depth(rep_c, u3R, 1); strcat(str_c, rep_c);
+    strcat(str_c, "\n\nLoom: "); strcat(str_c, bar_c);
+    return u3i_string(str_c);
+  }
 }
 

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -722,7 +722,6 @@ u3t_slog_hela(c3_l pri_l)
   u3t_slog_trace(pri_l, tax);
 }
 
-
 /* _ct_roundf(): truncate a float to precision equivalent to %.2f */
 static float
 _ct_roundf(float per_f)
@@ -739,7 +738,6 @@ _ct_roundf(float per_f)
   return tuc_f;
 }
 
-
 /* _ct_meme_percent(): convert two ints into a percentage */
 static float
 _ct_meme_percent(c3_w lit_w, c3_w big_w)
@@ -748,7 +746,6 @@ _ct_meme_percent(c3_w lit_w, c3_w big_w)
   float raw_f = (float) lit_w/big_w;
   return _ct_roundf(raw_f);
 }
-
 
 /* _ct_all_heap_size(): return the size in bytes of ALL space on the Loom
 **                      over all roads, currently in use as heap.
@@ -762,7 +759,6 @@ _ct_all_heap_size(u3_road* r) {
     return (u3a_heap(r)*4) + _ct_all_heap_size(u3tn(u3_road, r->par_p));
   }
 }
-
 
 /* These two structs, bar_item and bar_info, store the mutable data
 ** to normalize measured Loom usage values into ints that will fit
@@ -780,12 +776,10 @@ bar_item {
   float dif_f;
 };
 
-
 struct
 bar_info {
   struct bar_item s[6];
 };
-
 
 /* _ct_boost_small(): we want zero to be zero,
 **                    anything between zero and one to be one,
@@ -799,7 +793,6 @@ _ct_boost_small(float num_f)
     1.0 > num_f ? 1.0:
     num_f;
 }
-
 
 /* _ct_global_difference(): each low_w represents the normalized integer value
  *                          of its loom item, and ideally the sum of all loom low_w
@@ -816,7 +809,6 @@ _ct_global_difference(struct bar_info bar_u)
   return 100 - low_w;
 }
 
-
 /* _ct_compute_roundoff_error(): for each loom item in bar_u
 **                               compute the current difference between the int
 **                               size and the original float size.
@@ -829,7 +821,6 @@ _ct_compute_roundoff_error(struct bar_info bar_u)
   }
   return bar_u;
 }
-
 
 /* _ct_sort_by_roundoff_error(): sort loom items from most mis-sized to least */
 static struct bar_info
@@ -848,7 +839,6 @@ _ct_sort_by_roundoff_error(struct bar_info bar_u)
   return bar_u;
 }
 
-
 /* _ct_sort_by_index(): sort loom items into loom order */
 static struct bar_info
 _ct_sort_by_index(struct bar_info bar_u)
@@ -865,7 +855,6 @@ _ct_sort_by_index(struct bar_info bar_u)
   }
   return bar_u;
 }
-
 
 /* _ct_reduce_error(): reduce error by one int step
  *                     making oversized things a bit smaller
@@ -943,7 +932,6 @@ _ct_report_bargraph(
   bar_c[102] = 0;
 }
 
-
 /* _ct_size_prefix(): return the correct metric scalar prifix for a given int */
 static c3_c
 _ct_size_prefix(c3_d num_d)
@@ -955,7 +943,6 @@ _ct_size_prefix(c3_d num_d)
     (num_d % 1000) ? ' ':
     'X';
 }
-
 
 /* _ct_report_string(): convert a int into a string, adding a metric scale prefix letter*/
 static void
@@ -999,7 +986,6 @@ static void
   }
 }
 
-
 /* _ct_etch_memory(): create a single line report of a given captioned item
  *                    with a percentage of space used and the bytes used
  *                    scaled by a metric scaling postfix (ie MB, GB, etc)
@@ -1027,7 +1013,6 @@ _ct_etch_memory(c3_c rep_c[32], float per_f, c3_w num_w)
   rep_c[6] = '%';
 }
 
-
 /* _ct_etch_steps(): create a single line report of a given captioned item
 **                   scaled by a metric scaling postfix, but unitless.
 */
@@ -1036,8 +1021,6 @@ _ct_etch_steps(c3_c rep_c[32], c3_d sep_d)
 {
   _ct_report_string(rep_c, sep_d);
 }
-
-
 
 /* u3t_etch_meme(): report memory stats at call time */
 u3_noun

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -173,7 +173,6 @@
       u3_noun
       u3t_etch_meme(c3_l mod_l);
 
-
   /** Globals.
   **/
       /// Tracing profiler.

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -3,7 +3,8 @@
 #ifndef U3_TRACE_H
 #define U3_TRACE_H
 
-#include "c3.h"
+#include "c3/c3.h"
+#include "options.h"
 #include "types.h"
 
   /** Data structures.

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -167,6 +167,12 @@
       void
       u3t_slog_hela(c3_l pri_l);
 
+    /* u3t_etch_meme(): report memory stats at call time
+    */
+      u3_noun
+      u3t_etch_meme(c3_l mod_l);
+
+
   /** Globals.
   **/
       /// Tracing profiler.


### PR DESCRIPTION
### Description

Resolves #166 

I have added an support for the %meme hoon debugging hint. When a %meme hint is encountered, the usage of the vere memory arena is queried and printed (via slog).

The meme hint has two verbosity modes:
0: print the arena graph
1: print important memory information and the area graph

The arena graph is based on the ASCII graphs in Urbit's loom & road documentation

Example output in mode 0:
```
[=====$#############################################################################################~]
> ~>(%meme (add 1 1))
2
> =+  =+((bex (bex 30)) (bex (bex 30)))
  =+  =+((bex (bex 30)) (bex (bex 30)))
>>  warning: loom sums under 99.99%
>   after bexing: [=====$------------%%%%%%%%%%%%%%%%%%%%%%%%%########################################################~]
  ~>(%meme.[0 leaf+"after bexing"] (mul 100.000 100.003))
10.000.300.000
~zod:dojo> 
```
Example output in mode 1:
```
> =+  =+((bex (bex 30)) (bex (bex 30)))
  =+  =+((bex (bex 30)) (bex (bex 30)))
>>  warning: loom sums under 99.99%
>     after bexing
  Legend | Report:
                loom: 100.00%   2.147.482.236 GB     
                road:  93.25%   2.002.628.936 GB     

  =  immutable  heap:   6.45%     138.554.484 MB     
  -      solid  heap:  12.51%     268.661.488 MB     
  %      freed  heap:  25.00%     536.876.116 MB     
  #       open space:  55.74%   1.197.089.896 GB     
  +            stack:   0.00%           1.436 KB     
  ~  immutable stack:   0.29%       6.298.816 MB     

  $ allocation frame:   6.45%     138.554.484 MB     
      road direction:   South
          road depth:       4                        

Loom: [=====$------------%%%%%%%%%%%%%%%%%%%%%%%%%########################################################~]
  ~>(%meme.[1 leaf+"after bexing"] (mul 100.000 100.003))
10.000.300.000
~zod:dojo> 

```
if vere is compiled with the flag `CPU_DEBUG=1`, %meme mode 1 will report additional information:
```
> =+  =+((bex (bex 30)) (bex (bex 30)))
  =+  =+((bex (bex 30)) (bex (bex 30)))
>>  warning: loom sums under 99.99%
>     after bexing
  Legend | Report:
                loom: 100.00%   2.147.482.236 GB     
                road:  93.25%   2.002.628.952 GB     

  =  immutable  heap:   6.45%     138.554.468 MB     
  -      solid  heap:  12.51%     268.660.448 MB     
  %      freed  heap:  12.50%     268.440.916 MB     
  #       open space:  68.24%   1.465.526.152 GB     
  +            stack:   0.00%           1.436 KB     
  ~  immutable stack:   0.29%       6.298.816 MB     

  $ allocation frame:   6.45%     138.554.468 MB     
  |  road max memory:  25.50%     547.672.308 MB     

     road cells made:                  53.263 K      
     road nocks made:                  13.864 K      
      road direction:   South
          road depth:       4                        

Loom: [=====$-------------%%%%%|%%%%%%####################################################################~]
  ~>(%meme.[1 leaf+"after bexing"] (mul 100.000 100.003))
10.000.300.000
~zod:dojo> 
```

### Related
To see the basis of our ASCII graph design see, [this link](https://developers.urbit.org/reference/runtime/nouns) (scroll down to "u3: the road model"). There is similar info in `u3.md`.

This is the latest in a series of hoon debugging hints that I have authored: %bout, %hela, %nara, and %xray are my previous contributions.
