### PR TITLE
build: fix broken docker upload

### DIFF
--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -111,6 +111,6 @@ container_push(
     image = ":image_x86_64",
     registry = "docker.io",
     repository = _docker_repository,
-    tag = ":pace_tag",
+    tag_file = ":pace_tag",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Resolves [builds failing when attempting to tag release with pace on DockerHub](https://github.com/urbit/vere/actions/runs/4298049619/jobs/7491731178).

Fixing issue introduced by #258.

@mcevoypeter @matthew-levan  Requesting urgent review, as this affects all builds and Docker uploads. I think this is the cause, but I'm unsure. I'm also unsure how to test this without going through a PR.
