### PR TITLE
Command Line Option to set the time between snapshots

### DIFF
--- a/docker/start_urbit.sh
+++ b/docker/start_urbit.sh
@@ -49,7 +49,7 @@ if [ -e *.key ]; then
   mv $keyname /tmp
 
   # Boot urbit with the key, exit when done booting
-  urbit $ttyflag -w $(basename $keyname .key) -k /tmp/$keyname -c $(basename $keyname .key) -p $amesPort -x --http-port $httpPort --loom $loom
+  urbit $ttyflag -w $(basename $keyname .key) -k /tmp/$keyname -c $(basename $keyname .key) -p $amesPort -x --http-port $httpPort --loom $loom --snap-time $snap
 
   # Remove the keyfile for security
   rm /tmp/$keyname
@@ -61,11 +61,11 @@ elif [ -e *.comet ]; then
   rm *.comet
 
   urbit $ttyflag -c $(basename $cometname .comet) -p $amesPort -x --http-port $httpPort --loom $loom
-fi
+fi --snap-time $snap
 
 # Find the first directory and start urbit with the ship therein
 dirnames="*/"
 dirs=( $dirnames )
 dirname=''${dirnames[0]}
 
-exec urbit $ttyflag -p $amesPort --http-port $httpPort --loom $loom $dirname
+exec urbit $ttyflag -p $amesPort --http-port $httpPort --loom $loom $dirname --snap-time $snap

--- a/docker/start_urbit.sh
+++ b/docker/start_urbit.sh
@@ -6,6 +6,7 @@ set -eu
 amesPort="34343"
 httpPort="80"
 loom="31"
+snap="2"
 
 # check args
 for i in "$@"
@@ -21,6 +22,10 @@ case $i in
       ;;
   --loom=*)
       loom="${i#*=}"
+      shift
+      ;;
+  --snap-time=*)
+      snap="${i#*=}"
       shift
       ;;
 esac

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -309,7 +309,9 @@ _main_getopt(c3_i argc, c3_c** argv)
         break;
       }
       case c3__snap: {
-        u3_Host.ops_u.sap_w = _main_readw(optarg, 65536, &arg_w) *60.0;
+        if ( c3n == _main_readw(optarg, 65536, &arg_w) ) {
+          return c3n;
+        } else u3_Host.ops_u.sap_w = arg_w*60;
         break;
       }
       //  opts with args

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -312,7 +312,7 @@ _main_getopt(c3_i argc, c3_c** argv)
         if ( c3n == _main_readw(optarg, 65536, &arg_w) ) {
           return c3n;
         } else {
-          u3_Host.ops_u.sap_w = arg_w*60;
+          u3_Host.ops_u.sap_w = arg_w * 60;
           if ( 0 == u3_Host.ops_u.sap_w) 
             return c3n;
         }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -181,6 +181,7 @@ _main_init(void)
   u3_Host.ops_u.hap_w = 50000;
   u3_Host.ops_u.kno_w = DefaultKernel;
 
+  u3_Host.ops_u.sap_w = 120;    /* aka 2 minutes */
   u3_Host.ops_u.lut_y = 31;     /* aka 2G */
   u3_Host.ops_u.lom_y = 31;
 }
@@ -244,6 +245,7 @@ _main_getopt(c3_i argc, c3_c** argv)
     { "ames-port",           required_argument, NULL, 'p' },
     { "http-port",           required_argument, NULL, c3__http },
     { "https-port",          required_argument, NULL, c3__htls },
+    { "snap-time",           required_argument, NULL, c3__snap },
     { "no-conn",             no_argument,       NULL, c3__noco },
     { "no-dock",             no_argument,       NULL, c3__nodo },
     { "quiet",               no_argument,       NULL, 'q' },
@@ -304,6 +306,10 @@ _main_getopt(c3_i argc, c3_c** argv)
       }
       case c3__nodo: {
         u3_Host.ops_u.doc = c3n;
+        break;
+      }
+      case c3__snap: {
+        u3_Host.ops_u.sap_w = _main_readw(optarg, 65536, &arg_w) *60.0;
         break;
       }
       //  opts with args
@@ -727,6 +733,7 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "-p, --ames-port PORT          Set the ames port to bind to\n",
     "    --http-port PORT          Set the http port to bind to\n",
     "    --https-port PORT         Set the https port to bind to\n",
+    "    --snap-time TIME          Set the snapshotting rate in minutes\n",
     "-q, --quiet                   Quiet\n",
     "-R, --versions                Report urbit build info\n",
     "-r, --replay-from NUMBER      Load snapshot from event\n",

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -311,7 +311,11 @@ _main_getopt(c3_i argc, c3_c** argv)
       case c3__snap: {
         if ( c3n == _main_readw(optarg, 65536, &arg_w) ) {
           return c3n;
-        } else u3_Host.ops_u.sap_w = arg_w*60;
+        } else {
+          u3_Host.ops_u.sap_w = arg_w*60;
+          if ( 0 == u3_Host.ops_u.sap_w) 
+            return c3n;
+        }
         break;
       }
       //  opts with args
@@ -735,7 +739,7 @@ u3_ve_usage(c3_i argc, c3_c** argv)
     "-p, --ames-port PORT          Set the ames port to bind to\n",
     "    --http-port PORT          Set the http port to bind to\n",
     "    --https-port PORT         Set the https port to bind to\n",
-    "    --snap-time TIME          Set the snapshotting rate in minutes\n",
+    "    --snap-time TIME          Set the snapshotting rate in minutes (> 0)\n",
     "-q, --quiet                   Quiet\n",
     "-R, --versions                Report urbit build info\n",
     "-r, --replay-from NUMBER      Load snapshot from event\n",

--- a/pkg/vere/save.c
+++ b/pkg/vere/save.c
@@ -49,7 +49,7 @@ u3_save_io_init(u3_pier *pir_u)
 
   sav_u->tim_u.data = pir_u;
   uv_timer_init(u3L, &sav_u->tim_u);
-  uv_timer_start(&sav_u->tim_u, _save_time_cb, 120000, 120000);
+  uv_timer_start(&sav_u->tim_u, _save_time_cb, u3_Host.ops_u.sap_w*1000, u3_Host.ops_u.sap_w*1000);
 }
 
 /* u3_save_io_exit(): terminate save I/O.

--- a/pkg/vere/save.c
+++ b/pkg/vere/save.c
@@ -49,7 +49,8 @@ u3_save_io_init(u3_pier *pir_u)
 
   sav_u->tim_u.data = pir_u;
   uv_timer_init(u3L, &sav_u->tim_u);
-  uv_timer_start(&sav_u->tim_u, _save_time_cb, u3_Host.ops_u.sap_w*1000, u3_Host.ops_u.sap_w*1000);
+  uv_timer_start(&sav_u->tim_u, _save_time_cb, u3_Host.ops_u.sap_w * 1000,
+      u3_Host.ops_u.sap_w * 1000);
 }
 
 /* u3_save_io_exit(): terminate save I/O.

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -287,6 +287,7 @@
         c3_s    per_s;                      //      http port
         c3_s    pes_s;                      //      https port
         c3_s    por_s;                      //  -p, ames port
+        c3_w    sap_w;                      //      Snapshot timer legth (seconds)
         c3_o    qui;                        //  -q, quiet
         c3_o    rep;                        //  -R, report build info
         c3_c*   roc_c;                      //  -r, load rock by eve_d


### PR DESCRIPTION
This PR adds a command line option that allows the user to set the time in minutes between snapshots. This helps resolve the issues discussed in https://github.com/urbit/urbit/issues/4150. 

By allowing the user to set the time between shapshots it lets them decide how long they want to possibly wait to replay events. This also may allow urbit to run on an SD Card (which has ~10,000 write cycles.); reducing the cost to home host. 
