### PR TITLE
Move auto-docking to the start of the boot process

### DIFF
--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -791,6 +791,14 @@ void
 _boothack_cb(uv_timer_t* tim_u)
 {
   _king_doom(_boothack_doom());
+
+  //  copy binary into pier on boot
+  //
+  if ( (c3y == u3_Host.ops_u.nuu)
+     && (c3y == u3_Host.ops_u.doc) )
+  {
+    u3_king_dock(U3_VERE_PACE);
+  }
 }
 
 /* _king_loop_init(): stuff that comes before the event loop
@@ -1542,17 +1550,6 @@ u3_king_done(void)
     }
     else if ( c3y == u3_Host.play_o ) {
       u3l_log("vere: replay succeeded");
-    }
-
-    //  copy binary into pier on boot
-    //
-    if (  (c3y == u3_Host.ops_u.nuu)
-       && (c3y == u3_Host.ops_u.doc) )
-    {
-      //  hack to ensure we only try once
-      //
-      u3_Host.ops_u.nuu = c3n;
-      u3_king_dock(U3_VERE_PACE);
     }
   }
 


### PR DESCRIPTION
Resolves #278 

I moved docking from `u3_king_done` to `_boothack_cb` to make sure ship is always docker by default.

There are some unknowns:

- Should it happen before or after `_king_doom`?
- I removed the "hack", as I believe `_boothack_cb` will only be called once. Is that okay?
