### PR TITLE
unify memory printing functions

### DIFF
--- a/pkg/c3/util.c
+++ b/pkg/c3/util.c
@@ -1,0 +1,42 @@
+#include "util.h"
+
+c3_w
+_c3_printcap_mem_w(FILE *fil_u, c3_w wor_w, const c3_c *cap_c)
+{
+  return _c3_printcap_mem_z(fil_u, (c3_z)wor_w << 2, cap_c) >> 2;
+}
+
+c3_z
+_c3_printcap_mem_z(FILE *fil_u, c3_z byt_z, const c3_c *cap_c)
+{
+  c3_assert( 0 != fil_u );      /* ;;: I assume this is important from commit
+                                     f975ca908b143fb76c104ecc32cb59317ea5b198:
+                                     threads output file pointer through memory
+                                     marking and printing.
+
+                                    If not necessary, we can get rid of
+                                    c3_maid_w */
+
+  c3_z gib_z = (byt_z / (1 << 30));
+  c3_z mib_z = (byt_z % (1 << 30)) / (1 << 20);
+  c3_z kib_z = (byt_z % (1 << 20)) / (1 << 10);
+  c3_z bib_z = (byt_z % (1 << 10));
+
+  if ( gib_z ) {
+    fprintf(fil_u, "%s" "GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+            cap_c, gib_z, mib_z, kib_z, bib_z);
+  }
+  else if ( mib_z ) {
+    fprintf(fil_u, "%s" "MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+            cap_c, mib_z, kib_z, bib_z);
+  }
+  else if ( kib_z ) {
+    fprintf(fil_u, "%s" "KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
+            cap_c, kib_z, bib_z);
+  }
+  else {
+    fprintf(fil_u, "%s" "B/%" PRIc3_z "\r\n",
+            cap_c, bib_z);
+  }
+  return byt_z;
+}

--- a/pkg/c3/util.h
+++ b/pkg/c3/util.h
@@ -1,0 +1,82 @@
+#ifndef C3_UTIL_H
+#define C3_UTIL_H
+
+#include <stdio.h>
+
+#include "types.h"
+#include "defs.h"
+
+c3_w _c3_printcap_mem_w (FILE *fil_u, c3_w wor_w, const c3_c *cap_c);
+c3_z _c3_printcap_mem_z(FILE *fil_u, c3_z byt_z, const c3_c *cap_c);
+
+
+/*
+  c3_print_mem_w(
+      FILE * FILE  - file. must not be NULL,
+      c3_w   WOR   - size in words,
+    ? c3_c * q_CAP - caption,
+  )
+
+  Print word-sized quantity, WOR, in typical format:
+  [Caption: ][GiB|MiB|KiB|B]/QUANTITY
+*/
+#define   c3_print_mem_w( ... )                 \
+  c3_print_mem_w_0( __VA_ARGS__, "" )
+#define c3_print_mem_w_0( FILE, WOR, q_CAP, ... )       \
+  ((q_CAP[0])                                           \
+   ? _c3_printcap_mem_w((FILE), (WOR), q_CAP ": ")      \
+   : _c3_printcap_mem_w((FILE), (WOR), ""))
+
+
+/*
+  c3_print_mem_z(
+      FILE * FILE  - file. must not be NULL,
+      c3_w   BYT   - size in bytes,
+    ? c3_c * q_CAP - caption,
+  )
+
+  Print byte-sized quantity, BYT like c3_print_mem_w
+*/
+#define   c3_print_mem_z( ... )                 \
+  c3_print_mem_z_0( __VA_ARGS__, "" )
+#define c3_print_mem_z_0( FILE, BYT, q_CAP, ... )       \
+  ((q_CAP[0])                                           \
+   ? _c3_printcap_mem_z((FILE), (BYT), q_CAP ": ")      \
+   : _c3_printcap_mem_z((FILE), (BYT), ""))
+
+
+/*
+  c3_print_mem_w(
+      FILE * FILE  - file may be NULL,
+      c3_w   WOR   - size in words,
+    ? c3_c * q_CAP - caption,
+  )
+
+  Just like c3_print_mem_w with the exception that FILE may be null. In which
+  case, this is a NOP.
+*/
+#define   c3_maid_w( ... )                      \
+  c3_maid_w_0( __VA_ARGS__, "" )
+#define c3_maid_w_0( FILE, WOR, ... )           \
+  ((0 == (FILE))                                \
+   ? (WOR)                                      \
+   : c3_print_mem_w( FILE, WOR, __VA_ARGS__ ))
+
+
+/*
+  c3_print_memdiff_w(
+      FILE * FILE  - file,
+      c3_w   WOR0  - size in words,
+      c3_w   WOR1  - size in words,
+    ? c3_c * q_CAP - caption,
+  )
+
+  Prints absolute value of WOR0 - WOR1 using c3_print_mem_w
+*/
+#define c3_print_memdiff_w( ... )               \
+  c3_print_memdiff_w_0( __VA_ARGS__, "" )
+
+#define c3_print_memdiff_w_0( FILE, WOR0, WOR1, ... )   \
+  c3_print_mem_w(FILE, ((0+WOR0) > (0+WOR1) ? WOR0 - WOR1 : WOR1 - WOR0), __VA_ARGS__ )
+
+#endif /* ifndef C3_UTIL_H */

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1988,22 +1988,22 @@ u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
   c3_assert( 0 != fil_u );
 
   c3_z byt_z = ((c3_z)wor_w * 4);
-  c3_z gib_z = (byt_z / 1000000000);
-  c3_z mib_z = (byt_z % 1000000000) / 1000000;
-  c3_z kib_z = (byt_z % 1000000) / 1000;
-  c3_z bib_z = (byt_z % 1000);
+  c3_z gib_z = (byt_z / (1 << 30));
+  c3_z mib_z = (byt_z % (1 << 30)) / (1 << 20);
+  c3_z kib_z = (byt_z % (1 << 20)) / (1 << 10);
+  c3_z bib_z = (byt_z % (1 << 10));
 
   if ( byt_z ) {
     if ( gib_z ) {
-      fprintf(fil_u, "%s: GB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+      fprintf(fil_u, "%s: GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, gib_z, mib_z, kib_z, bib_z);
     }
     else if ( mib_z ) {
-      fprintf(fil_u, "%s: MB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+      fprintf(fil_u, "%s: MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, mib_z, kib_z, bib_z);
     }
     else if ( kib_z ) {
-      fprintf(fil_u, "%s: KB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
+      fprintf(fil_u, "%s: KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, kib_z, bib_z);
     }
     else if ( bib_z ) {

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -8,6 +8,7 @@
 #include "options.h"
 #include "retrieve.h"
 #include "trace.h"
+#include "util.h"
 #include "vortex.h"
 
 u3_road* u3a_Road;
@@ -1980,64 +1981,20 @@ u3a_print_time(c3_c* str_c, c3_c* cap_c, c3_d mic_d)
   }
 }
 
-/* u3a_print_memory: print memory amount.
-*/
-void
-u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
-{
-  c3_assert( 0 != fil_u );
-
-  c3_z byt_z = ((c3_z)wor_w * 4);
-  c3_z gib_z = (byt_z / (1 << 30));
-  c3_z mib_z = (byt_z % (1 << 30)) / (1 << 20);
-  c3_z kib_z = (byt_z % (1 << 20)) / (1 << 10);
-  c3_z bib_z = (byt_z % (1 << 10));
-
-  if ( byt_z ) {
-    if ( gib_z ) {
-      fprintf(fil_u, "%s: GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
-              cap_c, gib_z, mib_z, kib_z, bib_z);
-    }
-    else if ( mib_z ) {
-      fprintf(fil_u, "%s: MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
-              cap_c, mib_z, kib_z, bib_z);
-    }
-    else if ( kib_z ) {
-      fprintf(fil_u, "%s: KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
-              cap_c, kib_z, bib_z);
-    }
-    else if ( bib_z ) {
-      fprintf(fil_u, "%s: B/%" PRIc3_z "\r\n",
-              cap_c, bib_z);
-    }
-  }
-}
-
-/* u3a_maid(): maybe print memory.
-*/
-c3_w
-u3a_maid(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
-{
-  if ( 0 != fil_u ) {
-    u3a_print_memory(fil_u, cap_c, wor_w);
-  }
-  return wor_w;
-}
-
 /* u3a_mark_road(): mark ad-hoc persistent road structures.
 */
 c3_w
 u3a_mark_road(FILE* fil_u)
 {
   c3_w tot_w = 0;
-  tot_w += u3a_maid(fil_u, "  namespace", u3a_mark_noun(u3R->ski.gul));
-  tot_w += u3a_maid(fil_u, "  trace stack", u3a_mark_noun(u3R->bug.tax));
-  tot_w += u3a_maid(fil_u, "  trace buffer", u3a_mark_noun(u3R->bug.mer));
-  tot_w += u3a_maid(fil_u, "  profile batteries", u3a_mark_noun(u3R->pro.don));
-  tot_w += u3a_maid(fil_u, "  profile doss", u3a_mark_noun(u3R->pro.day));
-  tot_w += u3a_maid(fil_u, "  new profile trace", u3a_mark_noun(u3R->pro.trace));
-  tot_w += u3a_maid(fil_u, "  memoization cache", u3h_mark(u3R->cax.har_p));
-  return   u3a_maid(fil_u, "total road stuff", tot_w);
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(u3R->ski.gul), "  namespace");
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(u3R->bug.tax), "  trace stack");
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(u3R->bug.mer), "  trace buffer");
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(u3R->pro.don), "  profile batteries");
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(u3R->pro.day), "  profile doss");
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(u3R->pro.trace), "  new profile trace");
+  tot_w += c3_maid_w(fil_u, u3h_mark(u3R->cax.har_p), "  memoization cache");
+  return   c3_maid_w(fil_u, tot_w, "total road stuff");
 }
 
 /* u3a_reclaim(): clear ad-hoc persistent caches to reclaim memory.
@@ -2149,7 +2106,7 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_w eus_w, c3_w use_w)
     c3_free(cod_c);
   }
 
-  u3a_print_memory(stderr, "    size", box_u->siz_w);
+  c3_print_mem_w(stderr, box_u->siz_w, "    size");
 
   {
     c3_c* dat_c = _ca_print_box(box_u);
@@ -2169,7 +2126,7 @@ _ca_print_leak(c3_c* cap_c, u3a_box* box_u, c3_ws use_ws)
                   ((u3a_noun *)(u3a_boxto(box_u)))->mug_w,
                   use_ws);
 
-  u3a_print_memory(stderr, "    size", box_u->siz_w);
+  c3_print_mem_w(stderr, box_u->siz_w, "    size");
 
   {
     c3_c* dat_c = _ca_print_box(box_u);
@@ -2299,24 +2256,24 @@ u3a_sweep(void)
 
 #ifdef U3_CPU_DEBUG
     if ( (0 != u3R->par_p) && (u3R->all.max_w > 1000000) ) {
-      u3a_print_memory(stderr, "available", (tot_w - pos_w));
-      u3a_print_memory(stderr, "allocated", pos_w);
-      u3a_print_memory(stderr, "volatile", caf_w);
+      c3_print_mem_w(stderr, (tot_w - pos_w), "available");
+      c3_print_mem_w(stderr, pos_w, "allocated");
+      c3_print_mem_w(stderr, caf_w, "volatile");
 
-      u3a_print_memory(stderr, "maximum", u3R->all.max_w);
+      c3_print_mem_w(stderr, u3R->all.max_w, "maximum");
     }
 #endif
 
 #if 0
-    u3a_print_memory(stderr, "available", (tot_w - pos_w));
-    u3a_print_memory(stderr, "allocated", pos_w);
-    u3a_print_memory(stderr, "volatile", caf_w);
+    c3_print_mem_w(stderr, (tot_w - pos_w), "available");
+    c3_print_mem_w(stderr, pos_w, "allocated");
+    c3_print_mem_w(stderr, caf_w, "volatile");
 #endif
   }
 #endif
 
-  u3a_print_memory(stderr, "leaked", leq_w);
-  u3a_print_memory(stderr, "weaked", weq_w);
+  c3_print_mem_w(stderr, leq_w, "leaked");
+  c3_print_mem_w(stderr, weq_w, "weaked");
 
   c3_assert( (pos_w + leq_w + weq_w) == neg_w );
   c3_assert( (0 == leq_w) && (0 == weq_w) );

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -717,16 +717,6 @@
           void
           u3a_print_time(c3_c* str_c, c3_c* cap_c, c3_d mic_d);
 
-        /* u3a_print_memory(): print memory amount.
-        */
-          void
-          u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w);
-
-        /* u3a_maid(): maybe print memory.
-        */
-          c3_w
-          u3a_maid(FILE* fil_u, c3_c* cap_c, c3_w wor_w);
-
         /* u3a_deadbeef(): write 0xdeadbeef from hat to cap.
         */
           void

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -82,6 +82,7 @@
 #include "options.h"
 #include "retrieve.h"
 #include "types.h"
+#include "util.h"
 
 /// Snapshotting system.
 u3e_pool u3e_Pool;
@@ -1081,7 +1082,7 @@ u3e_save(void)
   /* attempt to avoid propagating anything insane to disk */
   u3a_loom_sane();
 
-  // u3a_print_memory(stderr, "sync: save", 4096 * pat_u->con_u->pgs_w);
+  // c3_print_mem_w(stderr, 4096 * pat_u->con_u->pgs_w, "sync: save");
 
   _ce_patch_sync(pat_u);
 
@@ -1197,8 +1198,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
         nuu_o = c3y;
       }
       else {
-        u3a_print_memory(stderr, "live: loaded",
-                         (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w) << u3a_page);
+        c3_print_mem_w(stderr, (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w) << u3a_page, "sync: save");
       }
     }
   }

--- a/pkg/noun/jets.c
+++ b/pkg/noun/jets.c
@@ -14,6 +14,7 @@
 #include "retrieve.h"
 #include "serial.h"
 #include "trace.h"
+#include "util.h"
 #include "urcrypt/urcrypt.h"
 #include "vortex.h"
 #include "xtract.h"
@@ -2319,22 +2320,22 @@ u3j_mark(FILE* fil_u)
 {
   c3_w tot_w = 0;
 
-  tot_w += u3a_maid(fil_u, "  warm jet state", u3h_mark(u3R->jed.war_p));
-  tot_w += u3a_maid(fil_u, "  cold jet state", u3h_mark(u3R->jed.cod_p));
-  tot_w += u3a_maid(fil_u, "  hank cache", u3h_mark(u3R->jed.han_p));
-  tot_w += u3a_maid(fil_u, "  battery hash cache", u3h_mark(u3R->jed.bas_p));
+  tot_w += c3_maid_w(fil_u, u3h_mark(u3R->jed.war_p), "  warm jet state");
+  tot_w += c3_maid_w(fil_u, u3h_mark(u3R->jed.cod_p), "  cold jet state");
+  tot_w += c3_maid_w(fil_u, u3h_mark(u3R->jed.han_p), "  hank cache");
+  tot_w += c3_maid_w(fil_u, u3h_mark(u3R->jed.bas_p), "  battery hash cache");
 
   {
     c3_w han_w = 0;
     u3h_walk_with(u3R->jed.han_p, _cj_mark_hank, &han_w);
-    tot_w += u3a_maid(fil_u, "  call site cache", han_w);
+    tot_w += c3_maid_w(fil_u, han_w, "  call site cache");
   }
 
   if ( u3R == &(u3H->rod_u) ) {
-    tot_w += u3a_maid(fil_u, "  hot jet state", u3h_mark(u3R->jed.hot_p));
+    tot_w += c3_maid_w(fil_u, u3h_mark(u3R->jed.hot_p), "  hot jet state");
   }
 
-  return u3a_maid(fil_u, "total jet stuff", tot_w);
+  return c3_maid_w(fil_u, tot_w, "total jet stuff");
 }
 
 /* _cj_free_hank(): free an entry from the hank cache.

--- a/pkg/noun/jets/e/jam.c
+++ b/pkg/noun/jets/e/jam.c
@@ -20,7 +20,7 @@ u3qe_jam(u3_atom a)
         u3l_log("item: B/0");
       }
       else {
-        u3a_print_memory(stderr, "item", siz_w);
+        c3_print_mem_w(stderr, siz_w, "item");
       }
     }
     if ( u3_blip != som ) {
@@ -31,11 +31,11 @@ u3qe_jam(u3_atom a)
     for ( som = u3t(a); c3y == u3du(som); som = u3t(som) ) u3a_discount_noun(u3h(som));
     u3h_discount(u3R->cax.har_p);
 
-    u3a_print_memory(stderr, "total", tot_w);
-    u3a_print_memory(stderr, "memoization cache", mem_w);
+    c3_print_mem_w(stderr, tot_w, "total");
+    c3_print_mem_w(stderr, mem_w, "memoization cache");
     u3h_root* har_u = u3to(u3h_root, u3R->cax.har_p);
     u3l_log("memoization entries: %d", har_u->use_w);
-		u3a_print_memory(stderr, "unused free", u3a_open(u3R));
+    c3_print_mem_w(stderr, u3a_open(u3R), "unused free");
     return tot_w;
   }
 #endif

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -21,6 +21,7 @@
 #include "retrieve.h"
 #include "trace.h"
 #include "urcrypt/urcrypt.h"
+#include "util.h"
 #include "vortex.h"
 #include "xtract.h"
 
@@ -885,13 +886,6 @@ u3m_leap(c3_w pad_w)
   _rod_vaal(u3R);
 }
 
-void
-_print_diff(c3_c* cap_c, c3_w a, c3_w b)
-{
-  c3_w diff = a<b ? b-a : a-b;
-  u3a_print_memory(stderr, cap_c, diff);
-}
-
 /* u3m_fall(): in u3R, return an inner road to its parent.
 */
 void
@@ -901,7 +895,7 @@ u3m_fall()
 
 #if 0
   /*  If you're printing a lot of these you need to change
-   *  u3a_print_memory from fprintf to u3l_log
+   *  c3_print_mem_w from fprintf to u3l_log
   */
   fprintf(stderr, "fall: from %s %p, to %s %p (cap 0x%x, was 0x%x)\r\n",
           _(u3a_is_north(u3R)) ? "north" : "south",
@@ -910,9 +904,9 @@ u3m_fall()
           u3to(u3_road, u3R->par_p),
           u3R->hat_p,
           u3R->rut_p);
-  _print_diff("unused free", u3R->hat_p, u3R->cap_p);
-  _print_diff("freeing", u3R->rut_p, u3R->hat_p);
-  _print_diff("stack", u3R->cap_p, u3R->mat_p);
+  c3_print_memdiff_w(stderr, u3R->hat_p, u3R->cap_p, "unused free");
+  c3_print_memdiff_w(stderr, u3R->rut_p, u3R->hat_p, "freeing");
+  c3_print_memdiff_w(stderr, u3R->cap_p, u3R->mat_p, "stack");
   static c3_w wat_w = 500000000;
   if (u3to(u3_road, u3R->par_p) == &u3H->rod_u) {
     wat_w = 500000000;
@@ -923,7 +917,7 @@ u3m_fall()
                      u3R->cap_p - u3R->hat_p :
                      u3R->hat_p - u3R->cap_p);
   }
-  u3a_print_memory(stderr, "low water mark", wat_w);
+  c3_print_mem_w(stderr, wat_w, "low water mark");
 
 #endif
 
@@ -1078,7 +1072,7 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
     if ( u3C.wag_w & u3o_debug_ram ) {
 #ifdef U3_CPU_DEBUG
       if ( u3R->all.max_w > 1000000 ) {
-        u3a_print_memory(stderr, "execute: top", u3R->all.max_w);
+        c3_print_mem_w(stderr, u3R->all.max_w, "execute: top");
       }
 #endif
       u3m_grab(pro, u3_none);
@@ -1175,7 +1169,7 @@ u3m_soft_run(u3_noun gul,
 
 #ifdef U3_CPU_DEBUG
     if ( u3R->all.max_w > 1000000 ) {
-      u3a_print_memory(stderr, "execute: run", u3R->all.max_w);
+      c3_print_mem_w(stderr, u3R->all.max_w, "execute: run");
     }
 #endif
 

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -12,6 +12,7 @@
 #include "options.h"
 #include "retrieve.h"
 #include "trace.h"
+#include "util.h"
 #include "vortex.h"
 #include "xtract.h"
 #include "zave.h"
@@ -3040,9 +3041,9 @@ u3n_mark(FILE* fil_u)
   u3p(u3h_root) har_p = u3R->byc.har_p;
   u3h_walk_with(har_p, _n_bam, &bam_w);
 
-  bam_w = u3a_maid(fil_u, "  bytecode programs", bam_w);
-  har_w = u3a_maid(fil_u, "  bytecode cache", u3h_mark(har_p));
-  return  u3a_maid(fil_u, "total nock stuff", bam_w + har_w);
+  bam_w = c3_maid_w(fil_u, bam_w, "  bytecode programs");
+  har_w = c3_maid_w(fil_u, u3h_mark(har_p), "  bytecode cache");
+  return  c3_maid_w(fil_u, bam_w + har_w, "total nock stuff");
 }
 
 /* u3n_reclaim(): clear ad-hoc persistent caches to reclaim memory.

--- a/pkg/noun/vortex.c
+++ b/pkg/noun/vortex.c
@@ -11,6 +11,7 @@
 #include "nock.h"
 #include "retrieve.h"
 #include "trace.h"
+#include "util.h"
 #include "xtract.h"
 
 #define _CVX_LOAD  4
@@ -348,10 +349,10 @@ u3v_mark(FILE* fil_u)
   u3v_arvo* arv_u = &(u3H->arv_u);
   c3_w tot_w = 0;
 
-  tot_w += u3a_maid(fil_u, "  kernel", u3a_mark_noun(arv_u->roc));
-  tot_w += u3a_maid(fil_u, "  date", u3a_mark_noun(arv_u->now));
-  tot_w += u3a_maid(fil_u, "  wish cache", u3a_mark_noun(arv_u->yot));
-  return   u3a_maid(fil_u, "total arvo stuff", tot_w);
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(arv_u->roc), "  kernel");
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(arv_u->now), "  date");
+  tot_w += c3_maid_w(fil_u, u3a_mark_noun(arv_u->yot), "  wish cache");
+  return   c3_maid_w(fil_u, tot_w, "total arvo stuff");
 }
 
 /* u3v_reclaim(): clear ad-hoc persistent caches to reclaim memory.

--- a/pkg/ur/BUILD.bazel
+++ b/pkg/ur/BUILD.bazel
@@ -17,7 +17,10 @@ cc_library(
     includes = ["."],
     linkstatic = True,
     visibility = ["//pkg:__subpackages__"],
-    deps = ["@murmur3"],
+    deps = [
+        "//pkg/c3",
+        "@murmur3",
+    ],
 )
 
 #

--- a/pkg/ur/hashcons.c
+++ b/pkg/ur/hashcons.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "defs.h"
+#include "util.h"
 #include "murmur3.h"
 
 //  declarations of inline functions
@@ -754,38 +755,11 @@ ur_cons(ur_root_t *r, ur_nref hed, ur_nref tal)
   }
 }
 
-static void
-_print_memory(FILE *f, const char *c, uint64_t bytes)
-{
-  if ( !bytes ) {
-    fprintf(f, "%s: B/0\r\n", c);
-  }
-  else {
-    uint64_t g = (bytes / (1 << 30));
-    uint64_t m = (bytes % (1 << 30)) / (1 << 20);
-    uint64_t k = (bytes % (1 << 20)) / (1 << 10);
-    uint64_t b = (bytes % (1 << 10));
-
-    if ( g ) {
-      fprintf(f, "%s: GiB/%z.%03z.%03z.%03z\r\n", c, g, m, k, b);
-    }
-    else if ( m ) {
-      fprintf(f, "%s: MiB/%z.%03z.%03z\r\n", c, m, k, b);
-    }
-    else if ( k ) {
-      fprintf(f, "%s: KiB/%z.%03z\r\n", c, k, b);
-    }
-    else if ( b ) {
-      fprintf(f, "%s: B/%z\r\n", c, b);
-    }
-  }
-}
-
 static uint64_t
 _dict_info(FILE *f, ur_dict_t *dict)
 {
   uint64_t data = dict->size * sizeof(*dict->buckets);
-  _print_memory(f, "    dict", data);
+  c3_print_mem_z(f, data, "    dict");
   return data;
 }
 
@@ -802,17 +776,17 @@ _atoms_info(FILE *f, ur_atoms_t *atoms)
 
   fprintf(f, "  atoms (%" PRIu64 "):\r\n", fill);
 
-  _print_memory(f, "    refs", refs);
+  c3_print_mem_z(f, refs, "    refs");
   total += refs;
 
   for ( i = 0; i < fill; i++ ) {
     data += atoms->lens[i];
   }
-  _print_memory(f, "    data", data);
+  c3_print_mem_z(f, data, "    data");
   total += data;
 
   total += _dict_info(f, &(atoms->dict));
-  _print_memory(f, "  total", total);
+  c3_print_mem_z(f, total, "  total");
   return total;
 }
 
@@ -828,11 +802,11 @@ _cells_info(FILE *f, ur_cells_t *cells)
 
   fprintf(f, "  cells (%" PRIu64 "):\r\n", fill);
 
-  _print_memory(f, "    refs", refs);
+  c3_print_mem_z(f, refs, "    refs");
   total += refs;
 
   total += _dict_info(f, &(cells->dict));
-  _print_memory(f, "  total", total);
+  c3_print_mem_z(f, total, "  total");
   return total;
 }
 
@@ -845,14 +819,14 @@ ur_root_info(FILE *f, ur_root_t *r)
 
   {
     uint64_t root = sizeof(*r);
-    _print_memory(f, "  root", root);
+    c3_print_mem_z(f, root, "  root");
     total += root;
   }
 
   total += _atoms_info(f, &(r->atoms));
   total += _cells_info(f, &(r->cells));
 
-  _print_memory(f, "total", total);
+  c3_print_mem_z(f, total, "total");
 }
 
 static void

--- a/pkg/ur/hashcons.c
+++ b/pkg/ur/hashcons.c
@@ -761,22 +761,22 @@ _print_memory(FILE *f, const char *c, uint64_t bytes)
     fprintf(f, "%s: B/0\r\n", c);
   }
   else {
-    uint32_t g = (bytes / 1000000000);
-    uint32_t m = (bytes % 1000000000) / 1000000;
-    uint32_t k = (bytes % 1000000) / 1000;
-    uint32_t b = (bytes % 1000);
+    uint64_t g = (bytes / (1 << 30));
+    uint64_t m = (bytes % (1 << 30)) / (1 << 20);
+    uint64_t k = (bytes % (1 << 20)) / (1 << 10);
+    uint64_t b = (bytes % (1 << 10));
 
     if ( g ) {
-      fprintf(f, "%s: GB/%d.%03d.%03d.%03d\r\n", c, g, m, k, b);
+      fprintf(f, "%s: GiB/%z.%03z.%03z.%03z\r\n", c, g, m, k, b);
     }
     else if ( m ) {
-      fprintf(f, "%s: MB/%d.%03d.%03d\r\n", c, m, k, b);
+      fprintf(f, "%s: MiB/%z.%03z.%03z\r\n", c, m, k, b);
     }
     else if ( k ) {
-      fprintf(f, "%s: KB/%d.%03d\r\n", c, k, b);
+      fprintf(f, "%s: KiB/%z.%03z\r\n", c, k, b);
     }
     else if ( b ) {
-      fprintf(f, "%s: B/%d\r\n", c, b);
+      fprintf(f, "%s: B/%z\r\n", c, b);
     }
   }
 }

--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -9,6 +9,7 @@
 #include "noun.h"
 #include "pace.h"
 #include "ur.h"
+#include "util.h"
 #include "uv.h"
 #include "version.h"
 
@@ -1635,8 +1636,8 @@ u3_king_grab(void* vod_p)
   tot_w += u3m_mark(fil_u);
   tot_w += u3_pier_mark(fil_u);
 
-  u3a_print_memory(fil_u, "total marked", tot_w);
-  u3a_print_memory(fil_u, "sweep", u3a_sweep());
+  c3_print_mem_w(fil_u, tot_w, "total marked");
+  c3_print_mem_w(fil_u, u3a_sweep(), "sweep");
 
 #ifdef U3_MEMORY_LOG
   {

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -20,6 +20,7 @@
 
 #include "ca_bundle.h"
 #include "pace.h"
+#include "util.h"
 #include "version.h"
 #include "whereami.h"
 
@@ -1713,7 +1714,7 @@ _cw_meld(c3_i argc, c3_c* argv[])
 
   pre_w = u3a_open(u3R);
   u3u_meld();
-  u3a_print_memory(stderr, "urbit: meld: gained", (u3a_open(u3R) - pre_w));
+  c3_print_mem_w(stderr, (u3a_open(u3R) - pre_w), "urbit: meld: gained");
 
   u3e_save();
   u3_disk_exit(log_u);
@@ -1833,7 +1834,7 @@ _cw_pack(c3_i argc, c3_c* argv[])
   u3_disk* log_u = _cw_disk_init(u3_Host.dir_c); // XX s/b try_aquire lock
 
   u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
-  u3a_print_memory(stderr, "urbit: pack: gained", u3m_pack());
+  c3_print_mem_w(stderr, u3m_pack(), "urbit: pack: gained");
 
   u3e_save();
   u3_disk_exit(log_u);

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -65,24 +65,25 @@ _serf_space(FILE* fil_u,  c3_w n)
 static void
 _serf_print_memory(FILE* fil_u, c3_w wor_w)
 {
-  c3_w byt_w = (wor_w * 4);
-  c3_w gib_w = (byt_w / 1000000000);
-  c3_w mib_w = (byt_w % 1000000000) / 1000000;
-  c3_w kib_w = (byt_w % 1000000) / 1000;
-  c3_w bib_w = (byt_w % 1000);
+  c3_z byt_z = ((c3_z)wor_w * 4);
+  c3_z gib_z = (byt_z / (1 << 30));
+  c3_z mib_z = (byt_z % (1 << 30)) / (1 << 20);
+  c3_z kib_z = (byt_z % (1 << 20)) / (1 << 10);
+  c3_z bib_z = (byt_z % (1 << 10));
 
-  if ( gib_w ) {
-    (fprintf(fil_u, "GB/%d.%03d.%03d.%03d\r\n",
-        gib_w, mib_w, kib_w, bib_w));
+
+  if ( gib_z ) {
+    (fprintf(fil_u, "GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+        gib_z, mib_z, kib_z, bib_z));
   }
-  else if ( mib_w ) {
-    (fprintf(fil_u, "MB/%d.%03d.%03d\r\n", mib_w, kib_w, bib_w));
+  else if ( mib_z ) {
+    (fprintf(fil_u, "MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n", mib_z, kib_z, bib_z));
   }
-  else if ( kib_w ) {
-    (fprintf(fil_u, "KB/%d.%03d\r\n", kib_w, bib_w));
+  else if ( kib_z ) {
+    (fprintf(fil_u, "KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n", kib_z, bib_z));
   }
   else {
-    (fprintf(fil_u, "B/%d\r\n", bib_w));
+    (fprintf(fil_u, "B/%" PRIc3_z "\r\n", bib_z));
   }
 }
 

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -1,7 +1,7 @@
 /// @file
 
 #include "noun.h"
-
+#include "util.h"               /* ;;:can we make it so that file directories prefix the header? */
 #include "vere.h"
 
 /*
@@ -58,35 +58,6 @@ _serf_space(FILE* fil_u,  c3_w n)
     (fprintf(fil_u," "));
 }
 
-/* _serf_print_memory(): print memory amount.
-**
-**  Helper for _serf_prof(), just an un-captioned u3a_print_memory().
-*/
-static void
-_serf_print_memory(FILE* fil_u, c3_w wor_w)
-{
-  c3_z byt_z = ((c3_z)wor_w * 4);
-  c3_z gib_z = (byt_z / (1 << 30));
-  c3_z mib_z = (byt_z % (1 << 30)) / (1 << 20);
-  c3_z kib_z = (byt_z % (1 << 20)) / (1 << 10);
-  c3_z bib_z = (byt_z % (1 << 10));
-
-
-  if ( gib_z ) {
-    (fprintf(fil_u, "GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
-        gib_z, mib_z, kib_z, bib_z));
-  }
-  else if ( mib_z ) {
-    (fprintf(fil_u, "MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n", mib_z, kib_z, bib_z));
-  }
-  else if ( kib_z ) {
-    (fprintf(fil_u, "KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n", kib_z, bib_z));
-  }
-  else {
-    (fprintf(fil_u, "B/%" PRIc3_z "\r\n", bib_z));
-  }
-}
-
 /* _serf_prof(): print memory profile. RETAIN.
 */
 c3_w
@@ -127,7 +98,7 @@ _serf_prof(FILE* fil_u, c3_w den, u3_noun mas)
     }
     else if ( c3y == it_mas ) {
       tot_w += u3a_mark_noun(tt_mas);
-      _serf_print_memory(fil_u, tot_w);
+      c3_print_mem_w(fil_u, tot_w);
 
 #if 1
       /* The basic issue here is that tt_mas is included in .sac
@@ -168,7 +139,7 @@ _serf_prof(FILE* fil_u, c3_w den, u3_noun mas)
 
       _serf_space(fil_u, den);
       fprintf(fil_u, "--");
-      _serf_print_memory(fil_u, tot_w);
+      c3_print_mem_w(fil_u, tot_w);
 
       return tot_w;
 
@@ -226,13 +197,13 @@ _serf_grab(u3_noun sac)
     c3_assert( u3R == &(u3H->rod_u) );
     fprintf(fil_u, "\r\n");
 
-    tot_w += u3a_maid(fil_u, "total userspace", _serf_prof(fil_u, 0, sac));
+    tot_w += c3_maid_w(fil_u, _serf_prof(fil_u, 0, sac), "total userspace");
     tot_w += u3m_mark(fil_u);
-    tot_w += u3a_maid(fil_u, "space profile", u3a_mark_noun(sac));
+    tot_w += c3_maid_w(fil_u, u3a_mark_noun(sac), "space profile");
 
-    u3a_print_memory(fil_u, "total marked", tot_w);
-    u3a_print_memory(fil_u, "free lists", u3a_idle(u3R));
-    u3a_print_memory(fil_u, "sweep", u3a_sweep());
+    c3_print_mem_w(fil_u, tot_w, "total marked");
+    c3_print_mem_w(fil_u, u3a_idle(u3R), "free lists");
+    c3_print_mem_w(fil_u, u3a_sweep(), "sweep");
 
     fflush(fil_u);
 
@@ -290,9 +261,9 @@ u3_serf_grab(void)
     _serf_grab(sac);
   }
   else {
-    u3a_print_memory(stderr, "total marked", u3m_mark(stderr));
-    u3a_print_memory(stderr, "free lists", u3a_idle(u3R));
-    u3a_print_memory(stderr, "sweep", u3a_sweep());
+    c3_print_mem_w(stderr, u3m_mark(stderr), "total marked");
+    c3_print_mem_w(stderr, u3a_idle(u3R), "free lists");
+    c3_print_mem_w(stderr, u3a_sweep(), "sweep");
     fprintf(stderr, "\r\n");
   }
 
@@ -318,7 +289,7 @@ u3_serf_post(u3_serf* sef_u)
   }
 
   if ( c3y == sef_u->pac_o ) {
-    u3a_print_memory(stderr, "serf: pack: gained", u3m_pack());
+    c3_print_mem_w(stderr, u3m_pack(), "serf: pack: gained");
     u3l_log("");
     sef_u->pac_o = c3n;
   }
@@ -969,7 +940,7 @@ u3_serf_live(u3_serf* sef_u, u3_noun com, u3_noun* ret)
       }
       else {
         u3z(com);
-        u3a_print_memory(stderr, "serf: pack: gained", u3m_pack());
+        c3_print_mem_w(stderr, u3m_pack(), "serf: pack: gained");
         *ret = u3nc(c3__live, u3_nul);
         return c3y;
       }
@@ -1120,7 +1091,7 @@ u3_serf_init(u3_serf* sef_u)
 
   //   if ( !(pen_w > (1 << 28)) ) {
   //     fprintf(stderr, "\r\n");
-  //     u3a_print_memory(stderr, "serf: contiguous free space", pen_w);
+  //     c3_print_mem_w(stderr, pen_w, "serf: contiguous free space");
   //     u3_serf_grab();
   //   }
   // }


### PR DESCRIPTION
Resolves #310 

Minimally, I think we should keep the first commit (converting to base 2).

Wondering if the attempt to unify the interfaces/refactor was a waste of time though given how adhoc all the memory printing stuff feels -- so why improve it :-/

It does appear to work well though. Compare output of `|mass`, `|pack`, others that print memory, etc.

```
~zod:dojo> |mass
%arvo: 
  %hoon: 
    %one: KiB/24.456
    %two: KiB/188.688
    %tri: KiB/274.624
    %qua: KiB/668.560
    %pen: MiB/3.277.464
  --MiB/4.409.744
  %hex: KiB/574.304
  %pit: B/168
  %lull: 
    %dot: MiB/1.918.864
    %typ: B/144
  --MiB/1.918.1008
  %zuse: 
    %dot: KiB/883.624
    %typ: KiB/700.680
  --MiB/1.560.280
  %vane: 
    %ames: 
      %peers-known: B/0
      %peers-alien: B/0
      %dot: MiB/3.055.096
      %typ: KiB/25.152
      %sac: KiB/201.864
    --MiB/3.282.088
    %behn: 
      %timers: B/0
> |mass
>=
kick: lost %mass on /arvo
~zod:dojo> KiB/269.944
      %typ: KiB/4.752
      %sac: KiB/42.168
    --KiB/316.840
    %clay: 
      %object-store: 
        %commits: KiB/83.640
        %pages: MiB/3.261.760
      --MiB/3.345.376
      %domestic: 
        %base: 
          %mime: B/0
          %flue: MiB/25.792.984
          %dojo: B/384
        --MiB/25.793.344
        %kids: 
          %mime: B/0
          %flue: KiB/80.856
          %dojo: B/456
        --KiB/81.288
      --MiB/25.874.632
      %foreign: B/0
      %ford-cache: KiB/48.960
      %dot: MiB/1.579.472
      %typ: KiB/8.400
      %sac: KiB/751.776
    --MiB/31.560.544
    %dill: 
      %hey: B/72
      %dug: B/120
      %dot: B/456
      %typ: KiB/5.664
      %sac: KiB/138.120
    --KiB/144.408
    %eyre: 
      %bindings: KiB/1.840
      %auth: B/0
      %connections: B/0
      %channels: B/0
      %axle: B/512
      %dot: MiB/1.1010.104
      %typ: KiB/3.192
      %sac: KiB/69.480
    --MiB/2.061.080
    %gall: 
      %foreign: B/0
      %blocked: 
      --B/0
      %active: 
        %acme: KiB/1.168
        %azimuth: B/976
        %dbug: B/976
        %dojo: KiB/1.856
        %eth-watcher: B/976
        %herm: B/976
        %hood: KiB/2.920
        %lens: B/808
        %ping: B/928
        %spider: KiB/1.024
      --KiB/12.440
      %dot: MiB/1.855.176
      %typ: KiB/3.216
      %sac: KiB/47.952
    --MiB/1.918.760
    %iris: 
      %nex: B/0
      %outbound: B/160
      %by-id: B/0
      %by-duct: B/0
      %axle: B/136
      %dot: KiB/113.208
      %typ: KiB/79.816
      %sac: KiB/15.336
    --KiB/208.632
    %jael: 
      %pki: B/944
      %etn: B/24
      %dot: KiB/974.632
      %typ: KiB/4.224
      %sac: KiB/32.520
    --KiB/1012.296
    %khan: 
      %dot: KiB/94.936
      %typ: KiB/70.368
      %sac: KiB/16.800
    --KiB/182.056
  --MiB/40.614.632
--MiB/49.006.064
total userspace: MiB/49.006.064
  kernel: KiB/13.424
  date: B/0
  wish cache: B/0
total arvo stuff: KiB/13.424
  warm jet state: KiB/67.448
  cold jet state: KiB/47.664
  hank cache: B/552
  battery hash cache: B/288
  call site cache: B/312
  hot jet state: KiB/188.608
total jet stuff: KiB/304.824
  bytecode programs: MiB/2.225.792
  bytecode cache: KiB/290.504
total nock stuff: MiB/2.516.272
  namespace: B/0
  trace stack: B/0
  trace buffer: B/88
  profile batteries: B/0
  profile doss: B/0
  new profile trace: B/0
  memoization cache: B/288
total road stuff: B/376
space profile: KiB/6.744
total marked: MiB/51.847.656
free lists: MiB/1.427.696
leaked: B/0
weaked: B/0
sweep: MiB/51.847.656
```