### PR TITLE
eval: add --cue option

### DIFF
--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1232,6 +1232,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
   c3_w    arg_w;
   c3_o    cue_o = c3n;
   c3_o    jam_o = c3n;
+  c3_o    kan_o = c3n;
   c3_o    new_o = c3n;
 
   static struct option lop_u[] = {
@@ -1243,7 +1244,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
     { NULL, 0, NULL, 0 }
   };
 
-  while ( -1 != (ch_i=getopt_long(argc, argv, "cjn", lop_u, &lid_i)) ) {
+  while ( -1 != (ch_i=getopt_long(argc, argv, "cjkn", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
         c3_w lom_w;
@@ -1261,6 +1262,10 @@ _cw_eval(c3_i argc, c3_c* argv[])
 
       case 'j': {
         jam_o = c3y;
+      } break;
+
+      case 'k': {
+        kan_o = c3y;
       } break;
 
       case 'n': {
@@ -1356,7 +1361,24 @@ _cw_eval(c3_i argc, c3_c* argv[])
       fprintf(stderr, "cue failed\n");
       exit(1);
     }
-    c3_c* pre_c = u3m_pretty(u3k(som));
+    c3_c* pre_c;
+    u3k(som);
+    //  if input is jammed khan output
+    if ( c3y == kan_o ) {
+      u3_noun cop, uid, mar, res, tan;
+      u3x_qual(som, &uid, &mar, &res, &tan);
+      //  and if result is a goof
+      if ( c3n == res ) {
+        //  pretty-print tang to stderr and output only header
+        u3_Host.ops_u.dem = c3y;
+        u3_pier_punt_goof("eval", tan);
+        cop = som;
+        som = u3i_trel(uid, mar, res);
+        u3k(som);
+        u3z(cop);
+      }
+    }
+    pre_c = u3m_pretty(som);
     fprintf(stdout, "%s\n", pre_c);
     c3_free(pre_c);
     u3z(som);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -65,7 +65,7 @@ _main_self_path(void)
 
 /* _main_readw(): parse a word from a string.
 */
-static u3_noun
+static c3_o
 _main_readw(const c3_c* str_c, c3_w max_w, c3_w* out_w)
 {
   c3_c* end_c;
@@ -76,6 +76,21 @@ _main_readw(const c3_c* str_c, c3_w max_w, c3_w* out_w)
     return c3y;
   }
   else return c3n;
+}
+
+/* _main_readw_loom(): parse loom pointer bit size from a string.
+*/
+static c3_i
+_main_readw_loom(const c3_c* arg_c, c3_y* out_y)
+{
+  c3_w lom_w;
+  c3_o res_o = _main_readw(optarg, u3a_bits_max + 1, &lom_w);
+  if ( res_o == c3n || (lom_w < 20) ) {
+    fprintf(stderr, "error: --%s must be >= 20 and <= %u\r\n", arg_c, u3a_bits_max);
+    return -1;
+  }
+  *out_y = lom_w;
+  return 0;
 }
 
 /* _main_presig(): prefix optional sig.
@@ -258,26 +273,17 @@ _main_getopt(c3_i argc, c3_c** argv)
       //  urth-loom
       //
       case 5: {
-        c3_w lut_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lut_w);
-        if ( (c3n == res_o) || (lut_w < 20) ) {
-          fprintf(stderr, "error: --urth-loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("urth-loom", &u3_Host.ops_u.lut_y)) {
           return c3n;
         }
-
-        u3_Host.ops_u.lut_y = lut_w;
         break;
       }
       //  special args
       //
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           return c3n;
         }
-        u3_Host.ops_u.lom_y = lom_w;
         break;
       }
       case c3__http: {
@@ -1247,13 +1253,9 @@ _cw_eval(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "cjkn", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 24) ) {
-          fprintf(stderr, "error: --loom must be >= 24 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case 'c': {
@@ -1515,13 +1517,9 @@ _cw_cram(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {
@@ -1594,13 +1592,9 @@ _cw_queu(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {
@@ -1679,13 +1673,9 @@ _cw_meld(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {
@@ -1753,13 +1743,9 @@ _cw_next(c3_i argc, c3_c* argv[])
       } break;
 
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {
@@ -1812,13 +1798,9 @@ _cw_pack(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {
@@ -1927,13 +1909,9 @@ _cw_prep(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {
@@ -1985,13 +1963,9 @@ _cw_chop(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {
@@ -2272,13 +2246,9 @@ _cw_vile(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        c3_w lom_w;
-        c3_o res_o = _main_readw(optarg, u3a_bits_max+1, &lom_w);
-        if ( (c3n == res_o) || (lom_w < 20) ) {
-          fprintf(stderr, "error: --loom must be >= 20 and <= %zu\r\n", u3a_bits_max);
+        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
-        u3_Host.ops_u.lom_y = lom_w;
       } break;
 
       case '?': {

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -2355,6 +2355,8 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
   FILE* fil_u = u3_term_io_hija();
 
   //  XX temporary, for urb.py test runner
+  //  XX eval --cue also using this;
+  //     would be nice to have official way to dump goof to stderr
   //
   if ( c3y == u3_Host.ops_u.dem ) {
     fil_u = stderr;


### PR DESCRIPTION
Partially Resolves #197

Adds the `--cue` option to the `eval` utility. This allows jammed nouns to be passed over `stdin` and pretty-printed to `stdout`.

Also includes a sub-option which will expect the incoming jammed noun to be Khan output. If the thread resulted in a `goof`, it's pretty-printed to `stderr` as a stack trace and the output is simply the `conn.c` header info (unique ID, `%avow` mark signalling Khan output, `%.n` loobean signalling thread failure).

Also includes the "todo"s from the comments for #155.

**Testing:**
- Built Vere in debug mode; no new warnings introduced
- Manually ran the following test cases in the terminal:
```
echo '42' | ~/Urbit/urbit eval -jn | ~/Urbit/urbit eval -cn
echo '[[1 2] [3 4]]' | ~/Urbit/urbit eval -jn | ~/Urbit/urbit eval -cn
echo "(cat 3 'abc' 'def')" | ~/Urbit/urbit eval -jn | ~/Urbit/urbit eval -cn
```
- I've done more strenuous testing, but it's hard to explicitly list here since it relies on a thin client which will be committed as a separate PR after this one is merged

Not strictly necessary for this PR, but I would like to add explicit testing for both `--jam` and `--cue`. @mcevoypeter @matthew-levan If either of you can recommend how to modify Bazel to do so, it would be appreciated.