### PR TITLE
simplify upload binary ci code

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -157,11 +157,8 @@ jobs:
       - name: Upload binary to bootstrap.urbit.org
         if: ${{ inputs.upload }}
         run: |
-          echo "${{ inputs.pace }}" > ./PACE
-          version="$(cat ./VERSION)"
-          bazel build :version
-          sha_version=$(grep 'URBIT_VERSION *".*"' ./bazel-bin/version.h \
-            | sed 's/^#define *URBIT_VERSION *"\([^"]*\)"/\1/')
+          bazel build :version_str
+          sha_version=$(cat ./bazel-bin/version)
           target="gs://${UPLOAD_BASE}/${{ inputs.pace }}/v${sha_version}/vere-v${sha_version}-${{ matrix.target }}"
 
           args=""


### PR DESCRIPTION
This PR removes the ugly `grep`/`sed` command that was used to produce the `sha_version` variable we use for determining which URL to upload our binary to. Instead, we simply use the value written to `./bazel-bin/version` by `bazel build :version_str` (which would be, for example, `1.20` for the `live` pace, and `1.20-{SHORT-SHA}` for the other ones).

Resolves #219.
