### PR TITLE
docker: use build cache; fix failing flow

### DIFF
--- a/.github/workflows/docker-shared.yml
+++ b/.github/workflows/docker-shared.yml
@@ -16,6 +16,34 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      #
+      # BUILD OR READ FROM CACHE
+      #
+
+      - name: chown /usr/local
+        run: |
+          # See https://github.com/actions/cache/issues/845.
+          sudo chown $(whoami) /usr/local && (chown -R $USER /usr/local/*-musl || true)
+
+      - name: Set up build cache
+        id: build-cache
+        uses: actions/cache@v3
+        with:
+          key: linux-x86_64-cache
+          path: |
+            # # Cache bazel path on Linux.
+            ~/.cache/bazel/_bazel_$(whoami)
+            # Cache musl libc toolchains.
+            /usr/local/*-musl
+
+      - name: Install toolchains
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: bazel run //bazel/toolchain:x86_64-linux-musl-gcc
+
+      #
+      # UPLOAD TO DOCKER
+      #
+
       - uses: docker/docker-login-action@v1.8.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Resolves failing GitHub build action

Tested [here](https://github.com/urbit/vere/actions/runs/4669925658/jobs/8269011549)