### PR TITLE
jets: update mod jet to match Arvo changes

### DIFF
--- a/pkg/noun/jets/a/add.c
+++ b/pkg/noun/jets/a/add.c
@@ -6,52 +6,53 @@
 
 #include "noun.h"
 
+u3_noun
+u3qa_add(u3_atom a,
+         u3_atom b)
+{
+  if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    c3_w c = a + b;
 
-  u3_noun
-  u3qa_add(u3_atom a,
-           u3_atom b)
-  {
-    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      c3_w c = a + b;
-
-      return u3i_words(1, &c);
-    }
-    else if ( 0 == a ) {
-      return u3k(b);
-    }
-    else {
-      mpz_t a_mp, b_mp;
-
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
-
-      mpz_add(a_mp, a_mp, b_mp);
-      mpz_clear(b_mp);
-
-      return u3i_mp(a_mp);
-    }
+    return u3i_words(1, &c);
   }
-  u3_noun
-  u3wa_add(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b) && a != 0) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_add(a, b);
-    }
+  else if ( 0 == a ) {
+    return u3k(b);
   }
+  else {
+    mpz_t a_mp, b_mp;
 
-  u3_noun
-  u3ka_add(u3_noun a,
-           u3_noun b)
-  {
-    u3_noun c = u3qa_add(a, b);
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
 
-    u3z(a); u3z(b);
-    return c;
+    mpz_add(a_mp, a_mp, b_mp);
+    mpz_clear(b_mp);
+
+    return u3i_mp(a_mp);
   }
+}
+
+u3_noun
+u3wa_add(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(a)) ||
+       (c3n == u3ud(b) && a != 0) )
+  {
+    return u3m_bail(c3__exit);
+  }
+  else {
+    return u3qa_add(a, b);
+  }
+}
+
+u3_noun
+u3ka_add(u3_noun a,
+         u3_noun b)
+{
+  u3_noun c = u3qa_add(a, b);
+
+  u3z(a); u3z(b);
+  return c;
+}

--- a/pkg/noun/jets/a/dec.c
+++ b/pkg/noun/jets/a/dec.c
@@ -6,52 +6,52 @@
 
 #include "noun.h"
 
+u3_noun
+u3qa_inc(u3_atom a)
+{
+  return u3i_vint(u3k(a));
+}
 
-  u3_noun
-  u3qa_inc(u3_atom a)
-  {
-    return u3i_vint(u3k(a));
+u3_noun
+u3qa_dec(u3_atom a)
+{
+  if ( 0 == a ) {
+    return u3m_error("decrement-underflow");
   }
-
-  u3_noun
-  u3qa_dec(u3_atom a)
-  {
-    if ( 0 == a ) {
-      return u3m_error("decrement-underflow");
+  else {
+    if ( _(u3a_is_cat(a)) ) {
+      return a - 1;
     }
     else {
-      if ( _(u3a_is_cat(a)) ) {
-        return a - 1;
-      }
-      else {
-        mpz_t a_mp;
+      mpz_t a_mp;
 
-        u3r_mp(a_mp, a);
-        mpz_sub_ui(a_mp, a_mp, 1);
+      u3r_mp(a_mp, a);
+      mpz_sub_ui(a_mp, a_mp, 1);
 
-        return u3i_mp(a_mp);
-      }
+      return u3i_mp(a_mp);
     }
   }
+}
 
-  u3_noun
-  u3wa_dec(u3_noun cor)
+u3_noun
+u3wa_dec(u3_noun cor)
+{
+  u3_noun a;
+
+  if ( (u3_none == (a = u3r_at(u3x_sam, cor))) ||
+       (c3n == u3ud(a)) )
   {
-    u3_noun a;
-
-    if ( (u3_none == (a = u3r_at(u3x_sam, cor))) ||
-         (c3n == u3ud(a)) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_dec(a);
-    }
+    return u3m_bail(c3__exit);
   }
-
-  u3_noun
-  u3ka_dec(u3_atom a)
-  {
-    u3_noun b = u3qa_dec(a);
-    u3z(a);
-    return b;
+  else {
+    return u3qa_dec(a);
   }
+}
+
+u3_noun
+u3ka_dec(u3_atom a)
+{
+  u3_noun b = u3qa_dec(a);
+  u3z(a);
+  return b;
+}

--- a/pkg/noun/jets/a/div.c
+++ b/pkg/noun/jets/a/div.c
@@ -6,46 +6,46 @@
 
 #include "noun.h"
 
-
-  u3_noun
-  u3qa_div(u3_atom a,
-           u3_atom b)
-  {
-    if ( 0 == b ) {
-      return u3m_error("divide-by-zero");
+u3_noun
+u3qa_div(u3_atom a,
+         u3_atom b)
+{
+  if ( 0 == b ) {
+    return u3m_error("divide-by-zero");
+  }
+  else {
+    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+      return a / b;
     }
     else {
-      if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-        return a / b;
-      }
-      else {
-        mpz_t a_mp, b_mp;
+      mpz_t a_mp, b_mp;
 
-        u3r_mp(a_mp, a);
-        u3r_mp(b_mp, b);
+      u3r_mp(a_mp, a);
+      u3r_mp(b_mp, b);
 
-        mpz_tdiv_q(a_mp, a_mp, b_mp);
-        mpz_clear(b_mp);
+      mpz_tdiv_q(a_mp, a_mp, b_mp);
+      mpz_clear(b_mp);
 
-        return u3i_mp(a_mp);
-      }
+      return u3i_mp(a_mp);
     }
   }
-  u3_noun
-  u3wa_div(u3_noun cor)
+}
+
+u3_noun
+u3wa_div(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(a)) ||
+       (c3n == u3ud(b)) )
   {
-    u3_noun a, b;
-
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_div(a, b);
-    }
+    return u3m_bail(c3__exit);
   }
-
+  else {
+    return u3qa_div(a, b);
+  }
+}
 
 u3_noun
 u3ka_div(u3_noun a,

--- a/pkg/noun/jets/a/mod.c
+++ b/pkg/noun/jets/a/mod.c
@@ -6,42 +6,44 @@
 
 #include "noun.h"
 
-
-  u3_noun
-  u3qa_mod(u3_atom a,
-           u3_atom b)
-  {
-    if ( 0 == b ) {
-      return u3m_error("divide-by-zero");
-    } else if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      return a % b;
-    } else {
-      mpz_t a_mp, b_mp;
-
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
-
-      mpz_tdiv_r(a_mp, a_mp, b_mp);
-      mpz_clear(b_mp);
-
-      return u3i_mp(a_mp);
-    }
+u3_noun
+u3qa_mod(u3_atom a,
+         u3_atom b)
+{
+  if ( 0 == b ) {
+    return u3m_error("divide-by-zero");
   }
-
-  u3_noun
-  u3wa_mod(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b)) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_mod(a, b);
-    }
+  else if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    return a % b;
   }
+  else {
+    mpz_t a_mp, b_mp;
+
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
+
+    mpz_tdiv_r(a_mp, a_mp, b_mp);
+    mpz_clear(b_mp);
+
+    return u3i_mp(a_mp);
+  }
+}
+
+u3_noun
+u3wa_mod(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(a)) ||
+       (c3n == u3ud(b)) )
+  {
+    return u3m_bail(c3__exit);
+  }
+  else {
+    return u3qa_mod(a, b);
+  }
+}
 
 u3_noun
 u3ka_mod(u3_noun a,

--- a/pkg/noun/jets/a/mod.c
+++ b/pkg/noun/jets/a/mod.c
@@ -12,7 +12,7 @@
            u3_atom b)
   {
     if ( 0 == b ) {
-      return u3m_bail(c3__exit);
+      return u3m_error("divide-by-zero");
     } else if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
       return a % b;
     } else {

--- a/pkg/noun/jets/a/mul.c
+++ b/pkg/noun/jets/a/mul.c
@@ -6,52 +6,53 @@
 
 #include "noun.h"
 
+u3_noun
+u3qa_mul(u3_atom a,
+         u3_atom b)
+{
+  if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    c3_d c = ((c3_d) a) * ((c3_d) b);
 
-  u3_noun
-  u3qa_mul(u3_atom a,
-           u3_atom b)
-  {
-    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      c3_d c = ((c3_d) a) * ((c3_d) b);
-
-      return u3i_chubs(1, &c);
-    }
-    else if ( 0 == a ) {
-      return 0;
-    }
-    else {
-      mpz_t a_mp, b_mp;
-
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
-
-      mpz_mul(a_mp, a_mp, b_mp);
-      mpz_clear(b_mp);
-
-      return u3i_mp(a_mp);
-    }
+    return u3i_chubs(1, &c);
   }
-  u3_noun
-  u3wa_mul(u3_noun cor)
-  {
-    u3_noun a, b;
-
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(a)) ||
-         (c3n == u3ud(b) && a != 0) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_mul(a, b);
-    }
+  else if ( 0 == a ) {
+    return 0;
   }
-  u3_noun
-  u3ka_mul(u3_noun a,
-           u3_noun b)
-  {
-    u3_noun c = u3qa_mul(a, b);
+  else {
+    mpz_t a_mp, b_mp;
 
-    u3z(a); u3z(b);
-    return c;
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
+
+    mpz_mul(a_mp, a_mp, b_mp);
+    mpz_clear(b_mp);
+
+    return u3i_mp(a_mp);
   }
+}
 
+u3_noun
+u3wa_mul(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(a)) ||
+       (c3n == u3ud(b) && a != 0) )
+  {
+    return u3m_bail(c3__exit);
+  }
+  else {
+    return u3qa_mul(a, b);
+  }
+}
+
+u3_noun
+u3ka_mul(u3_noun a,
+         u3_noun b)
+{
+  u3_noun c = u3qa_mul(a, b);
+
+  u3z(a); u3z(b);
+  return c;
+}

--- a/pkg/noun/jets/a/sub.c
+++ b/pkg/noun/jets/a/sub.c
@@ -6,60 +6,62 @@
 
 #include "noun.h"
 
-
-  u3_noun
-  u3qa_sub(u3_atom a,
-           u3_atom b)
-  {
-    if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
-      if ( a < b ) {
-        return u3m_error("subtract-underflow");
-      }
-      else return (a - b);
-    }
-    else if ( 0 == b ) {
-      return u3k(a);
+u3_noun
+u3qa_sub(u3_atom a,
+         u3_atom b)
+{
+  if ( _(u3a_is_cat(a)) && _(u3a_is_cat(b)) ) {
+    if ( a < b ) {
+      return u3m_error("subtract-underflow");
     }
     else {
-      mpz_t a_mp, b_mp;
+      return (a - b);
+    }
+  }
+  else if ( 0 == b ) {
+    return u3k(a);
+  }
+  else {
+    mpz_t a_mp, b_mp;
 
-      u3r_mp(a_mp, a);
-      u3r_mp(b_mp, b);
+    u3r_mp(a_mp, a);
+    u3r_mp(b_mp, b);
 
-      if ( mpz_cmp(a_mp, b_mp) < 0 ) {
-        mpz_clear(a_mp);
-        mpz_clear(b_mp);
-
-        return u3m_error("subtract-underflow");
-      }
-      mpz_sub(a_mp, a_mp, b_mp);
+    if ( mpz_cmp(a_mp, b_mp) < 0 ) {
+      mpz_clear(a_mp);
       mpz_clear(b_mp);
 
-      return u3i_mp(a_mp);
+      return u3m_error("subtract-underflow");
     }
-  }
+    mpz_sub(a_mp, a_mp, b_mp);
+    mpz_clear(b_mp);
 
-  u3_noun
-  u3wa_sub(u3_noun cor)
+    return u3i_mp(a_mp);
+  }
+}
+
+u3_noun
+u3wa_sub(u3_noun cor)
+{
+  u3_noun a, b;
+
+  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
+       (c3n == u3ud(b)) ||
+       (c3n == u3ud(a) && b != 0) )
   {
-    u3_noun a, b;
-
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0)) ||
-         (c3n == u3ud(b)) ||
-         (c3n == u3ud(a) && b != 0) )
-    {
-      return u3m_bail(c3__exit);
-    } else {
-      return u3qa_sub(a, b);
-    }
+    return u3m_bail(c3__exit);
   }
-
-  u3_noun
-  u3ka_sub(u3_noun a,
-           u3_noun b)
-  {
-    u3_noun c = u3qa_sub(a, b);
-
-    u3z(a); u3z(b);
-    return c;
+  else {
+    return u3qa_sub(a, b);
   }
+}
+
+u3_noun
+u3ka_sub(u3_noun a,
+         u3_noun b)
+{
+  u3_noun c = u3qa_sub(a, b);
+
+  u3z(a); u3z(b);
+  return c;
+}


### PR DESCRIPTION
Companion PR for [#6355](https://github.com/urbit/urbit/pull/6355) in `urbit/urbit` - **they must be released together**.

Required changes to `mod` jet to match bail condition of new `mod` logic in Arvo.

Tested changes successfully against latest code from `develop` (both `urbit/urbit` and `urbit/vere`).
