### PR TITLE
term: stop setting scroll regions for printfs

### DIFF
--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -484,7 +484,8 @@ _term_it_save_stub(u3_utty* uty_u, u3_noun tub)
   u3_utat* tat_u = &uty_u->tat_u;
   u3_noun  lin   = tat_u->mir.lin;
 
-  //  keep track of changes to bottom-most line, to aid spinner drawing logic.
+  //  keep track of changes to bottom-most line, to aid screen in restoration
+  //  after printfs or spinners.
   //  -t mode doesn't need this logic, because it doesn't render the spinner.
   //
   if ( ( tat_u->siz.row_l - 1 == tat_u->mir.rus_w ) &&
@@ -1472,13 +1473,11 @@ u3_term_io_hija(void)
           c3_assert(!"hija-tcsetattr");
         }
 
-        //  set scroll region to exclude the prompt,
-        //  scroll up one line to make space,
-        //  and move the cursor onto that space.
+        //  move the cursor to the bottom left corner,
+        //  and wipe that bottom line.
         //
-        _term_it_send_csi(uty_u, 'r', 2, 1, uty_u->tat_u.siz.row_l - 1);
-        _term_it_send_csi(uty_u, 'S', 1, 1);
-        _term_it_send_csi(uty_u, 'H', 2, uty_u->tat_u.siz.row_l - 1, 1);
+        _term_it_send_csi(uty_u, 'H', 2, uty_u->tat_u.siz.row_l, 1);
+        _term_it_dump_buf(uty_u, &uty_u->ufo_u.cel_u);
       }
     }
   }
@@ -1509,11 +1508,11 @@ u3_term_io_loja(int x, FILE* f)
           c3_assert(!"loja-tcsetattr");
         }
 
-        //  clear the scrolling region we set previously,
-        //  and restore cursor to its original position.
+        //  push the printfs up one more line,
+        //  and re-render the bottom-most line, which we clobbered.
         //
-        _term_it_dump_buf(uty_u, &uty_u->ufo_u.reg_u);
-        _term_it_dump_buf(uty_u, &uty_u->ufo_u.ruc_u);
+        _term_it_dump(uty_u, TERM_LIT("\n"));
+        _term_it_restore_line(uty_u);
       }
     }
   }


### PR DESCRIPTION
We were leveraging scrolling regions (the [`r` CSI command](https://terminalguide.namepad.de/seq/csi_sr/)) and scroll commands (the [`S` CSI command](https://terminalguide.namepad.de/seq/csi_cs/), for "scroll up") to create space in which printfs could exist. (This, besides the spinner, is where we depend on the assumption that there is a prompt on the bottom-most line of the screen.)

In the context of tmux, a scroll region scrolling up would simply push its contents up into scrollback/history. However, in the context of other terminals, 'S' is interpreted as "delete the top line(s), then shift all remaining content up". This obliterates the content of those top lines from existence irretrievably.

An alternative implementation prints a newline character at the bottom of the configured scroll region. This preserves the lines in scrollback in xterm, but this doesn't seem to be consistent across terminal emulators. (This seems like a desirable solution for webterm though, because we know we're always running xterm(.js) there.)

The solution we land on here, which behaves consistently in different environments, is reminiscent of the pre-terminal update implementation. We do not set a scroll region, instead we clear the bottom-most line, write the printf, bump it up by printing a newline character, and then restore the contents of the bottom-most line. Now that no scroll region is explicitly set, all tested terminals properly accept the bumped-up lines into their scrollback buffers.

We can do this only because we already track the contents that get drawn to the bottom-most line of the screen, for purposes of restoring it after we've clobbered it by drawing the spinner on top. The change herein is, in that sense, a deepening of the coupling to drum's semantics. Fortunately, both of these problems can be resolved by the much-desired, long-awaited project of Logging Reform. We must, as always, announce: Soon™.

Fixes #168.