### PR TITLE
build: upload soon and edge tags to dockerhub

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -200,6 +200,11 @@ jobs:
         run: |
           bazel run //docker:push_version_x86_64
 
+      - name: Build and push pace-tagged Docker image
+        if: ${{ inputs.docker && matrix.target == 'linux-x86_64' }}
+        run: |
+          bazel run //docker:push_pace_x86_64
+
       - name: Build and push latest-tagged Docker image
         if: ${{ inputs.docker && matrix.target == 'linux-x86_64' && inputs.pace == 'live' }}
         run: |

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -75,6 +75,16 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
+genrule(
+    name = "pace_tag",
+    srcs = ["PACE"],
+    outs = ["docker_pace_tag"],
+    cmd = """
+    tr -d '\n' < $< > $@
+    """,
+    visibility = ["//visibility:private"],
+)
+
 container_push(
     name = "push_latest_x86_64",
     format = "Docker",
@@ -92,5 +102,15 @@ container_push(
     registry = "docker.io",
     repository = _docker_repository,
     tag_file = ":version_tag",
+    visibility = ["//visibility:public"],
+)
+
+container_push(
+    name = "push_pace_x86_64",
+    format = "Docker",
+    image = ":image_x86_64",
+    registry = "docker.io",
+    repository = _docker_repository,
+    tag = ":pace_tag",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Resolves #160

Adds a job which will push a tag with the pace value to DockerHub. Technically also adds a `live` tag which references the same image as the `latest` tag.
