### PR TITLE
fix strange page errors by ensuring single guard page

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1258,8 +1258,27 @@ void
 u3e_ward(u3_post low_p, u3_post hig_p)
 {
 #ifdef U3_GUARD_PAGE
-  if ( (low_p > gar_pag_p) || (hig_p < gar_pag_p) ) {
+  const u3p(c3_w) gar_p = gar_pag_p;
+
+  if ( (low_p > gar_p) || (hig_p < gar_p) ) {
     _ce_center_guard_page();
+
+    if ( 0 != mprotect(u3a_into(gar_p),
+                       pag_siz_i,
+                       (PROT_READ | PROT_WRITE)) )
+    {
+      fprintf(stderr, "loom: failed to unprotect old guard page: %s\r\n",
+                      strerror(errno));
+      c3_assert(0);
+    }
+
+    {
+      c3_w pag_w = gar_p >> u3a_page;
+      c3_w blk_w = (pag_w >> 5);
+      c3_w bit_w = (pag_w & 31);
+
+      u3P.dit_w[blk_w] |= (1 << bit_w);
+    }
   }
 #endif
 }


### PR DESCRIPTION
Partially fixes #234.

This PR is a port of @joemfb's [urbit/urbit#6125](https://github.com/urbit/urbit/pull/6125).

Note that any stale `PROT_NONE` pages in live ship looms that currently exist will be cleaned out upon restart (i.e., when they upgrade to the new `vere`, at the least).