### PR TITLE
s/fake_tests/inputs.fake_tests/

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Run fake ship tests
-        if: ${{ matrix.target == 'linux-x86_64' && fake_tests }}
+        if: ${{ matrix.target == 'linux-x86_64' && inputs.fake_tests }}
         run: |
           # See https://github.com/urbit/vere/issues/40.
           bazel build //pkg/vere:test-fake-ship


### PR DESCRIPTION
Resolves #206

a56035fdacf7e4cf93350fdd4c8412c85f5fddc1 broke CI because named-value `fake_tests` introduced wasn't properly qualified with `inputs.`
