### PR TITLE
Add missing `{CS}-` segments to `edge` and `soon` link formats

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -65,8 +65,8 @@ number in VERSION, `{CS}` is the shortened commit SHA of the commit the binary
 is built from, and `{P}` is one of `linux-aarch64`, `linux-x86_64`,
 `macos-aarch64`, and `macos-x86_64`:
 
-- https://bootstrap.urbit.org/vere/edge/v{VN}-{CS}/vere-v{VN}-{P}
-- https://bootstrap.urbit.org/vere/soon/v{VN}-{CS}/vere-v{VN}-{P}
+- https://bootstrap.urbit.org/vere/edge/v{VN}-{CS}/vere-v{VN}-{CS}-{P}
+- https://bootstrap.urbit.org/vere/soon/v{VN}-{CS}/vere-v{VN}-{CS}-{P}
 - https://bootstrap.urbit.org/vere/live/v{VN}/vere-v{VN}-{P}
 
 The most recently deployed version of a given train (pace) is uploaded to


### PR DESCRIPTION
To verify that the updated link formats are correct:

Run:
```
PLATFORM=linux-aarch64
PACE=edge
VERSION=`curl -s https://bootstrap.urbit.org/vere/$PACE/last | cat`
echo $VERSION  # see something similar to `1.18-7c890c3`
wget https://bootstrap.urbit.org/vere/$PACE/v$VERSION/vere-v$VERSION-$PLATFORM
```

Also, see [L155 of `.github/workflows/shared.yml`](https://github.com/urbit/vere/blob/c7107216dc1ff4824e314daca28ac64a2d83aabc/.github/workflows/shared.yml#L155):

```target="gs://${UPLOAD_BASE}/${{ inputs.pace }}/v${sha_version}/vere-v${sha_version}-${{ matrix.target }}"```

Resolves #179.
