### PR TITLE
click: thin client for interacting with a running ship from Earth

### DIFF
--- a/bin/click
+++ b/bin/click
@@ -1,0 +1,110 @@
+#!/bin/bash
+# ==============================================================================
+# click
+#
+#   Thin client for interacting with running Urbit ship via conn.c.
+#
+#   Compiles a Hoon command given as text against an optional list of
+#   dependencies and then executes it on a running ship.
+#
+#   The click-format helper script handles command formatting, whereas this
+#   script handles operational control flow. See the documentation in
+#   click-format for the details of command structure, dependency management,
+#   etc.
+#
+# ==============================================================================
+
+# ==========================================================
+# CONSTANTS
+# ==========================================================
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_NAME=$(basename "$0")
+
+# ==========================================================
+# VARIABLES
+# ==========================================================
+
+FILTER_GOOF=0
+KHAN_TED=0
+STATUS=0
+
+# ==========================================================
+# FUNCTIONS
+# ==========================================================
+
+show_help() {
+    cat <<EOF
+Usage:
+    $SCRIPT_NAME [options] <path-to-pier> <hoon> [<dependencies> ...]
+
+    Thin client for interacting with running Urbit ship via conn.c
+
+    opitons:
+        -h  Show usage info
+        -k  Execute command using "khan-eval" thread
+        -p  Filter failure stack traces from result and pretty-print them to stderr
+EOF
+}
+
+main() {
+    CLIC_CMD="$SCRIPT_DIR/click-format"
+    EVAL_CMD="$PIER/.run"
+    CUE_OPTS="-n"
+
+    if [[ $KHAN_TED -eq 1 ]]; then
+        CLIC_CMD="$CLIC_CMD -k"
+    fi
+    if [[ $FILTER_GOOF -eq 1 ]]; then
+        CUE_OPTS="$CUE_OPTS -k"
+    fi
+
+    $CLIC_CMD "$HOON" $DEPS |
+        $EVAL_CMD eval --jam -n |
+        nc -U -W 1 "$PIER/.urb/conn.sock" |
+        $EVAL_CMD eval --cue $CUE_OPTS
+}
+
+# ==========================================================
+# MAIN
+# ==========================================================
+
+# reset getopts
+OPTIND=1
+
+# parse options
+while getopts ":hkp" OPT; do
+    case "$OPT" in
+        k)
+            KHAN_TED=1
+            ;;
+        p)
+            FILTER_GOOF=1
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            STATUS=1
+            ;&
+        h)
+            show_help
+            exit "$STATUS"
+            ;;
+  esac
+done
+
+# skip over opts after parsing
+shift $((OPTIND-1))
+
+# check for mandatory input
+if [[ $# -lt 2 ]]; then
+    echo "ERROR: missing input" >&2
+    show_help
+    exit 1
+fi
+
+PIER=$1
+HOON=$2
+shift 2
+DEPS=$*
+
+main

--- a/bin/click
+++ b/bin/click
@@ -26,6 +26,7 @@ SCRIPT_NAME=$(basename "$0")
 # ==========================================================
 
 FILTER_GOOF=0
+JAM_HEX=0
 JAM_ONLY=0
 KHAN_TED=0
 STATUS=0
@@ -46,29 +47,33 @@ Usage:
         -j  Jam only
         -k  Execute command using "khan-eval" thread
         -p  Filter failure stack traces from result and pretty-print them to stderr
+        -x  Jam to hex
 EOF
 }
 
 main() {
-    if [[ $KHAN_TED -ne 0 ]]; then
-        CLIC_CMD="$CLIC_CMD -k"
-    fi
     if [[ $FILTER_GOOF -ne 0 ]]; then
         CUE_OPTS="$CUE_OPTS -k"
     fi
+    if [[ $KHAN_TED -ne 0 ]]; then
+        CLIC_CMD="$CLIC_CMD -k"
+    fi
 
     $CLIC_CMD "$HOON" $DEPS |
-        $EVAL_CMD eval --jam -n |
+        $EVAL_CMD eval --jam $JAM_OPTS |
         nc -U -W 1 "$PIER/.urb/conn.sock" |
         $EVAL_CMD eval --cue $CUE_OPTS
 }
 
 jam() {
+    if [[ $JAM_HEX -ne 0 ]]; then
+        JAM_OPTS=""
+    fi
     if [[ $KHAN_TED -ne 0 ]]; then
         CLIC_CMD="$CLIC_CMD -k"
     fi
 
-    $CLIC_CMD "$HOON" $DEPS | $EVAL_CMD eval --jam -n
+    $CLIC_CMD "$HOON" $DEPS | $EVAL_CMD eval --jam $JAM_OPTS
 }
 
 # ==========================================================
@@ -79,7 +84,7 @@ jam() {
 OPTIND=1
 
 # parse options
-while getopts ":hjkp" OPT; do
+while getopts ":hjkpx" OPT; do
     case "$OPT" in
         j)
             JAM_ONLY=1
@@ -89,6 +94,9 @@ while getopts ":hjkp" OPT; do
             ;;
         p)
             FILTER_GOOF=1
+            ;;
+        x)
+            JAM_HEX=1
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
@@ -120,6 +128,7 @@ DEPS=$*
 # setup shared variables
 CLIC_CMD="$SCRIPT_DIR/click-format"
 EVAL_CMD="$PIER/.run"
+JAM_OPTS="-n"
 CUE_OPTS="-n"
 
 if [[ $JAM_ONLY -ne 0 ]]; then

--- a/bin/click
+++ b/bin/click
@@ -31,6 +31,8 @@ JAM_ONLY=0
 KHAN_TED=0
 STATUS=0
 
+OUTPUT=''
+
 # ==========================================================
 # FUNCTIONS
 # ==========================================================
@@ -43,11 +45,12 @@ Usage:
     Thin client for interacting with running Urbit ship via conn.c
 
     opitons:
-        -h  Show usage info
-        -j  Jam only
-        -k  Execute command using "khan-eval" thread
-        -p  Filter failure stack traces from result and pretty-print them to stderr
-        -x  Jam to hex
+        -h                  Show usage info
+        -j                  Jam only
+        -k                  Execute command using "khan-eval" thread
+        -o <path-to-file>   Output to file
+        -p                  Filter failure stack traces from result and pretty-print them to stderr
+        -x                  Jam to hex
 EOF
 }
 
@@ -84,13 +87,16 @@ jam() {
 OPTIND=1
 
 # parse options
-while getopts ":hjkpx" OPT; do
+while getopts ":hjko:px" OPT; do
     case "$OPT" in
         j)
             JAM_ONLY=1
             ;;
         k)
             KHAN_TED=1
+            ;;
+        o)
+            OUTPUT=$OPTARG
             ;;
         p)
             FILTER_GOOF=1
@@ -130,11 +136,20 @@ CLIC_CMD="$SCRIPT_DIR/click-format"
 EVAL_CMD="$PIER/.run"
 JAM_OPTS="-n"
 CUE_OPTS="-n"
+TMP_OUT=`mktemp -q --tmpdir`
 
-if [[ $JAM_ONLY -ne 0 ]]; then
-    jam
+{
+    if [[ $JAM_ONLY -ne 0 ]]; then
+        jam
+    else
+        main
+    fi
+} > $TMP_OUT
+
+if [[ -n $OUTPUT ]]; then
+    mv $TMP_OUT $OUTPUT
 else
-    main
+    cat $TMP_OUT
 fi
 
 exit 0

--- a/bin/click
+++ b/bin/click
@@ -20,17 +20,22 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SCRIPT_NAME=$(basename "$0")
+CLICK_CMD="$SCRIPT_DIR/click-format"
 
 # ==========================================================
 # VARIABLES
 # ==========================================================
 
+MIN_INPUT=0
+STATUS=0
+
+EXECUTE=0
 FILTER_GOOF=0
 JAM_HEX=0
 JAM_ONLY=0
 KHAN_TED=0
-STATUS=0
 
+INPUT=''
 OUTPUT=''
 
 # ==========================================================
@@ -38,14 +43,18 @@ OUTPUT=''
 # ==========================================================
 
 show_help() {
-    cat <<EOF
+    cat >&2 <<EOF
 Usage:
     $SCRIPT_NAME [options] <path-to-pier> <hoon> [<dependencies> ...]
+    $SCRIPT_NAME [options] -i <path-to-file> <path-to-pier> [<dependencies> ...]
+    $SCRIPT_NAME [-o|-p] -e -i <path-to-file> <path-to-pier>
 
     Thin client for interacting with running Urbit ship via conn.c
 
-    opitons:
+    options:
+        -e                  Execute jammed Hoon
         -h                  Show usage info
+        -i <path-to-file>   Read input from file
         -j                  Jam only
         -k                  Execute command using "khan-eval" thread
         -o <path-to-file>   Output to file
@@ -54,15 +63,12 @@ Usage:
 EOF
 }
 
-main() {
+full() {
     if [[ $FILTER_GOOF -ne 0 ]]; then
         CUE_OPTS="$CUE_OPTS -k"
     fi
-    if [[ $KHAN_TED -ne 0 ]]; then
-        CLIC_CMD="$CLIC_CMD -k"
-    fi
 
-    $CLIC_CMD "$HOON" $DEPS |
+    $CLICK_CMD "$HOON" $DEPS |
         $EVAL_CMD eval --jam $JAM_OPTS |
         nc -U -W 1 "$PIER/.urb/conn.sock" |
         $EVAL_CMD eval --cue $CUE_OPTS
@@ -72,11 +78,17 @@ jam() {
     if [[ $JAM_HEX -ne 0 ]]; then
         JAM_OPTS=""
     fi
-    if [[ $KHAN_TED -ne 0 ]]; then
-        CLIC_CMD="$CLIC_CMD -k"
+
+    $CLICK_CMD "$HOON" $DEPS | $EVAL_CMD eval --jam $JAM_OPTS
+}
+
+execute() {
+    if [[ $FILTER_GOOF -ne 0 ]]; then
+        CUE_OPTS="$CUE_OPTS -k"
     fi
 
-    $CLIC_CMD "$HOON" $DEPS | $EVAL_CMD eval --jam $JAM_OPTS
+    nc -U -W 1 "$PIER/.urb/conn.sock" < $INPUT |
+        $EVAL_CMD eval --cue $CUE_OPTS
 }
 
 # ==========================================================
@@ -87,8 +99,14 @@ jam() {
 OPTIND=1
 
 # parse options
-while getopts ":hjko:px" OPT; do
+while getopts ":ehi:jko:px" OPT; do
     case "$OPT" in
+        e)
+            EXECUTE=1
+            ;;
+        i)
+            INPUT=$OPTARG
+            ;;
         j)
             JAM_ONLY=1
             ;;
@@ -107,49 +125,104 @@ while getopts ":hjko:px" OPT; do
         \?)
             echo "Invalid option: -$OPTARG" >&2
             STATUS=1
-            ;&
+            ;;
         h)
             show_help
-            exit "$STATUS"
+            exit 0
             ;;
   esac
 done
+
+# check for opt issues
+if [[ $EXECUTE -ne 0 ]]; then
+    if [[ $JAM_ONLY -ne 0 ]]; then
+        echo "Invalid option: cannot mix -e and -j" >&2
+        STATUS=1
+    fi
+    if [[ -z $INPUT ]]; then
+        echo "Invalid option: -e requires -i" >&2
+        STATUS=1
+    fi
+
+    if [[ $KHAN_TED -ne 0 ]]; then
+        echo "-k meaningless with -e; ignoring" >&2
+    fi
+fi
+if [[ $JAM_ONLY -ne 0 ]]; then
+    if [[ $FILTER_GOOF -ne 0 ]]; then
+        echo "-p meaningless with -j; ignoring" >&2
+    fi
+else
+    if [[ $JAM_HEX -ne 0 ]]; then
+        echo "Invalid option: -x requires -j" >&2
+        STATUS=1
+    fi
+fi
+
+# handle errors
+if [[ $STATUS -ne 0 ]]; then
+    show_help
+    exit "$STATUS"
+fi
 
 # skip over opts after parsing
 shift $((OPTIND-1))
 
 # check for mandatory input
-if [[ $# -lt 2 ]]; then
+if [[ -n $INPUT ]]; then
+    MIN_INPUT=1
+else
+    MIN_INPUT=2
+fi
+
+if [[ $# -lt $MIN_INPUT ]]; then
     echo "ERROR: missing input" >&2
     show_help
     exit 1
 fi
 
 # read args
-PIER=$1
-HOON=$2
-shift 2
+if [[ -n $INPUT ]]; then
+    PIER=$1
+    shift
+
+    if [[ $EXECUTE -eq 0 ]]; then
+        # read from file, escape 's, replace newlines w/ gaps
+        HOON="$(cat $INPUT | sed "s;';\\\\';g" | sed ':a;N;s/\n/  /;$!ba')"
+    fi
+else
+    PIER=$1
+    HOON=$2
+    shift 2
+fi
 DEPS=$*
 
 # setup shared variables
-CLIC_CMD="$SCRIPT_DIR/click-format"
+if [[ $KHAN_TED -ne 0 ]]; then
+    CLICK_CMD="$CLICK_CMD -k"
+fi
 EVAL_CMD="$PIER/.run"
 JAM_OPTS="-n"
 CUE_OPTS="-n"
 TMP_OUT=`mktemp -q --tmpdir`
 
+# main logic
 {
-    if [[ $JAM_ONLY -ne 0 ]]; then
+    if [[ $EXECUTE -ne 0 ]]; then
+        execute
+    elif [[ $JAM_ONLY -ne 0 ]]; then
         jam
     else
-        main
+        full
     fi
 } > $TMP_OUT
 
+# route output
 if [[ -n $OUTPUT ]]; then
     mv $TMP_OUT $OUTPUT
 else
     cat $TMP_OUT
 fi
 
+# done
 exit 0

--- a/bin/click
+++ b/bin/click
@@ -26,6 +26,7 @@ SCRIPT_NAME=$(basename "$0")
 # ==========================================================
 
 FILTER_GOOF=0
+JAM_ONLY=0
 KHAN_TED=0
 STATUS=0
 
@@ -42,20 +43,17 @@ Usage:
 
     opitons:
         -h  Show usage info
+        -j  Jam only
         -k  Execute command using "khan-eval" thread
         -p  Filter failure stack traces from result and pretty-print them to stderr
 EOF
 }
 
 main() {
-    CLIC_CMD="$SCRIPT_DIR/click-format"
-    EVAL_CMD="$PIER/.run"
-    CUE_OPTS="-n"
-
-    if [[ $KHAN_TED -eq 1 ]]; then
+    if [[ $KHAN_TED -ne 0 ]]; then
         CLIC_CMD="$CLIC_CMD -k"
     fi
-    if [[ $FILTER_GOOF -eq 1 ]]; then
+    if [[ $FILTER_GOOF -ne 0 ]]; then
         CUE_OPTS="$CUE_OPTS -k"
     fi
 
@@ -63,6 +61,14 @@ main() {
         $EVAL_CMD eval --jam -n |
         nc -U -W 1 "$PIER/.urb/conn.sock" |
         $EVAL_CMD eval --cue $CUE_OPTS
+}
+
+jam() {
+    if [[ $KHAN_TED -ne 0 ]]; then
+        CLIC_CMD="$CLIC_CMD -k"
+    fi
+
+    $CLIC_CMD "$HOON" $DEPS | $EVAL_CMD eval --jam -n
 }
 
 # ==========================================================
@@ -73,8 +79,11 @@ main() {
 OPTIND=1
 
 # parse options
-while getopts ":hkp" OPT; do
+while getopts ":hjkp" OPT; do
     case "$OPT" in
+        j)
+            JAM_ONLY=1
+            ;;
         k)
             KHAN_TED=1
             ;;
@@ -102,9 +111,21 @@ if [[ $# -lt 2 ]]; then
     exit 1
 fi
 
+# read args
 PIER=$1
 HOON=$2
 shift 2
 DEPS=$*
 
-main
+# setup shared variables
+CLIC_CMD="$SCRIPT_DIR/click-format"
+EVAL_CMD="$PIER/.run"
+CUE_OPTS="-n"
+
+if [[ $JAM_ONLY -ne 0 ]]; then
+    jam
+else
+    main
+fi
+
+exit 0

--- a/bin/click-format
+++ b/bin/click-format
@@ -1,0 +1,131 @@
+#!/bin/bash
+# ==============================================================================
+# click-format
+#
+#   Formatting helper script for click.
+#
+#   Takes a Hoon command and an optional list of Clay file dependencies (as
+#   paths or beams) and formats them as a text representation of a Hoon noun.
+#   When jammed, this noun can be passed to conn.c to execute the command on a
+#   running ship.
+#
+#   If a dependency file is passed as a beam, it will be interpreted as-is. If a
+#   dependency file is passed as a path, the default beak (i.e. [our base now])
+#   will be prepended to it.
+#
+#   The structure of a conn.c thread call looks like this:
+#
+#       [42 %fyrd [%base %hi %tape [%ship ~zod]]]
+#        1  2      3     4   5      6     7
+#
+#       1 = Unique ID for mapping results to requests
+#       2 = Command to conn.c routing the request
+#       3 = Desk in which thread lives
+#       4 = Name of thread
+#       5 = Mark for output type
+#       6 = Mark for input type
+#       7 = Input to thread as a noun
+#
+#   (1) - (6) are held constant by this client. (7) is provided by the user.
+#
+# ==============================================================================
+
+# ==========================================================
+# CONSTANTS
+# ==========================================================
+
+# Request ID
+# A client that ran many simultaneous queries would want to somehow assign these
+RID=0
+
+# Command
+# See conn.c for information about other commands and how they work
+COMMAND="%fyrd"
+
+# Desk
+# Desk in which the thread lives. All threads used by click live in '%base'.
+DESK="%base"
+
+# Threads
+# Name of thread to call. Only 'eval' and 'khan-eval' are used by click.
+EVAL_TED="%eval"
+KHAN_TED="%khan-eval"
+THREAD=$EVAL_TED
+
+# Output mark
+# Output format of thread results (always noun for click)
+MARK_OUT="%noun"
+
+# Input mark
+# Format of input to thread (always constant for click)
+MARK_IN="%ted-eval"
+
+# ==========================================================
+# VARIABLES
+# ==========================================================
+
+STATUS=0
+TED_IN=""
+
+# ==========================================================
+# FUNCTIONS
+# ==========================================================
+
+show_help() {
+    cat <<EOF
+Usage:
+    $(basename "$0") [options] <hoon> [<dependency> ...]
+
+    Format a text representation of a Hoon noun for use as input to eval threads via conn.c
+
+    options:
+        -h  Show usage info
+        -k  Format for the 'khan-eval' thread instead
+EOF
+}
+
+# ==========================================================
+# MAIN
+# ==========================================================
+
+# reset getopts
+OPTIND=1
+
+# parse options
+while getopts ":hk" OPT; do
+    case "$OPT" in
+        k)
+            THREAD=$KHAN_TED
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            STATUS=1
+            ;&
+        h)
+            show_help
+            exit "$STATUS"
+            ;;
+  esac
+done
+
+# skip over opts after parsing
+shift $((OPTIND-1))
+
+# check for mandatory input
+if [[ $# -lt 1 ]]; then
+    echo "ERROR: no command" >&2
+    show_help
+    exit 1
+fi
+
+# setup input page
+if [[ $# -eq 1 ]]; then
+    TED_IN="[$MARK_IN '$1']"
+else
+    TED_IN="'$1'"
+    shift
+    TED_IN="[$MARK_IN [$TED_IN [$* ~]]]"
+fi
+
+# format command
+echo "[$RID $COMMAND [$DESK $THREAD $MARK_OUT $TED_IN]]"


### PR DESCRIPTION
Resolves #197 

**click** = **cli** for **c**onn.c & **K**han

I didn't know where it should live, so for now I put it into a `bin` folder in root Vere. Overview:
```
Usage:
    click [options] <path-to-pier> <hoon> [<dependencies> ...]
    click [options] -i <path-to-file> <path-to-pier> [<dependencies> ...]
    click [-o|-p] -e -i <path-to-file> <path-to-pier>

    Thin client for interacting with running Urbit ship via conn.c

    options:
        -e                  Execute jammed Hoon
        -h                  Show usage info
        -i <path-to-file>   Read input from file
        -j                  Jam only
        -k                  Execute command using "khan-eval" thread
        -o <path-to-file>   Output to file
        -p                  Filter failure stack traces from result and pretty-print them to stderr
        -x                  Jam to hex
```
Where:
- `-e` reuses a pre-jammed noun
- `-j` creates a pre-jammed noun
- `-k` calls the input Hoon using the "khan-eval" thread, which parses the Hoon as thread code and calls it from a child thread
- `-p` returns failed threads as just `%.n`, printing the stacktrace to `stderr` instead of returning it to click

Will add a commit with unit tests shortly. The following commands operate correctly:
```
./bin/click ~/Urbit/test-piers/zod '42'
./bin/click ~/Urbit/test-piers/zod $'(cat 3 \\\'abc\\\' \\\'def\\\')'
./bin/click ~/Urbit/test-piers/zod '(gad 2 2)' '/lib/gad/hoon'
./bin/click -k ~/Urbit/test-piers/zod $'=/  m  (strand ,vase)  ;<  ~  bind:m  (poke [~zod %hood] %helm-hi !>(\\\'\\\'))  (pure:m !>(\\\'success\\\'))'
./bin/click -k -p ~/Urbit/test-piers/zod $'=/  m  (strand ,vase)  ;<  vax=vase  bind:m  (eval-hoon [%zpzp ~] ~)  (pure:m !>(\\\'success\\\'))'

./bin/click -j ~/Urbit/test-piers/zod '42'
./bin/click -jx ~/Urbit/test-piers/zod '42'

./bin/click -o tmp.txt ~/Urbit/test-piers/zod '42'

./bin/click -i txt/cat.txt ~/Urbit/test-piers/zod
./bin/click -k -i txt/poke.txt ~/Urbit/test-piers/zod
./bin/click -k -j -i txt/poke.txt -o /tmp/poke.jam ~/Urbit/test-piers/zod && ./bin/click -e -i /tmp/poke.jam ~/Urbit/test-piers/zod
./bin/click -k -j -i txt/err.txt -o /tmp/err.jam ~/Urbit/test-piers/zod && ./bin/click -e -i /tmp/err.jam -p ~/Urbit/test-piers/zod
```