### PR TITLE
ci: run fake ship tests under gc

### DIFF
--- a/pkg/vere/BUILD.bazel
+++ b/pkg/vere/BUILD.bazel
@@ -332,7 +332,7 @@ genrule(
 
     set -x
 
-    $(execpath :urbit) --lite-boot --daemon ./pier 2> urbit-output
+    $(execpath :urbit) --lite-boot --daemon --gc ./pier 2> urbit-output
 
     port=$$(grep loopback ./pier/.http.ports | awk -F ' ' '{print $$1}')
 


### PR DESCRIPTION
Adds `--gc` to the boot phase of the fake ship tests as the binary we build for them already uses the correct `copts`.

Resolves #332.