### PR TITLE
Docker: Support for `--loom` and `--httpPort`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,11 @@ For best performance, you must map the Ames UDP port to the *same* port on the h
 
 For this purpose you can force Ames to use a custom port. `/bin/start-urbit --port=$AMES_PORT` can be passed as an argument to the `docker start` command. Passing `/bin/start-urbit --port=13436` for example, would use port 13436. You must pass the name of the start script `/bin/start-urbit` in order to also pass arguments, if this is omitted your container will not start.
 
+You can also set the http port using `--http-port=$HTTP_PORT`. Passing `/bin/start-urbit --http-port=8085` for example, would use port 8085. The default http port is 8080.
+
+### Variable Loom Size
+You can also set a variable loom size using `--loom=$LOOM_SIZE`. Passing `/bin/start-urbit --loom=32` for example, would setup a 4GB loom. The default loom size is 31 (2GB).
+
 ### Examples
 Creating a volume for ~sampel=palnet:
 ```

--- a/docker/start_urbit.sh
+++ b/docker/start_urbit.sh
@@ -3,16 +3,26 @@
 set -eu
 
 # set defaults
-amesPort=34343
+amesPort="34343"
+httpPort="80"
+loom="31"
 
 # check args
 for i in "$@"
 do
 case $i in
-    -p=*|--port=*)
-        amesPort="''${i#*=}"
-        shift
-        ;;
+  -p=*|--port=*)
+      amesPort="${i#*=}"
+      shift
+      ;;
+  --http-port=*)
+      httpPort="${i#*=}"
+      shift
+      ;;
+  --loom=*)
+      loom="${i#*=}"
+      shift
+      ;;
 esac
 done
 
@@ -34,7 +44,7 @@ if [ -e *.key ]; then
   mv $keyname /tmp
 
   # Boot urbit with the key, exit when done booting
-  urbit $ttyflag -w $(basename $keyname .key) -k /tmp/$keyname -c $(basename $keyname .key) -p $amesPort -x
+  urbit $ttyflag -w $(basename $keyname .key) -k /tmp/$keyname -c $(basename $keyname .key) -p $amesPort -x --http-port $httpPort --loom $loom
 
   # Remove the keyfile for security
   rm /tmp/$keyname
@@ -53,4 +63,4 @@ dirnames="*/"
 dirs=( $dirnames )
 dirname=''${dirnames[0]}
 
-exec urbit $ttyflag -p $amesPort $dirname
+exec urbit $ttyflag -p $amesPort --http-port $httpPort  --loom $loom $dirnamev

--- a/docker/start_urbit.sh
+++ b/docker/start_urbit.sh
@@ -63,4 +63,4 @@ dirnames="*/"
 dirs=( $dirnames )
 dirname=''${dirnames[0]}
 
-exec urbit $ttyflag -p $amesPort --http-port $httpPort  --loom $loom $dirnamev
+exec urbit $ttyflag -p $amesPort --http-port $httpPort  --loom $loom $dirname

--- a/docker/start_urbit.sh
+++ b/docker/start_urbit.sh
@@ -55,7 +55,7 @@ elif [ -e *.comet ]; then
   cometname=''${comets[0]}
   rm *.comet
 
-  urbit $ttyflag -c $(basename $cometname .comet) -p $amesPort -x
+  urbit $ttyflag -c $(basename $cometname .comet) -p $amesPort -x --http-port $httpPort --loom $loom
 fi
 
 # Find the first directory and start urbit with the ship therein
@@ -63,4 +63,4 @@ dirnames="*/"
 dirs=( $dirnames )
 dirname=''${dirnames[0]}
 
-exec urbit $ttyflag -p $amesPort --http-port $httpPort  --loom $loom $dirname
+exec urbit $ttyflag -p $amesPort --http-port $httpPort --loom $loom $dirname


### PR DESCRIPTION
Modified start_urbit.sh script to allow the user to pick loom size and http port.
This is the start script Native Planet uses for our docker container

Resolves #189 
