### PR TITLE
build: fix docker pace deploy

### DIFF
--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -77,7 +77,7 @@ genrule(
 
 genrule(
     name = "pace_tag",
-    srcs = ["PACE"],
+    srcs = ["//:PACE"],
     outs = ["docker_pace_tag"],
     cmd = """
     tr -d '\n' < $< > $@


### PR DESCRIPTION
Resolves [builds failing when attempting to tag release with pace on DockerHub](https://github.com/urbit/vere/actions/runs/4298049619/jobs/7491731178).

Can we please review this more carefully? I don't want this to be a repeat of #272. I'm also surprised that no one has commented on [every build on push to deploy failing for 10 days](https://github.com/urbit/vere/actions).

I genuinely don't know Bazel well. I'm attempting to implement the correct syntax using the existing files and Bazel docs as references, but I don't know that a PR is correct when I submit it, especially since it's impossible to test something like this locally.