### PR TITLE
Configure gmp with --disable-assembly on macos-aarch64

### DIFF
--- a/bazel/third_party/gmp/gmp.BUILD
+++ b/bazel/third_party/gmp/gmp.BUILD
@@ -19,6 +19,8 @@ configure_make(
     ] + select({
         "@//:linux_aarch64": ["--host=aarch64-linux-musl"],
         "@//:linux_x86_64": ["--host=x86_64-linux-musl"],
+        # See https://gmplib.org/list-archives/gmp-bugs/2023-January/005228.html.
+        "@//:macos_aarch64": ["--disable-assembly"],
         "//conditions:default": [],
     }),
     lib_source = ":all",


### PR DESCRIPTION
## Description

Resolves #176. A big thank you to @matthew-levan and @joemfb for uncovering this problem with the new `macos-aarch64` build and its resulting solution.

## Testing

Both @matthew-levan and @tomholford confirmed this change allowed them to boot comets successfully on their respective `macos-aarch64` machines. Without the change, they were seeing a segfault.