### PR TITLE
install.md: remove paste command `$`s

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ order to build Vere. Before going any further, install them using your package
 manager. For example, on macOS:
 
 ```console
-$ brew install automake libtool
+brew install automake libtool
 ```
 
 ### Linux
@@ -33,7 +33,7 @@ After installing `automake` and `libtool`, you need to install the [musl libc] t
 To install the `x86_64-linux-musl-gcc` toolchain at
 `/usr/local/x86_64-linux-musl-gcc`, run:
 ```console
-$ bazel run //bazel/toolchain:x86_64-linux-musl-gcc
+bazel run //bazel/toolchain:x86_64-linux-musl-gcc
 ```
 
 This will take a few minutes.
@@ -43,7 +43,7 @@ This will take a few minutes.
 To install the `aarch64-linux-musl-gcc` toolchain at
 `/usr/local/aarch64-linux-musl-gcc`, run:
 ```console
-$ bazel run //bazel/toolchain:aarch64-linux-musl-gcc
+bazel run //bazel/toolchain:aarch64-linux-musl-gcc
 ```
 
 This will take a few minutes.
@@ -56,13 +56,13 @@ After installing `automake` and `libtool`, you're ready to build Vere.
 
 Once you install the prerequisites, you're ready to build:
 ```console
-$ bazel build :urbit
+bazel build :urbit
 ```
 
 The default optimization level is `-O3`, but if you want to specify a different
 optimization level, use [`--copt`][copt]:
 ```console
-$ bazel build --copt='-O0' :urbit
+bazel build --copt='-O0' :urbit
 ```
 
 Note [`--copt`][copt] can be used to specify any C compiler options, not just
@@ -73,13 +73,13 @@ optimization levels.
 You can build and run unit tests only on native builds. If you have a native
 build and want to run all unit tests, run:
 ```console
-$ bazel test --build_tests_only ...
+bazel test --build_tests_only ...
 ```
 
 If you want to run a specific test, say
 [`pkg/noun/hashtable_tests.c`](pkg/noun/hashtable_tests.c), run:
 ```console
-$ bazel test //pkg/noun:hashtable_tests
+bazel test //pkg/noun:hashtable_tests
 ```
 
 ## Build Configuration File
@@ -90,8 +90,8 @@ file is not tracked by `git`, so whatever you add to it will not affect anyone
 else. As an example, if you want to change the optimization level but don't want
 type `--copt='-O0'` each time, you can do the following:
 ```console
-$ echo "build --copt='-O0'" >> .user.bazelrc
-$ bazel build :urbit
+echo "build --copt='-O0'" >> .user.bazelrc
+bazel build :urbit
 ```
 
 For more information on Bazel configuration files, consult the


### PR DESCRIPTION
Remove the `$`s at the start of the paste commands. They don't provide any useful context here, since no output is shown, just the commands, and they make copy-pasting commands from the file to terminal more difficult.