### PR TITLE
Replace `c3_assert()` with `u3_assert()` or `exit()`

### DIFF
--- a/pkg/c3/defs.h
+++ b/pkg/c3/defs.h
@@ -21,34 +21,6 @@
 
   /** Random useful C macros.
   **/
-    /* Assert.  Good to capture.
-
-       TODO: determine which c3_assert calls can rather call c3_dessert, i.e. in
-       public releases, which calls to c3_assert should abort and which should
-       no-op? If the latter, is the assert useful inter-development to validate
-       conditions we might accidentally break or not useful at all?
-    */
-
-#     if defined(ASAN_ENABLED) && defined(__clang__)
-#       define c3_assert(x)                       \
-          do {                                    \
-            if (!(x)) {                           \
-              assert(x);                          \
-            }                                     \
-          } while(0)
-#     else
-#       define c3_assert(x)                       \
-          do {                                    \
-            if (!(x)) {                           \
-              fflush(stderr);                     \
-              fprintf(stderr, "\rAssertion '%s' " \
-                      "failed in %s:%d\r\n",      \
-                      #x, __FILE__, __LINE__);    \
-              assert(x);                          \
-            }                                     \
-          } while(0)
-#endif
-
     /* Dessert. Debug assert. If a debugger is attached, it will break in and
        execution can be allowed to proceed without aborting the process.
        Otherwise, the unhandled SIGTRAP will dump core.
@@ -68,10 +40,6 @@
 #else
   #define c3_dessert(x) ((void)(0))
 #endif
-
-    /* Stub.
-    */
-#     define c3_stub       c3_assert(!"stub")
 
     /* Size in words.
     */
@@ -137,7 +105,7 @@
         if ( 0 == rut ) {                                       \
           fprintf(stderr, "c3_malloc(%" PRIu64 ") failed\r\n",  \
                           (c3_d)s);                             \
-          c3_assert(!"memory lost");                            \
+          exit(ENOMEM);                                         \
         }                                                       \
         rut;})
 #     define c3_calloc(s) ({                                    \
@@ -145,7 +113,7 @@
         if ( 0 == rut ) {                                       \
           fprintf(stderr, "c3_calloc(%" PRIu64 ") failed\r\n",  \
                           (c3_d)s);                             \
-          c3_assert(!"memory lost");                            \
+          exit(ENOMEM);                                         \
         }                                                       \
         rut;})
 #     define c3_realloc(a, b) ({                                \
@@ -153,7 +121,7 @@
         if ( 0 == rut ) {                                       \
           fprintf(stderr, "c3_realloc(%" PRIu64 ") failed\r\n", \
                           (c3_d)b);                             \
-          c3_assert(!"memory lost");                            \
+          exit(ENOMEM);                                         \
         }                                                       \
         rut;})
 

--- a/pkg/ent/tests.c
+++ b/pkg/ent/tests.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,8 +9,9 @@ int main(void) {
     char buf[256] = {0};
 
     if (0 != ent_getentropy(buf, sizeof(buf))) {
+        int errno_ = errno;
         perror("getentropy");
-        exit(1);
+        exit(errno_);
     }
 
     for (int i = 0; i < sizeof buf; i++) {

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -2,6 +2,7 @@
 
 #include "allocate.h"
 
+#include "error.h"
 #include "hashtable.h"
 #include "log.h"
 #include "manage.h"
@@ -111,7 +112,7 @@ _box_make(void* box_v, c3_w siz_w, c3_w use_w)
   u3a_box* box_u = box_v;
   c3_w*    box_w = box_v;
 
-  c3_assert(siz_w >= u3a_minimum);
+  u3_assert(siz_w >= u3a_minimum);
 
   box_u->siz_w = siz_w;
   box_w[siz_w - 1] = siz_w;     /* stor size at end of allocation as well */
@@ -132,8 +133,8 @@ _box_make(void* box_v, c3_w siz_w, c3_w use_w)
 static void
 _box_attach(u3a_box* box_u)
 {
-  c3_assert(box_u->siz_w >= (1 + c3_wiseof(u3a_fbox)));
-  c3_assert(0 != u3of(u3a_fbox, box_u));
+  u3_assert(box_u->siz_w >= (1 + c3_wiseof(u3a_fbox)));
+  u3_assert(0 != u3of(u3a_fbox, box_u));
 
 #if 0
   //  For debugging, fill the box with beef.
@@ -176,13 +177,15 @@ _box_detach(u3a_box* box_u)
 
   if ( nex_p ) {
     if ( u3to(u3a_fbox, nex_p)->pre_p != fre_p ) {
-      c3_assert(!"loom: corrupt");
+      fprintf(stderr, "loom: corrupt\r\n");
+      exit(ENOTRECOVERABLE);
     }
     u3to(u3a_fbox, nex_p)->pre_p = pre_p;
   }
   if ( pre_p ) {
     if( u3to(u3a_fbox, pre_p)->nex_p != fre_p ) {
-      c3_assert(!"loom: corrupt");
+      fprintf(stderr, "loom: corrupt\r\n");
+      exit(ENOTRECOVERABLE);
     }
     u3to(u3a_fbox, pre_p)->nex_p = nex_p;
   }
@@ -190,7 +193,8 @@ _box_detach(u3a_box* box_u)
     c3_w sel_w = _box_slot(box_u->siz_w);
 
     if ( fre_p != u3R->all.fre_p[sel_w] ) {
-      c3_assert(!"loom: corrupt");
+      fprintf(stderr, "loom: corrupt\r\n");
+      exit(ENOTRECOVERABLE);
     }
     u3R->all.fre_p[sel_w] = nex_p;
   }
@@ -203,7 +207,7 @@ _box_free(u3a_box* box_u)
 {
   c3_w* box_w = (c3_w *)(void *)box_u;
 
-  c3_assert(box_u->use_w != 0);
+  u3_assert(box_u->use_w != 0);
   box_u->use_w -= 1;
   if ( 0 != box_u->use_w ) {
     return;
@@ -378,13 +382,13 @@ u3a_sane(void)
 
     while ( fre_u ) {
       if ( fre_u == u3R->all.fre_u[i_w] ) {
-        c3_assert(fre_u->pre_u == 0);
+        u3_assert(fre_u->pre_u == 0);
       }
       else {
-        c3_assert(fre_u->pre_u != 0);
-        c3_assert(fre_u->pre_u->nex_u == fre_u);
+        u3_assert(fre_u->pre_u != 0);
+        u3_assert(fre_u->pre_u->nex_u == fre_u);
         if ( fre_u->nex_u != 0 ) {
-          c3_assert(fre_u->nex_u->pre_u == fre_u);
+          u3_assert(fre_u->nex_u->pre_u == fre_u);
         }
       }
       fre_u = fre_u->nex_u;
@@ -536,14 +540,16 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w off_w)
                  (u3to(u3a_fbox, u3to(u3a_fbox, *pfr_p)->pre_p)->nex_p
                     != (*pfr_p)) )
             {                   /* this->pre->nex isn't this */
-              c3_assert(!"loom: corrupt");
+              fprintf(stderr, "loom: corrupt\r\n");
+              exit(ENOTRECOVERABLE);
             }
 
             if( (0 != u3to(u3a_fbox, *pfr_p)->nex_p) &&
                 (u3to(u3a_fbox, u3to(u3a_fbox, *pfr_p)->nex_p)->pre_p
                    != (*pfr_p)) )
             {                   /* this->nex->pre isn't this */
-              c3_assert(!"loom: corrupt");
+              fprintf(stderr, "loom: corrupt\r\n");
+              exit(ENOTRECOVERABLE);
             }
 
             /* pop the block */
@@ -575,7 +581,7 @@ _ca_willoc(c3_w len_w, c3_w ald_w, c3_w off_w)
             return u3a_boxto(_box_make(box_w, des_w, 1));
           }
           else {
-            c3_assert(0 == box_u->use_w);
+            u3_assert(0 == box_u->use_w);
             box_u->use_w = 1;
 
 #ifdef      U3_MEMORY_DEBUG
@@ -738,7 +744,7 @@ u3a_calloc(size_t num_i, size_t len_i)
   size_t byt_i = num_i * len_i;
   c3_w* out_w;
 
-  c3_assert(byt_i / len_i == num_i);
+  u3_assert(byt_i / len_i == num_i);
   out_w = u3a_malloc(byt_i);
   memset(out_w, 0, byt_i);
 
@@ -981,8 +987,8 @@ _me_wash_north_in(u3_noun som)
 static void
 _me_wash_north(u3_noun dog)
 {
-  c3_assert(c3y == u3a_is_dog(dog));
-  // c3_assert(c3y == u3a_north_is_junior(u3R, dog));
+  u3_assert(c3y == u3a_is_dog(dog));
+  // u3_assert(c3y == u3a_north_is_junior(u3R, dog));
   {
     u3a_noun* dog_u = u3a_to_ptr(dog);
 
@@ -1014,8 +1020,8 @@ _me_wash_south_in(u3_noun som)
 static void
 _me_wash_south(u3_noun dog)
 {
-  c3_assert(c3y == u3a_is_dog(dog));
-  // c3_assert(c3y == u3a_south_is_junior(u3R, dog));
+  u3_assert(c3y == u3a_is_dog(dog));
+  // u3_assert(c3y == u3a_south_is_junior(u3R, dog));
   {
     u3a_noun* dog_u = u3a_to_ptr(dog);
 
@@ -1185,7 +1191,7 @@ _ca_take_next_north(u3a_pile* pil_u, u3_noun veb)
       if ( veb_u->mug_w >> 31 ) {
         u3_noun nov = (u3_noun)veb_u->mug_w;
 
-        c3_assert( c3y == u3a_north_is_normal(u3R, nov) );
+        u3_assert(c3y == u3a_north_is_normal(u3R, nov));
 
 #ifdef VERBOSE_TAKE
         u3l_log("north: %p is already %p", veb_u, u3a_to_ptr(nov));
@@ -1240,7 +1246,7 @@ _ca_take_next_south(u3a_pile* pil_u, u3_noun veb)
       if ( veb_u->mug_w >> 31 ) {
         u3_noun nov = (u3_noun)veb_u->mug_w;
 
-        c3_assert( c3y == u3a_south_is_normal(u3R, nov) );
+        u3_assert(c3y == u3a_south_is_normal(u3R, nov));
 
 #ifdef VERBOSE_TAKE
         u3l_log("south: %p is already %p", veb_u, u3a_to_ptr(nov));
@@ -1355,7 +1361,7 @@ u3a_take(u3_noun veb)
   u3_noun pro;
   u3t_on(coy_o);
 
-  c3_assert(u3_none != veb);
+  u3_assert(u3_none != veb);
 
   pro = ( c3y == u3a_is_north(u3R) )
         ? _ca_take_north(veb)
@@ -1395,7 +1401,7 @@ _me_gain_north(u3_noun dog)
   else {
     /* junior nouns are disallowed
     */
-    c3_assert(!_(u3a_north_is_junior(u3R, dog)));
+    u3_assert(!_(u3a_north_is_junior(u3R, dog)));
 
     /* normal pointers are refcounted
     */
@@ -1417,7 +1423,7 @@ _me_gain_south(u3_noun dog)
   else {
     /* junior nouns are disallowed
     */
-    c3_assert(!_(u3a_south_is_junior(u3R, dog)));
+    u3_assert(!_(u3a_south_is_junior(u3R, dog)));
 
     /* normal nouns are refcounted
     */
@@ -1512,7 +1518,7 @@ u3_noun
 u3a_gain(u3_noun som)
 {
   u3t_on(mal_o);
-  c3_assert(u3_none != som);
+  u3_assert(u3_none != som);
 
   if ( !_(u3a_is_cat(som)) ) {
     som = _(u3a_is_north(u3R))
@@ -1711,7 +1717,7 @@ u3a_mark_ptr(void* ptr_v)
       siz_w = 0;
     }
     else {
-      c3_assert(use_ws != 0);
+      u3_assert(use_ws != 0);
 
       if ( 0x80000000 == (c3_w)use_ws ) {    // see _raft_prof()
         use_ws = -1;
@@ -1839,7 +1845,7 @@ u3a_count_ptr(void* ptr_v)
       siz_w = 0;
     }
     else {
-      c3_assert(use_ws != 0);
+      u3_assert(use_ws != 0);
 
       if ( use_ws < 0 ) {
         siz_w = 0;
@@ -1913,7 +1919,7 @@ u3a_discount_ptr(void* ptr_v)
     siz_w = 0;
   }
   else {
-    c3_assert(use_ws != 0);
+    u3_assert(use_ws != 0);
 
     if ( use_ws < 0 ) {
       use_ws = -use_ws;
@@ -1963,7 +1969,7 @@ u3a_discount_noun(u3_noun som)
 void
 u3a_print_time(c3_c* str_c, c3_c* cap_c, c3_d mic_d)
 {
-  c3_assert( 0 != str_c );
+  u3_assert(0 != str_c);
 
   c3_w sec_w = (mic_d / 1000000);
   c3_w mec_w = (mic_d % 1000000) / 1000;
@@ -1985,7 +1991,7 @@ u3a_print_time(c3_c* str_c, c3_c* cap_c, c3_d mic_d)
 void
 u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
 {
-  c3_assert( 0 != fil_u );
+  u3_assert(0 != fil_u);
 
   c3_z byt_z = ((c3_z)wor_w * 4);
   c3_z gib_z = (byt_z / 1000000000);
@@ -2318,8 +2324,8 @@ u3a_sweep(void)
   u3a_print_memory(stderr, "leaked", leq_w);
   u3a_print_memory(stderr, "weaked", weq_w);
 
-  c3_assert( (pos_w + leq_w + weq_w) == neg_w );
-  c3_assert( (0 == leq_w) && (0 == weq_w) );
+  u3_assert((pos_w + leq_w + weq_w) == neg_w);
+  u3_assert((0 == leq_w) && (0 == weq_w));
 
   return neg_w;
 }
@@ -2408,7 +2414,7 @@ _ca_pack_move_north(c3_w* box_w, c3_w* end_w, u3_post new_p)
     if ( old_u->use_w ) {
       c3_w* new_w = (void*)u3a_botox(u3a_into(new_p));
 
-      c3_assert( box_w[siz_w - 1] == new_p );
+      u3_assert(box_w[siz_w - 1] == new_p);
 
       //  note: includes leading size
       //
@@ -2420,7 +2426,7 @@ _ca_pack_move_north(c3_w* box_w, c3_w* end_w, u3_post new_p)
         }
       }
       else {
-        c3_assert( new_w == box_w );
+        u3_assert(new_w == box_w);
       }
 
       //  restore trailing size
@@ -2464,7 +2470,7 @@ _ca_pack_move_south(c3_w* box_w, c3_w* end_w, u3_post new_p)
     if ( old_u->use_w ) {
       c3_w* new_w = (void*)u3a_botox(u3a_into(new_p));
 
-      c3_assert( old_u->siz_w == new_p );
+      u3_assert(old_u->siz_w == new_p);
 
       //  note: includes trailing size
       //
@@ -2476,7 +2482,7 @@ _ca_pack_move_south(c3_w* box_w, c3_w* end_w, u3_post new_p)
         }
       }
       else {
-        c3_assert( new_w == box_w );
+        u3_assert(new_w == box_w);
       }
 
       //  restore leading size
@@ -2500,7 +2506,7 @@ _ca_pack_move_south(c3_w* box_w, c3_w* end_w, u3_post new_p)
       }
     }
     else {
-      c3_assert( end_w == box_w );
+      u3_assert(end_w == box_w);
       break;
     }
   }
@@ -2734,11 +2740,19 @@ u3a_loom_sane()
       u3a_fbox *pre_u = u3to(u3a_fbox, this_u->pre_p)
         ,      *nex_u = u3to(u3a_fbox, this_u->nex_p);
 
-      if (nex_p && nex_u->pre_p != this_p) c3_assert(!"loom: wack");
-      if (pre_p && pre_u->nex_p != this_p) c3_assert(!"loom: wack");
+      if (nex_p && nex_u->pre_p != this_p) {
+        fprintf(stderr, "loom: corrupt\r\n");
+        exit(ENOTRECOVERABLE);
+      }
+      if (pre_p && pre_u->nex_p != this_p) {
+        fprintf(stderr, "loom: corrupt\r\n");
+        exit(ENOTRECOVERABLE);
+      }
       if (!pre_p                /* this must be the head of a freelist */
-          && u3R->all.fre_p[_box_slot(this_u->box_u.siz_w)] != this_p)
-        c3_assert(!"loom: wack");
+          && u3R->all.fre_p[_box_slot(this_u->box_u.siz_w)] != this_p) {
+        fprintf(stderr, "loom: corrupt\r\n");
+        exit(ENOTRECOVERABLE);
+      }
     }
   }
 }

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -2741,16 +2741,16 @@ u3a_loom_sane()
         ,      *nex_u = u3to(u3a_fbox, this_u->nex_p);
 
       if (nex_p && nex_u->pre_p != this_p) {
-        fprintf(stderr, "loom: corrupt\r\n");
+        fprintf(stderr, "loom: wack\r\n");
         exit(ENOTRECOVERABLE);
       }
       if (pre_p && pre_u->nex_p != this_p) {
-        fprintf(stderr, "loom: corrupt\r\n");
+        fprintf(stderr, "loom: wack\r\n");
         exit(ENOTRECOVERABLE);
       }
       if (!pre_p                /* this must be the head of a freelist */
           && u3R->all.fre_p[_box_slot(this_u->box_u.siz_w)] != this_p) {
-        fprintf(stderr, "loom: corrupt\r\n");
+        fprintf(stderr, "loom: wack\r\n");
         exit(ENOTRECOVERABLE);
       }
     }

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -1,6 +1,7 @@
 #ifndef U3_ALLOCATE_H
 #define U3_ALLOCATE_H
 
+#include "error.h"
 #include "manage.h"
 #include "options.h"
 
@@ -386,7 +387,7 @@
       u3C.vits_w = 1;
       break;
     default:
-      c3_assert(0);
+      exit(ENOTSUP);
     }
 
   u3C.walign_w = 1 << u3C.vits_w;
@@ -479,7 +480,7 @@
                 u3m_bail(c3__meme);
               }
 # ifdef U3_MEMORY_DEBUG
-              c3_assert( pil_u->top_p >= u3R->cap_p );
+              u3_assert(pil_u->top_p >= u3R->cap_p);
 # endif
             }
             else {
@@ -487,13 +488,13 @@
                 u3m_bail(c3__meme);
               }
 # ifdef U3_MEMORY_DEBUG
-              c3_assert( pil_u->top_p <= u3R->cap_p );
+              u3_assert(pil_u->top_p <= u3R->cap_p);
 # endif
             }
 #endif /* ifndef U3_GUARD_PAGE */
 
 #ifdef U3_MEMORY_DEBUG
-            c3_assert( pil_u->rod_u == u3R );
+            u3_assert(pil_u->rod_u == u3R);
 #endif
 
             return u3a_peek(pil_u);

--- a/pkg/noun/error.h
+++ b/pkg/noun/error.h
@@ -8,7 +8,7 @@
 #define u3_assert(condition)                                                   \
   do {                                                                         \
     if ( !(condition) ) {                                                      \
-      u3m_bail(c3_oops);                                                       \
+      u3m_bail(c3__oops);                                                      \
     }                                                                          \
   } while ( 0 )
 

--- a/pkg/noun/error.h
+++ b/pkg/noun/error.h
@@ -5,7 +5,8 @@
 
 #include "manage.h"
 
-#define u3_assert(condition)                                                   \
+/// Bail with `c3_oops` if the given condition is false.
+#define u3_assert(condition)                                                    \
   do {                                                                         \
     if ( !(condition) ) {                                                      \
       u3m_bail(c3__oops);                                                      \

--- a/pkg/noun/error.h
+++ b/pkg/noun/error.h
@@ -1,0 +1,15 @@
+/// @file
+
+#ifndef U3_ERROR_H
+#define U3_ERROR_H
+
+#include "manage.h"
+
+#define u3_assert(condition)                                                   \
+  do {                                                                         \
+    if ( !(condition) ) {                                                      \
+      u3m_bail(c3_oops);                                                       \
+    }                                                                          \
+  } while ( 0 )
+
+#endif /* ifndef U3_ERROR_H */

--- a/pkg/noun/error.h
+++ b/pkg/noun/error.h
@@ -6,9 +6,14 @@
 #include "manage.h"
 
 /// Bail with `c3_oops` if the given condition is false.
-#define u3_assert(condition)                                                    \
+#define u3_assert(condition)                                                   \
   do {                                                                         \
     if ( !(condition) ) {                                                      \
+      fprintf(stderr,                                                          \
+              "\rAssertion '%s' failed in %s:%d\r\n",                          \
+              #condition,                                                      \
+              __FILE__,                                                        \
+              __LINE__);                                                       \
       u3m_bail(c3__oops);                                                      \
     }                                                                          \
   } while ( 0 )

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1127,7 +1127,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
     if ( pag_siz_i % sys_i ) {
       fprintf(stderr, "loom: incompatible system page size (%zuKB)\r\n",
                       sys_i >> 10);
-      exit(1);
+      exit(EINVAL);
     }
   }
 

--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -224,7 +224,7 @@ _ch_slot_put(u3h_slot* sot_w, u3_noun kev, c3_w lef_w, c3_w rem_w, c3_w* use_w)
                                kev,
                                use_w);
 
-    c3_assert( c3y == u3h_slot_is_node(*sot_w) );
+    u3_assert( c3y == u3h_slot_is_node(*sot_w) );
     *sot_w = u3h_node_to_slot(hav_v);
   }
   else {

--- a/pkg/noun/hashtable_tests.c
+++ b/pkg/noun/hashtable_tests.c
@@ -121,7 +121,7 @@ _test_skip_slot(void)
   {
     c3_w mug_w = 31 << 20; //  5 bits, all ones
     c3_w res_w = _ch_skip_slot(mug_w, 20);
-    c3_assert((1 << 25) == res_w);
+    u3_assert((1 << 25) == res_w);
 
     if ( (1 << 25) != res_w ) {
       fprintf(stderr, "bit skip_slot (d): failed\r\n");

--- a/pkg/noun/hashtable_tests.c
+++ b/pkg/noun/hashtable_tests.c
@@ -233,7 +233,7 @@ main(int argc, char* argv[])
 
   if ( !_test_hashtable() ) {
     fprintf(stderr, "test_hashtable: failed\r\n");
-    exit(1);
+    exit(ECANCELED);
   }
 
   //  GC

--- a/pkg/noun/imprison.c
+++ b/pkg/noun/imprison.c
@@ -2,6 +2,7 @@
 
 #include "imprison.h"
 
+#include "error.h"
 #include "jets/k.h"
 #include "jets/q.h"
 #include "manage.h"
@@ -40,7 +41,7 @@ _ci_slab_init(u3i_slab* sab_u, c3_w len_w)
   vat_u->len_w = len_w;
 
 #ifdef U3_MEMORY_DEBUG
-  c3_assert( len_w );
+  u3_assert(len_w > 0);
 #endif
 
   sab_u->_._vat_u = vat_u;
@@ -203,11 +204,11 @@ u3i_slab_free(u3i_slab* sab_u)
   u3t_on(mal_o);
 
   if ( 1 == len_w ) {
-    c3_assert( !vat_u );
+    u3_assert(vat_u == NULL);
   }
   else {
     c3_w* tav_w = (sab_u->buf_w - c3_wiseof(u3a_atom));
-    c3_assert( tav_w == (c3_w*)vat_u );
+    u3_assert(tav_w == (c3_w*)vat_u);
     u3a_wfree(vat_u);
   }
 
@@ -228,7 +229,7 @@ u3i_slab_mint(u3i_slab* sab_u)
   if ( 1 == len_w ) {
     c3_w dat_w = *sab_u->buf_w;
 
-    c3_assert( !vat_u );
+    u3_assert(vat_u == NULL);
 
     u3t_off(mal_o);
     pro = u3i_word(dat_w);
@@ -237,7 +238,7 @@ u3i_slab_mint(u3i_slab* sab_u)
   else {
     u3a_atom* vat_u = sab_u->_._vat_u;
     c3_w* tav_w = (sab_u->buf_w - c3_wiseof(u3a_atom));
-    c3_assert( tav_w == (c3_w*)vat_u );
+    u3_assert(tav_w == (c3_w*)vat_u);
 
     //  trim trailing zeros
     //
@@ -266,7 +267,7 @@ u3i_slab_moot(u3i_slab* sab_u)
   if ( 1 == len_w) {
     c3_w dat_w = *sab_u->buf_w;
 
-    c3_assert( !sab_u->_._vat_u );
+    u3_assert(sab_u->_._vat_u == NULL);
 
     u3t_off(mal_o);
     pro = u3i_word(dat_w);
@@ -275,7 +276,7 @@ u3i_slab_moot(u3i_slab* sab_u)
   else {
     u3a_atom* vat_u = sab_u->_._vat_u;
     c3_w* tav_w = (sab_u->buf_w - c3_wiseof(u3a_atom));
-    c3_assert( tav_w == (c3_w*)vat_u );
+    u3_assert(tav_w == (c3_w*)vat_u);
 
     pro = _ci_atom_mint(vat_u, len_w);
   }
@@ -456,7 +457,7 @@ u3i_mp(mpz_t a_mp)
 u3_atom
 u3i_vint(u3_noun a)
 {
-  c3_assert(u3_none != a);
+  u3_assert(u3_none != a);
 
   if ( _(u3a_is_cat(a)) ) {
     return ( a == 0x7fffffff ) ? u3i_word(a + 1) : (a + 1);
@@ -819,7 +820,7 @@ u3i_molt(u3_noun som, ...)
     va_end(ap);
   }
 
-  c3_assert( 0 != len_w );
+  u3_assert(0 != len_w);
   pms_m = alloca(len_w * sizeof(struct _molt_pair));
 
   //  Install.

--- a/pkg/noun/jets.c
+++ b/pkg/noun/jets.c
@@ -3,6 +3,7 @@
 #include "jets.h"
 
 #include "allocate.h"
+#include "error.h"
 #include "hashtable.h"
 #include "imprison.h"
 #include "jets/k.h"
@@ -90,9 +91,9 @@ _cj_hash(c3_c* has_c)
   c3_w i_w, len_w = strlen(has_c);
   if ( 64 != len_w ) {
     u3l_log("bash not 64 characters: %s", has_c);
-    c3_assert(0);
+    u3m_bail(c3__oops);
   }
-  c3_assert( 64 == len_w );
+  u3_assert(64 == len_w);
   c3_y dig_y[32];
   for ( i_w = 0; i_w < 64; ) {
     c3_y hi_y  = has_c[i_w++],
@@ -321,7 +322,7 @@ static c3_w
 _cj_install(u3j_core* ray_u, c3_w jax_l, u3_noun pel, u3_noun lab, u3j_core* dev_u)
 {
   c3_w i_w;
-  c3_assert(u3R == &(u3H->rod_u));
+  u3_assert(u3R == &(u3H->rod_u));
 
   if ( dev_u ) {
     for ( i_w = 0; 0 != dev_u[i_w].cos_c; i_w++ ) {
@@ -709,7 +710,7 @@ _cj_cast(u3_noun cor, u3_noun loc)
     fis_u->pax = u3k(u3t(par));
   }
   u3z(rev);
-  c3_assert( u3_nul == j );
+  u3_assert(u3_nul == j);
 
   return u3of(u3j_fink, fin_u);
 }
@@ -746,7 +747,7 @@ _cj_nail(u3_noun loc, u3_noun axe,
   u3_noun jax, hap, bal, jit;
   u3_weak act;
   act = _cj_find_warm(loc);
-  c3_assert(u3_none != act);
+  u3_assert(u3_none != act);
   u3x_qual(act, &jax, &hap, &bal, &jit);
 
   *lab = u3k(bal);
@@ -813,7 +814,7 @@ _cj_hot_mean(c3_l par_l, u3_noun nam)
 c3_w
 u3j_boot(c3_o nuu_o)
 {
-  c3_assert(u3R == &(u3H->rod_u));
+  u3_assert(u3R == &(u3H->rod_u));
 
   u3D.len_l = _cj_count(0, u3D.dev_u);
   u3D.all_l = (2 * u3D.len_l) + 1024;     //  horrid heuristic
@@ -1125,7 +1126,7 @@ _cj_hank_fine(_cj_hank* han_u, u3_noun cor, u3_noun *inn)
     }
     else {
       u3j_site* sit_u = &(han_u->sit_u);
-      c3_assert(u3_none != sit_u->loc);
+      u3_assert(u3_none != sit_u->loc);
       return _cj_fine(*inn, sit_u->fin_p);
     }
   }
@@ -1704,7 +1705,7 @@ u3j_gate_prep(u3j_site* sit_u, u3_noun cor)
       u3l_log("u3j_gate_prep(): parent axis includes sample");
       u3m_p("axis", pax);
       u3_weak act = _cj_find_warm(loc);
-      c3_assert( u3_none != act );
+      u3_assert(u3_none != act);
       sit_u->jet_o = c3n;
       sit_u->lab = u3k(u3h(u3t(u3t(act))));
       u3z(act);
@@ -1828,7 +1829,7 @@ _cj_mine(u3_noun cey, u3_noun cor, u3_noun bas)
     }
     else {
       u3_weak pac = _cj_find_warm(pel);
-      c3_assert(u3_none != pac);
+      u3_assert(u3_none != pac);
       par_l = u3h(pac);
       bal   = u3nc(u3k(nam), u3k(u3h(u3t(u3t(pac)))));
       u3z(pac);
@@ -2179,7 +2180,7 @@ void
 u3j_ream(void)
 {
   u3_noun rel = u3_nul;
-  c3_assert(u3R == &(u3H->rod_u));
+  u3_assert(u3R == &(u3H->rod_u));
   u3h_free(u3R->jed.war_p);
   u3R->jed.war_p = u3h_new();
   u3h_walk_with(u3R->jed.cod_p, _cj_warm_tap, &rel);
@@ -2195,7 +2196,7 @@ u3_noun
 u3j_stay(void)
 {
   u3_noun rel = u3_nul;
-  c3_assert(u3R == &(u3H->rod_u));
+  u3_assert(u3R == &(u3H->rod_u));
   u3h_walk_with(u3R->jed.cod_p, _cj_warm_tap, &rel);
   return rel;
 }

--- a/pkg/noun/jets/e/hmac.c
+++ b/pkg/noun/jets/e/hmac.c
@@ -16,7 +16,7 @@
             u3_atom wid,
             u3_atom dat)
   {
-    c3_assert(_(u3a_is_cat(boq)) && _(u3a_is_cat(wik)) && _(u3a_is_cat(wid)));
+    u3_assert(_(u3a_is_cat(boq)) && _(u3a_is_cat(wik)) && _(u3a_is_cat(wid)));
 
     // prep the hashing gate
     u3j_site sit_u;

--- a/pkg/noun/jets/e/loss.c
+++ b/pkg/noun/jets/e/loss.c
@@ -116,7 +116,7 @@
                (inx_w == 0) ? u3_nul
                             : u3k(loc_u->kad[inx_w - 1]));
     if ( loc_u->kct_w == inx_w ) {
-      c3_assert(loc_u->kct_w < (1 << 31));
+      u3_assert(loc_u->kct_w < (1 << 31));
       loc_u->kct_w++;
     } else {
       u3z(loc_u->kad[inx_w]);
@@ -181,7 +181,7 @@
         c3_w     max_w,
         c3_w     goy_w)
   {
-    c3_assert(max_w >= *inx_w);
+    u3_assert(max_w >= *inx_w);
 
     if ( max_w == *inx_w ) {
       if ( c3n == _lonk(loc_u, *inx_w, goy_w) ) {

--- a/pkg/noun/jets/f/ap.c
+++ b/pkg/noun/jets/f/ap.c
@@ -513,7 +513,8 @@
                             u3qdb_put(q_gen, u3_blip, diz)),
                        u3nc(c3__cnzy, u3_blip));
 
-    c3_assert(0);
+    // It's unclear why we're bailing here. See cf63265ac05 for more.
+    u3m_bail(c3__oops);
     u3z(diz);
     return ret;
   }

--- a/pkg/noun/jets/f/flip.c
+++ b/pkg/noun/jets/f/flip.c
@@ -14,7 +14,7 @@
         return u3nc(1, c3n);
       }
       else {
-        c3_assert((c3n == u3t(hel)));
+        u3_assert((c3n == u3t(hel)));
 
         return u3nc(1, c3y);
       }

--- a/pkg/noun/jets/f/hike.c
+++ b/pkg/noun/jets/f/hike.c
@@ -89,7 +89,8 @@
   u3qf_hike(u3_noun axe,
             u3_noun pac)
   {
-    c3_assert(0);
+    // Effectively disable this jet. See commit fad65ff83e2 for more.
+    u3m_bail(c3__oops);
     if ( (u3_nul == pac) ) {
       return u3nc(0, u3k(axe));
     }

--- a/pkg/noun/jets_tests.c
+++ b/pkg/noun/jets_tests.c
@@ -531,7 +531,7 @@ main(int argc, char* argv[])
 
   if ( !_test_jets() ) {
     fprintf(stderr, "test jets: failed\r\n");
-    exit(1);
+    exit(ECANCELED);
   }
 
   //  GC

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -739,7 +739,7 @@ u3m_bail(u3_noun how)
         fprintf(stderr, "\r\nbail: %s\r\n", str_c);
       }
       else if ( 1 != u3h(how) ) {
-        c3_assert(_(u3ud(u3h(how))));
+        u3_assert(_(u3ud(u3h(how))));
         fprintf(stderr, "\r\nbail: %d\r\n", u3h(how));
       }
     }
@@ -765,7 +765,7 @@ u3m_bail(u3_noun how)
     //    XX JB: these seem unrecoverable, at least wrt memory management,
     //    so they've been disabled above for now
     //
-    c3_assert(_(u3a_is_cat(how)));
+    u3_assert(_(u3a_is_cat(how)));
     u3m_signal(how);
   }
 
@@ -867,7 +867,7 @@ u3m_leap(c3_w pad_w)
   /* Attach the new road to its parents.
   */
   {
-    c3_assert(0 == u3R->kid_p);
+    u3_assert(0 == u3R->kid_p);
     rod_u->par_p = u3of(u3_road, u3R);
     u3R->kid_p = u3of(u3_road, rod_u);
   }
@@ -897,7 +897,7 @@ _print_diff(c3_c* cap_c, c3_w a, c3_w b)
 void
 u3m_fall()
 {
-  c3_assert(0 != u3R->par_p);
+  u3_assert(0 != u3R->par_p);
 
 #if 0
   /*  If you're printing a lot of these you need to change
@@ -945,7 +945,7 @@ u3m_fall()
 void
 u3m_hate(c3_w pad_w)
 {
-  c3_assert(0 == u3R->ear_p);
+  u3_assert(0 == u3R->ear_p);
 
   u3R->ear_p = u3R->cap_p;
   u3m_leap(pad_w);
@@ -1029,7 +1029,7 @@ u3m_flog(c3_w gof_w)
 void
 u3m_water(c3_w* low_w, c3_w* hig_w)
 {
-  c3_assert(u3R == &u3H->rod_u);
+  u3_assert(u3R == &u3H->rod_u);
 
   *low_w = u3a_heap(u3R);
   *hig_w = u3a_temp(u3R) + c3_wiseof(u3v_home);
@@ -1118,7 +1118,7 @@ u3m_soft_sure(u3_funk fun_f, u3_noun arg)
 {
   u3_noun pro, pru = u3m_soft_top(0, (1 << 18), fun_f, arg);
 
-  c3_assert(_(u3du(pru)));
+  u3_assert(_(u3du(pru)));
   pro = u3k(u3t(pru));
   u3z(pru);
 
@@ -1198,9 +1198,9 @@ u3m_soft_run(u3_noun gul,
     /* Produce - or fall again.
     */
     {
-      c3_assert(_(u3du(why)));
+      u3_assert(_(u3du(why)));
       switch ( u3h(why) ) {
-        default: c3_assert(0); return 0;
+        default: exit(ENOTSUP);
 
         case 0: {                             //  unusual: bail with success.
           pro = u3m_love(why);
@@ -1253,7 +1253,7 @@ u3m_soft_esc(u3_noun ref, u3_noun sam)
   /* Assert preconditions.
   */
   {
-    c3_assert(0 != u3R->ski.gul);
+    u3_assert(0 != u3R->ski.gul);
     gul = u3h(u3R->ski.gul);
   }
 
@@ -1360,7 +1360,7 @@ u3m_soft(c3_w    mil_w,
       //
       default: {
         u3m_p("invalid mot", u3h(why));
-        c3_assert(0);
+        exit(ENOTSUP);
       }
     }
 
@@ -1667,7 +1667,11 @@ _cm_limits(void)
   //  Moar stack.
   //
   {
-    c3_assert( 0 == getrlimit(RLIMIT_STACK, &rlm) );
+    if (getrlimit(RLIMIT_STACK, &rlm) == -1) {
+      c3_i err_i = errno;
+      fprintf(stderr, "boot: failed to get stack size: %s\r\n", strerror(err_i));
+      exit(err_i);
+    }
 
     rlm.rlim_cur = c3_min(rlm.rlim_max, (65536 << 10));
 
@@ -1981,7 +1985,7 @@ _cm_pack_rewrite(void)
 {
   //  XX fix u3a_rewrit* to support south roads
   //
-  c3_assert( &(u3H->rod_u) == u3R );
+  u3_assert(&(u3H->rod_u) == u3R);
 
   //  NB: these implementations must be kept in sync with u3m_reclaim();
   //  anything not reclaimed must be rewritable
@@ -2048,8 +2052,8 @@ _migrate_seek(const u3a_road *rod_u)
     {
       if (!box_u->use_w)
         continue;
-      c3_assert(box_u->siz_w);
-      c3_assert(box_u->use_w);
+      u3_assert(box_u->siz_w);
+      u3_assert(box_u->use_w);
       box_w[box_u->siz_w - 1] = new_p;
       new_p = c3_align(new_p + box_u->siz_w, 2, C3_ALGHI);
     }
@@ -2105,8 +2109,8 @@ _migrate_move(u3a_road *rod_u)
       continue;
 
     new_w = (void *)u3a_botox(u3a_into(new_p));
-    c3_assert(box_w[siz_w - 1] == new_p);
-    c3_assert(new_w <= box_w);
+    u3_assert(box_w[siz_w - 1] == new_p);
+    u3_assert(new_w <= box_w);
 
     c3_w i_w;
     for (i_w = 0; i_w < siz_w - 1; i_w++)

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1672,8 +1672,9 @@ _cm_limits(void)
     rlm.rlim_cur = c3_min(rlm.rlim_max, (65536 << 10));
 
     if ( 0 != setrlimit(RLIMIT_STACK, &rlm) ) {
-      u3l_log("boot: stack size: %s", strerror(errno));
-      exit(1);
+      c3_i err_i = errno;
+      u3l_log("boot: stack size: %s", strerror(err_i));
+      exit(err_i);
     }
   }
 
@@ -1718,7 +1719,7 @@ _cm_signals(void)
 {
   if ( 0 != sigsegv_install_handler(u3e_fault) ) {
     u3l_log("boot: sigsegv install failed");
-    exit(1);
+    exit(ENOTSUP);
   }
 
 # if defined(U3_OS_PROF)
@@ -1732,8 +1733,9 @@ _cm_signals(void)
     sigaddset(&set, SIGPROF);
 
     if ( 0 != pthread_sigmask(SIG_BLOCK, &set, NULL) ) {
-      u3l_log("boot: thread mask SIGPROF: %s", strerror(errno));
-      exit(1);
+      c3_i err_i = errno;
+      u3l_log("boot: thread mask SIGPROF: %s", strerror(err_i));
+      exit(err_i);
     }
   }
 # endif
@@ -1830,7 +1832,7 @@ u3m_init(size_t len_i)
      || (len_i > u3a_bytes) )
   {
     u3l_log("loom: bad size: %zu", len_i);
-    exit(1);
+    exit(EINVAL);
   }
 
   // map at fixed address.
@@ -1848,6 +1850,7 @@ u3m_init(size_t len_i)
                    (PROT_READ | PROT_WRITE),
                    (MAP_ANON | MAP_PRIVATE),
                    -1, 0);
+      c3_i err_i = errno;
 
       u3l_log("boot: mapping %zuMB failed", len_i >> 20);
       u3l_log("see urbit.org/using/install/#about-swap-space"
@@ -1856,7 +1859,7 @@ u3m_init(size_t len_i)
         u3l_log("if porting to a new platform, try U3_OS_LoomBase %p",
                 map_v);
       }
-      exit(1);
+      exit(err_i);
     }
 
     u3C.wor_i = len_i >> 2;

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -189,7 +189,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
           return pro;
         }
       }
-      c3_assert(!"not reached");
 
       case 1: {
         u3_noun pro = u3k(gal);
@@ -197,7 +196,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
         u3a_lose(bus); u3a_lose(fol);
         return pro;
       }
-      c3_assert(!"not reached");
 
       case 2: {
         u3_noun nex = _n_nock_on(u3k(bus), u3k(u3t(gal)));
@@ -208,7 +206,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
         fol = nex;
         continue;
       }
-      c3_assert(!"not reached");
 
       case 3: {
         u3_noun gof, pro;
@@ -219,7 +216,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
         u3a_lose(gof); u3a_lose(fol);
         return pro;
       }
-      c3_assert(!"not reached");
 
       case 4: {
         u3_noun gof, pro;
@@ -230,7 +226,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
         u3a_lose(fol);
         return pro;
       }
-      c3_assert(!"not reached");
 
       case 5: {
         u3_noun wim = _n_nock_on(bus, u3k(gal));
@@ -239,7 +234,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
         u3a_lose(wim); u3a_lose(fol);
         return pro;
       }
-      c3_assert(!"not reached");
 
       case 6: {
         u3_noun b_gal, c_gal, d_gal;
@@ -260,7 +254,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
           continue;
         }
       }
-      c3_assert(!"not reached");
 
       case 7: {
         u3_noun b_gal, c_gal;
@@ -276,7 +269,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
           continue;
         }
       }
-      c3_assert(!"not reached");
 
       case 8: {
         u3_noun b_gal, c_gal;
@@ -293,7 +285,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
           continue;
         }
       }
-      c3_assert(!"not reached");
 
       case 9: {
         u3_noun b_gal, c_gal;
@@ -326,7 +317,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
           }
         }
       }
-      c3_assert(!"not reached");
 
       case 10: {
         u3_noun p_gal, q_gal;
@@ -389,7 +379,6 @@ _n_nock_on(u3_noun bus, u3_noun fol)
           return pro;
         }
       }
-      c3_assert(!"not reached");
     }
   }
 }
@@ -556,7 +545,7 @@ _n_arg(c3_y cod_y)
       return sizeof(c3_l);
 
     default:
-      c3_assert( cod_y < LAST );
+      u3_assert(cod_y < LAST);
       return 0;
   }
 }
@@ -592,7 +581,7 @@ _n_melt(u3_noun ops, c3_w* byc_w, c3_w* cal_w,
           }
           else {
             fprintf(stderr, "_n_melt(): over 2^16 registration sites.\r\n");
-            c3_assert(0);
+            u3m_bail(c3__oops);
           }
           break;
       }
@@ -634,7 +623,7 @@ _n_melt(u3_noun ops, c3_w* byc_w, c3_w* cal_w,
           }
           else {
             fprintf(stderr, "_n_melt(): over 2^16 memos.\r\n");
-            c3_assert(0);
+            u3m_bail(c3__oops);
           }
           break;
         }
@@ -644,7 +633,7 @@ _n_melt(u3_noun ops, c3_w* byc_w, c3_w* cal_w,
         case FISK: case FISL: case SUSH: case SANS:
         case LISL: case LISK: case SKIS: case SLIS:
         case HILS: case HINS:
-          c3_assert(0); //overflows
+          u3m_bail(c3__oops); //overflows
           break;
 
         case KICB: case TICB:
@@ -657,7 +646,7 @@ _n_melt(u3_noun ops, c3_w* byc_w, c3_w* cal_w,
           }
           else {
             fprintf(stderr, "_n_melt(): over 2^16 call sites.\r\n");
-            c3_assert(0);
+            u3m_bail(c3__oops);
           }
           break;
 
@@ -674,7 +663,7 @@ _n_melt(u3_noun ops, c3_w* byc_w, c3_w* cal_w,
           }
           else {
             fprintf(stderr, "_n_melt(): over 2^16 literals.\r\n");
-            c3_assert(0);
+            u3m_bail(c3__oops);
           }
           break;
       }
@@ -817,8 +806,7 @@ _n_prog_asm(u3_noun ops, u3n_prog* pog_u, u3_noun sip)
       u3_noun cod = u3h(op);
       switch ( cod ) {
         default:
-          c3_assert(0);
-          return;
+          u3m_bail(c3__oops);
 
         /* memo index args */
         case SKIB: case SLIB: {
@@ -924,9 +912,9 @@ _n_prog_asm(u3_noun ops, u3n_prog* pog_u, u3_noun sip)
   }
   u3z(top);
   // this assert will fail if we overflow a c3_w worth of instructions
-  c3_assert(u3_nul == ops);
+  u3_assert(u3_nul == ops);
   // this is just a sanity check
-  c3_assert(u3_nul == sip);
+  u3_assert(u3_nul == sip);
 }
 
 /* _n_prog_from_ops(): new program from _n_comp() product
@@ -1612,8 +1600,7 @@ _n_print_byc(c3_y* pog, c3_w her_w)
         fprintf(stderr, "%u]", _n_rewo(pog, &ip_w));
         break;
       default:
-        c3_assert(0);
-        break;
+        u3m_bail(c3__oops);
     }
   }
   fprintf(stderr, " halt}\r\n");
@@ -1890,7 +1877,7 @@ _n_hilt_hind(u3_noun tok, u3_noun pro)
     u3z(delta);
   }
   else {
-    c3_assert( u3_nul == tok );
+    u3_assert(u3_nul == tok);
   }
 
   u3z(tok);
@@ -1985,7 +1972,7 @@ _n_hint_hind(u3_noun tok, u3_noun pro)
     // unpack q_tok to get the priority integer and the tank
     // p_q_tok is the priority, q_q_tok is the tank we will work with
     u3_noun p_q_tok, q_q_tok;
-    c3_assert(c3y == u3r_cell(q_tok, &p_q_tok, &q_q_tok));
+    u3_assert(c3y == u3r_cell(q_tok, &p_q_tok, &q_q_tok));
 
     // format the timing report
     c3_c str_c[64];
@@ -2000,7 +1987,7 @@ _n_hint_hind(u3_noun tok, u3_noun pro)
     u3z(delta);
   }
   else {
-    c3_assert( u3_nul == tok );
+    u3_assert( u3_nul == tok );
   }
 
   u3z(tok);
@@ -2991,7 +2978,7 @@ _n_ream(u3_noun kev)
 void
 u3n_ream()
 {
-  c3_assert(u3R == &(u3H->rod_u));
+  u3_assert(u3R == &(u3H->rod_u));
   u3h_walk(u3R->byc.har_p, _n_ream);
 }
 
@@ -3118,7 +3105,7 @@ u3n_slam_on(u3_noun gat, u3_noun sam)
 #if 0
   if ( &u3H->rod_u == u3R ) {
     if ( exc_w == 1 ) {
-      c3_assert(0);
+      u3m_bail(c3__oops);
     }
     exc_w++;
   }

--- a/pkg/noun/nock_tests.c
+++ b/pkg/noun/nock_tests.c
@@ -73,7 +73,7 @@ main(int argc, char* argv[])
 
   if ( !_test_meme() ) {
     fprintf(stderr, "test meme: failed\r\n");
-    exit(1);
+    exit(ECANCELED);
   }
 
   //  GC

--- a/pkg/noun/noun.h
+++ b/pkg/noun/noun.h
@@ -4,6 +4,7 @@
 #define U3_NOUN_H
 
 #include "allocate.h"
+#include "error.h"
 #include "hashtable.h"
 #include "jets.h"
 #include "jets/k.h"

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -14,7 +14,7 @@
 static u3_weak
 _frag_word(c3_w a_w, u3_noun b)
 {
-  c3_assert(0 != a_w);
+  u3_assert(0 != a_w);
 
   {
     c3_w dep_w = u3x_dep(a_w);
@@ -62,8 +62,8 @@ _frag_deep(c3_w a_w, u3_noun b)
 u3_weak
 u3r_at(u3_atom a, u3_noun b)
 {
-  c3_assert(u3_none != a);
-  c3_assert(u3_none != b);
+  u3_assert(u3_none != a);
+  u3_assert(u3_none != b);
 
   u3t_on(far_o);
 
@@ -173,7 +173,7 @@ u3r_vmean(u3_noun som, va_list ap)
   c3_w               len_w;
   struct _mean_pair* prs_m;
 
-  c3_assert(u3_none != som);
+  u3_assert(u3_none != som);
 
   //  traverse copy of va_list for alloca
   //
@@ -190,7 +190,7 @@ u3r_vmean(u3_noun som, va_list ap)
 
   va_end(aq);
 
-  c3_assert( 0 != len_w );
+  u3_assert( 0 != len_w );
   prs_m = alloca(len_w * sizeof(struct _mean_pair));
 
   //  traverse va_list and extract args
@@ -444,9 +444,8 @@ _cr_sing_cape(u3a_pile* pil_u, u3p(u3h_root) har_p)
         u3a_wed(&(a_u->tel), &(b_u->tel));
       } break;
 
-      default: {
-        c3_assert(0);
-      } break;
+      default:
+        exit(ENOTSUP);
     }
 
     //  track equal pairs to short-circuit possible (re-)comparison
@@ -547,9 +546,8 @@ _cr_sing(u3_noun a, u3_noun b)
         u3a_wed(&(a_u->tel), &(b_u->tel));
       } break;
 
-      default: {
-        c3_assert(0);
-      } break;
+      default:
+        exit(ENOTSUP);
     }
 
     //  [ovr_s] counts comparisons, if it overflows, we've likely hit
@@ -695,8 +693,8 @@ u3_atom
 u3r_nord(u3_noun a,
         u3_noun b)
 {
-  c3_assert(u3_none != a);
-  c3_assert(u3_none != b);
+  u3_assert(u3_none != a);
+  u3_assert(u3_none != b);
 
   if ( a == b ) {
     return 1;
@@ -762,7 +760,7 @@ c3_o
 u3r_sing_c(const c3_c* a_c,
            u3_noun     b)
 {
-  c3_assert(u3_none != b);
+  u3_assert(u3_none != b);
 
   if ( !_(u3a_is_atom(b)) ) {
     return c3n;
@@ -792,7 +790,7 @@ u3r_bush(u3_noun  a,
            u3_noun* b,
            u3_noun* c)
 {
-  c3_assert(u3_none != a);
+  u3_assert(u3_none != a);
 
   if ( _(u3a_is_atom(a)) ) {
     return c3n;
@@ -842,7 +840,7 @@ u3r_cell(u3_noun  a,
            u3_noun* b,
            u3_noun* c)
 {
-  c3_assert(u3_none != a);
+  u3_assert(u3_none != a);
 
   if ( _(u3a_is_atom(a)) ) {
     return c3n;
@@ -1083,8 +1081,8 @@ c3_b
 u3r_bit(c3_w    a_w,
           u3_atom b)
 {
-  c3_assert(u3_none != b);
-  c3_assert(_(u3a_is_atom(b)));
+  u3_assert(u3_none != b);
+  u3_assert(_(u3a_is_atom(b)));
 
   if ( _(u3a_is_cat(b)) ) {
     if ( a_w >= 31 ) {
@@ -1116,8 +1114,8 @@ c3_y
 u3r_byte(c3_w    a_w,
            u3_atom b)
 {
-  c3_assert(u3_none != b);
-  c3_assert(_(u3a_is_atom(b)));
+  u3_assert(u3_none != b);
+  u3_assert(_(u3a_is_atom(b)));
 
   if ( _(u3a_is_cat(b)) ) {
     if ( a_w > 3 ) {
@@ -1151,8 +1149,8 @@ u3r_bytes(c3_w    a_w,
             c3_y*   c_y,
             u3_atom d)
 {
-  c3_assert(u3_none != d);
-  c3_assert(_(u3a_is_atom(d)));
+  u3_assert(u3_none != d);
+  u3_assert(_(u3a_is_atom(d)));
 
   if ( _(u3a_is_cat(d)) ) {
     c3_w e_w = d >> (c3_min(a_w, 4) << 3);
@@ -1231,8 +1229,8 @@ void
 u3r_mp(mpz_t   a_mp,
        u3_atom b)
 {
-  c3_assert(u3_none != b);
-  c3_assert(_(u3a_is_atom(b)));
+  u3_assert(u3_none != b);
+  u3_assert(_(u3a_is_atom(b)));
 
   if ( _(u3a_is_cat(b)) ) {
     mpz_init_set_ui(a_mp, b);
@@ -1257,8 +1255,8 @@ c3_s
 u3r_short(c3_w  a_w,
           u3_atom b)
 {
-  c3_assert( u3_none != b );
-  c3_assert( c3y == u3a_is_atom(b) );
+  u3_assert( u3_none != b );
+  u3_assert(c3y == u3a_is_atom(b));
 
   if ( c3y == u3a_is_cat(b) ) {
     switch ( a_w ) {
@@ -1290,8 +1288,8 @@ c3_w
 u3r_word(c3_w    a_w,
            u3_atom b)
 {
-  c3_assert(u3_none != b);
-  c3_assert(_(u3a_is_atom(b)));
+  u3_assert(u3_none != b);
+  u3_assert(_(u3a_is_atom(b)));
 
   if ( _(u3a_is_cat(b)) ) {
     if ( a_w > 0 ) {
@@ -1349,8 +1347,8 @@ u3r_words(c3_w    a_w,
           c3_w*   c_w,
           u3_atom d)
 {
-  c3_assert(u3_none != d);
-  c3_assert(_(u3a_is_atom(d)));
+  u3_assert(u3_none != d);
+  u3_assert(_(u3a_is_atom(d)));
 
   if ( b_w == 0 ) {
     return;
@@ -1627,8 +1625,8 @@ u3r_chop(c3_g  met_g,
   else {
     u3a_atom* src_u = u3a_to_ptr(src);
 
-    c3_assert(u3_none != src);
-    c3_assert(_(u3a_is_atom(src)));
+    u3_assert(u3_none != src);
+    u3_assert(_(u3a_is_atom(src)));
 
     len_w = src_u->len_w;
     src_w = src_u->buf_w;
@@ -1865,7 +1863,7 @@ u3r_mug(u3_noun veb)
 
   //  sanity check
   //
-  c3_assert( u3_none != veb );
+  u3_assert(u3_none != veb);
 
   u3a_pile_prep(&pil_u, sizeof(*fam_u));
 

--- a/pkg/noun/retrieve_tests.c
+++ b/pkg/noun/retrieve_tests.c
@@ -234,7 +234,7 @@ main(int argc, char* argv[])
 
   if ( !_test_mug() ) {
     fprintf(stderr, "test_mug: failed\r\n");
-    exit(1);
+    exit(ECANCELED);
   }
 
   //  GC

--- a/pkg/noun/serial.c
+++ b/pkg/noun/serial.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 
 #include "allocate.h"
+#include "error.h"
 #include "hashtable.h"
 #include "jets/k.h"
 #include "jets/q.h"
@@ -461,7 +462,7 @@ _cs_cue_xeno_next(u3a_pile*    pil_u,
     }
 
     switch ( tag_e ) {
-      default: c3_assert(0);
+      default: exit(ENOTSUP);
 
       case ur_jam_cell: {
         _cue_frame_t* fam_u = u3a_push(pil_u);
@@ -611,7 +612,7 @@ u3s_cue_xeno_init_with(c3_d pre_d, c3_d siz_d)
 {
   u3_cue_xeno* sil_u;
 
-  c3_assert( &(u3H->rod_u) == u3R );
+  u3_assert(&(u3H->rod_u) == u3R);
 
   sil_u = c3_calloc(sizeof(*sil_u));
   ur_dict32_grow((ur_root_t*)0, &sil_u->dic_u, pre_d, siz_d);
@@ -636,7 +637,7 @@ u3s_cue_xeno_with(u3_cue_xeno* sil_u,
 {
   u3_weak som;
 
-  c3_assert( &(u3H->rod_u) == u3R );
+  u3_assert(&(u3H->rod_u) == u3R);
 
   som = _cs_cue_xeno(sil_u, len_d, byt_y);
   ur_dict32_wipe(&sil_u->dic_u);
@@ -661,7 +662,7 @@ u3s_cue_xeno(c3_d        len_d,
   u3_cue_xeno* sil_u;
   u3_weak        som;
 
-  c3_assert( &(u3H->rod_u) == u3R );
+  u3_assert(&(u3H->rod_u) == u3R);
 
   sil_u = u3s_cue_xeno_init();
   som   = _cs_cue_xeno(sil_u, len_d, byt_y);
@@ -719,7 +720,7 @@ _cs_cue_bytes_next(u3a_pile*     pil_u,
     _cs_cue_need(ur_bsr_tag(red_u, &tag_e));
 
     switch ( tag_e ) {
-      default: c3_assert(0);
+      default: exit(ENOTSUP);
 
       case ur_jam_cell: {
         _cue_frame_t* fam_u = u3a_push(pil_u);

--- a/pkg/noun/serial_tests.c
+++ b/pkg/noun/serial_tests.c
@@ -254,7 +254,7 @@ main(int argc, char* argv[])
 
   if ( !_test_jam_roundtrip() ) {
     fprintf(stderr, "test jam: failed\r\n");
-    exit(1);
+    exit(ECANCELED);
   }
 
   //  GC

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -8,6 +8,7 @@
 #include <time.h>
 
 #include "allocate.h"
+#include "error.h"
 #include "imprison.h"
 #include "jets/k.h"
 #include "log.h"
@@ -53,7 +54,7 @@ u3t_mean(u3_noun roc)
 void
 u3t_drop(void)
 {
-  c3_assert(_(u3du(u3R->bug.tax)));
+  u3_assert(_(u3du(u3R->bug.tax)));
   {
     u3_noun tax = u3R->bug.tax;
 
@@ -113,8 +114,8 @@ static void
 _ct_sane(u3_noun lab)
 {
   if ( u3_nul != lab ) {
-    c3_assert(c3y == u3du(lab));
-    c3_assert(c3y == u3ud(u3h(lab)));
+    u3_assert(c3y == u3du(lab));
+    u3_assert(c3y == u3ud(u3h(lab)));
     _ct_sane(u3t(lab));
   }
 }
@@ -237,7 +238,7 @@ u3t_samp(void)
       mot_l = c3_s3('f','a','r');
     }
     else if ( _(u3T.noc_o) ) {
-      c3_assert(!_(u3T.glu_o));
+      u3_assert(!_(u3T.glu_o));
       mot_l = c3_s3('n','o','c');
     }
     else if ( _(u3T.glu_o) ) {
@@ -252,7 +253,7 @@ u3t_samp(void)
     {
       u3_noun lab = _t_samp_process(rod_u);
 
-      c3_assert(u3R == &u3H->rod_u);
+      u3_assert(u3R == &u3H->rod_u);
       if ( 0 == u3R->pro.day ) {
         /* bunt a +doss
         */
@@ -464,7 +465,7 @@ u3t_event_trace(const c3_c* name, c3_c type)
 void
 u3t_print_steps(FILE* fil_u, c3_c* cap_c, c3_d sep_d)
 {
-  c3_assert( 0 != fil_u );
+  u3_assert(0 != fil_u);
 
   c3_w gib_w = (sep_d / 1000000000ULL);
   c3_w mib_w = (sep_d % 1000000000ULL) / 1000000ULL;
@@ -495,7 +496,7 @@ u3t_print_steps(FILE* fil_u, c3_c* cap_c, c3_d sep_d)
 void
 u3t_damp(FILE* fil_u)
 {
-  c3_assert( 0 != fil_u );
+  u3_assert(0 != fil_u);
 
   if ( 0 != u3R->pro.day ) {
     u3_noun wol = u3do("pi-tell", u3R->pro.day);

--- a/pkg/noun/urth.c
+++ b/pkg/noun/urth.c
@@ -702,8 +702,10 @@ u3u_mmap_read(c3_c* cap_c, c3_c* pat_c, c3_d* out_d, c3_y** out_y)
   //  open file
   //
   if ( -1 == (fid_i = c3_open(pat_c, O_RDONLY, 0644)) ) {
+    c3_i err_i = errno;
     fprintf(stderr, "%s: c3_open failed (%s): %s\r\n",
-                    cap_c, pat_c, strerror(errno));
+                    cap_c, pat_c, strerror(err_i));
+    errno = err_i;
     return c3n;
   }
 
@@ -713,9 +715,11 @@ u3u_mmap_read(c3_c* cap_c, c3_c* pat_c, c3_d* out_d, c3_y** out_y)
     struct stat buf_b;
 
     if ( -1 == fstat(fid_i, &buf_b) ) {
+      c3_i err_i = errno;
       fprintf(stderr, "%s: stat failed (%s): %s\r\n",
-                      cap_c, pat_c, strerror(errno));
+                      cap_c, pat_c, strerror(err_i));
       close(fid_i);
+      errno = err_i;
       return c3n;
     }
 
@@ -728,9 +732,11 @@ u3u_mmap_read(c3_c* cap_c, c3_c* pat_c, c3_d* out_d, c3_y** out_y)
     void* ptr_v;
 
     if ( MAP_FAILED == (ptr_v = mmap(0, len_d, PROT_READ, MAP_SHARED, fid_i, 0)) ) {
+      int err_i = errno;
       fprintf(stderr, "%s: mmap failed (%s): %s\r\n",
-                      cap_c, pat_c, strerror(errno));
+                      cap_c, pat_c, strerror(err_i));
       close(fid_i);
+      errno = err_i;
       return c3n;
     }
 

--- a/pkg/noun/urth.c
+++ b/pkg/noun/urth.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 
 #include "allocate.h"
+#include "error.h"
 #include "events.h"
 #include "hashtable.h"
 #include "imprison.h"
@@ -44,7 +45,7 @@ _cu_atom_to_ref(ur_root_t* rot_u, u3a_atom* vat_u)
       c3_y* byt_y = (c3_y*)vat_u->buf_w;
       c3_d  len_d = ((c3_d)vat_u->len_w) << 2;
 
-      c3_assert( len_d );
+      u3_assert(len_d > 0);
 
       //  NB: this call will account for any trailing null bytes
       //  caused by an overestimate in [len_d]
@@ -254,7 +255,7 @@ static u3_noun
 _cu_ref_to_noun(ur_root_t* rot_u, ur_nref ref, _cu_loom* lom_u)
 {
   switch ( ur_nref_tag(ref) ) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
 
     //  all ur indirect atoms have been pre-reallocated on the loom.
     //
@@ -369,7 +370,7 @@ static ur_nref
 _cu_realloc(FILE* fil_u, ur_root_t** tor_u, ur_nvec_t* doc_u)
 {
 #ifdef U3_MEMORY_DEBUG
-  c3_assert(0);
+  exit(ENOSYS);
 #endif
 
   //  bypassing page tracking as an optimization
@@ -451,7 +452,7 @@ u3u_meld(void)
   ur_root_t* rot_u;
   ur_nvec_t  cod_u;
 
-  c3_assert( &(u3H->rod_u) == u3R );
+  u3_assert(&(u3H->rod_u) == u3R);
 
   _cu_realloc(stderr, &rot_u, &cod_u);
 
@@ -643,7 +644,7 @@ u3u_cram(c3_c* dir_c, c3_d eve_d)
   c3_d  len_d;
   c3_y* byt_y;
 
-  c3_assert( &(u3H->rod_u) == u3R );
+  u3_assert(&(u3H->rod_u) == u3R);
 
   {
     ur_root_t* rot_u;

--- a/pkg/noun/urth.c
+++ b/pkg/noun/urth.c
@@ -703,10 +703,8 @@ u3u_mmap_read(c3_c* cap_c, c3_c* pat_c, c3_d* out_d, c3_y** out_y)
   //  open file
   //
   if ( -1 == (fid_i = c3_open(pat_c, O_RDONLY, 0644)) ) {
-    c3_i err_i = errno;
     fprintf(stderr, "%s: c3_open failed (%s): %s\r\n",
-                    cap_c, pat_c, strerror(err_i));
-    errno = err_i;
+                    cap_c, pat_c, strerror(errno));
     return c3n;
   }
 
@@ -716,11 +714,9 @@ u3u_mmap_read(c3_c* cap_c, c3_c* pat_c, c3_d* out_d, c3_y** out_y)
     struct stat buf_b;
 
     if ( -1 == fstat(fid_i, &buf_b) ) {
-      c3_i err_i = errno;
       fprintf(stderr, "%s: stat failed (%s): %s\r\n",
-                      cap_c, pat_c, strerror(err_i));
+                      cap_c, pat_c, strerror(errno));
       close(fid_i);
-      errno = err_i;
       return c3n;
     }
 
@@ -733,11 +729,9 @@ u3u_mmap_read(c3_c* cap_c, c3_c* pat_c, c3_d* out_d, c3_y** out_y)
     void* ptr_v;
 
     if ( MAP_FAILED == (ptr_v = mmap(0, len_d, PROT_READ, MAP_SHARED, fid_i, 0)) ) {
-      int err_i = errno;
       fprintf(stderr, "%s: mmap failed (%s): %s\r\n",
-                      cap_c, pat_c, strerror(err_i));
+                      cap_c, pat_c, strerror(errno));
       close(fid_i);
-      errno = err_i;
       return c3n;
     }
 

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -4,6 +4,7 @@
 #define U3_XTRACT_H
 
 #include "c3.h"
+#include "error.h"
 #include "types.h"
 
   /**  Constants.
@@ -47,13 +48,13 @@
       /* u3x_cap(): root axis, 2 or 3.
       */
 #       define u3x_cap(a_w) ({                        \
-          c3_assert( 1 < a_w );                       \
+          u3_assert(1 < a_w);                          \
           (0x2 | (a_w >> (u3x_dep(a_w) - 1))); })
 
       /* u3x_mas(): remainder after cap.
       */
 #       define u3x_mas(a_w) ({                        \
-          c3_assert( 1 < a_w );                       \
+          u3_assert(1 < a_w);                          \
           ( (a_w & ~(1 << u3x_dep(a_w))) | (1 << (u3x_dep(a_w) - 1)) ); })
 
       /* u3x_peg(): connect two axes.

--- a/pkg/ur/hashcons.c
+++ b/pkg/ur/hashcons.c
@@ -3,6 +3,7 @@
 #include "hashcons.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <stddef.h>
@@ -436,7 +437,7 @@ ur_mug
 ur_nref_mug(ur_root_t *r, ur_nref ref)
 {
   switch ( ur_nref_tag(ref) ) {
-    default: assert(0);
+    default: exit(ENOTSUP);
 
     case ur_direct: return ur_mug64(ref);
     case ur_iatom:  return r->atoms.mugs[ur_nref_idx(ref)];
@@ -525,7 +526,7 @@ ur_bytes(ur_root_t *r, ur_nref ref, uint8_t **byt, uint64_t *len)
 {
   assert( !ur_deep(ref) );
   switch ( ur_nref_tag(ref) ) {
-    default: assert(0);
+    default: exit(ENOTSUP);
 
     case ur_direct: {
       *len = ur_met3_64(ref);

--- a/pkg/ur/serial.c
+++ b/pkg/ur/serial.c
@@ -3,6 +3,7 @@
 #include "serial.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 
 static void*
@@ -21,7 +22,7 @@ static inline void
 _bsw_atom(ur_root_t *r, ur_nref ref, ur_bsw_t *bsw, uint64_t len)
 {
   switch ( ur_nref_tag(ref) ) {
-    default: assert(0);
+    default: exit(ENOTSUP);
 
     case ur_direct: return ur_bsw_atom64(bsw, len, ref);
 
@@ -190,7 +191,7 @@ _cue_next(ur_root_t      *r,
     }
 
     switch ( tag ) {
-      default: assert(0);
+      default: exit(ENOTSUP);
 
       case ur_jam_cell: {
         //  reallocate the stack if full
@@ -423,7 +424,7 @@ _cue_test_next(_cue_test_stack_t *s,
     }
 
     switch ( tag ) {
-      default: assert(0);
+      default: exit(ENOTSUP);
 
       case ur_jam_cell: {
         //  reallocate the stack if full

--- a/pkg/vere/auto.c
+++ b/pkg/vere/auto.c
@@ -12,7 +12,7 @@ u3_auto_plan(u3_auto* car_u, u3_ovum *egg_u)
   egg_u->car_u = car_u;
 
   if ( !car_u->ent_u ) {
-    c3_assert(!car_u->ext_u);
+    u3_assert(!car_u->ext_u);
 
     egg_u->pre_u = egg_u->nex_u = 0;
     car_u->ent_u = car_u->ext_u = egg_u;
@@ -42,12 +42,14 @@ u3_auto_plan(u3_auto* car_u, u3_ovum *egg_u)
 u3_ovum*
 u3_auto_redo(u3_auto* car_u, u3_ovum *egg_u)
 {
-  c3_assert( egg_u->car_u == car_u );
+  if ( egg_u->car_u != car_u ) {
+    return NULL;
+  }
 
   egg_u->try_w++;
 
   if ( !car_u->ent_u ) {
-    c3_assert(!car_u->ext_u);
+    u3_assert(!car_u->ext_u);
 
     egg_u->pre_u = egg_u->nex_u = 0;
     car_u->ent_u = car_u->ext_u = egg_u;
@@ -159,7 +161,9 @@ void
 u3_auto_drop(u3_auto* car_u, u3_ovum* egg_u)
 {
   {
-    c3_assert( egg_u->car_u );
+    if ( !egg_u->car_u ) {
+      return;
+    }
 
     //  the previous ovum (or [ext_u]) will point to our next ovum
     //
@@ -206,7 +210,7 @@ u3_auto_next(u3_auto* car_u, u3_noun* ovo)
     else {
       u3_ovum* egg_u = car_u->ext_u;
 
-      c3_assert( !egg_u->pre_u );
+      u3_assert(!egg_u->pre_u);
 
       if ( egg_u->nex_u ) {
         egg_u->nex_u->pre_u = 0;
@@ -413,9 +417,21 @@ _auto_link(u3_auto* car_u, u3_pier* pir_u, u3_auto* nex_u)
 
   //  assert that io callbacks are present (info_f and slog_f are optional)
   //
-  c3_assert( car_u->io.talk_f );
-  c3_assert( car_u->io.kick_f );
-  c3_assert( car_u->io.exit_f );
+  if ( !car_u->io.talk_f ) {
+    fprintf(stderr,
+            "auto: refusing to link driver: talk callback is NULL\r\n");
+    return NULL;
+  }
+  if ( !car_u->io.kick_f ) {
+    fprintf(stderr,
+            "auto: refusing to link driver: kick callback is NULL\r\n");
+    return NULL;
+  }
+  if ( !car_u->io.exit_f ) {
+    fprintf(stderr,
+            "auto: refusing to link driver: exit callback is NULL\r\n");
+    return NULL;
+  }
 
   car_u->pir_u = pir_u;
   car_u->nex_u = nex_u;

--- a/pkg/vere/boot_tests.c
+++ b/pkg/vere/boot_tests.c
@@ -20,12 +20,12 @@ _setup(void)
   sil_u = u3s_cue_xeno_init_with(ur_fib27, ur_fib28);
   if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) {
     printf("*** fail _setup 1\n");
-    exit(1);
+    exit(EPROTO);
   }
   u3s_cue_xeno_done(sil_u);
   if ( c3n == u3v_boot_lite(pil) ) {
     printf("*** fail _setup 2\n");
-    exit(1);
+    exit(ECANCELED);
   }
 }
 
@@ -41,18 +41,18 @@ _test_lily()
 
   if ( c3y == u3v_lily(c3__uv, cod, &lit_l) ) {
     printf("*** fail _test_lily-1\n");
-    exit(1);
+    exit(ECANCELED);
   }
   cod = u3dc("scot", c3__ud, 0x7fffffff);
   if ( (c3n == u3v_lily(c3__ud, cod, &lit_l)) ||
        (0x7fffffff != lit_l) ) {
     printf("*** fail _test_lily-2a\n");
-    exit(1);
+    exit(ECANCELED);
   }
   cod = u3dc("scot", c3__ux, u3i_word(0x80000000));
   if ( c3y == u3v_lily(c3__ux, cod, &lit_l) ) {
     printf("*** fail _test_lily-2b\n");
-    exit(1);
+    exit(ECANCELED);
   }
 }
 

--- a/pkg/vere/dawn.c
+++ b/pkg/vere/dawn.c
@@ -14,7 +14,7 @@ static uv_buf_t
 _dawn_oct_to_buf(u3_noun oct)
 {
   if ( c3n == u3a_is_cat(u3h(oct)) ) {
-    exit(1);
+    exit(EINVAL);
   }
 
   c3_w len_w  = u3h(oct);
@@ -35,7 +35,7 @@ _dawn_buf_to_oct(uv_buf_t buf_u)
   u3_noun len = u3i_words(1, (c3_w*)&buf_u.len);
 
   if ( c3n == u3a_is_cat(len) ) {
-    exit(1);
+    exit(EINVAL);
   }
 
   return u3nc(len, u3i_bytes(buf_u.len, (const c3_y*)buf_u.base));

--- a/pkg/vere/dawn.c
+++ b/pkg/vere/dawn.c
@@ -185,7 +185,7 @@ _dawn_fail(u3_noun who, u3_noun rac, u3_noun sas)
   c3_c* rac_c;
 
   switch (rac) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
     case c3__czar: {
       rac_c = "galaxy";
       break;

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 
 #include "c3.h"
+#include "error.h"
 
 /* mdb_logerror(): writes an error message and lmdb error code to f.
 */
@@ -574,7 +575,7 @@ u3_lmdb_walk_next(u3_lmdb_walk* itr_u, size_t* len_i, void** buf_v)
   MDB_val key_u, val_u;
   c3_w    ret_w, ops_w;
 
-  c3_assert( itr_u->nex_d <= itr_u->las_d );
+  u3_assert( itr_u->nex_d <= itr_u->las_d );
 
   ops_w = ( c3y == itr_u->red_o ) ? MDB_NEXT : MDB_GET_CURRENT;
   if ( (ret_w = mdb_cursor_get(itr_u->cur_u, &key_u, &val_u, ops_w)) ) {

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -139,7 +139,7 @@ _disk_commit_start(struct _cd_save* req_u)
 {
   u3_disk* log_u = req_u->log_u;
 
-  c3_assert( c3n == log_u->ted_o );
+  u3_assert( c3n == log_u->ted_o );
   log_u->ted_o = c3y;
   log_u->ted_u.data = req_u;
 
@@ -186,8 +186,8 @@ _disk_batch(u3_disk* log_u, c3_d len_d)
 {
   u3_fact* tac_u = log_u->put_u.ext_u;
 
-  c3_assert( (1ULL + log_u->dun_d) == tac_u->eve_d );
-  c3_assert( log_u->sen_d == log_u->put_u.ent_u->eve_d );
+  u3_assert( (1ULL + log_u->dun_d) == tac_u->eve_d );
+  u3_assert( log_u->sen_d == log_u->put_u.ent_u->eve_d );
 
   struct _cd_save* req_u = c3_malloc(sizeof(*req_u));
   req_u->log_u = log_u;
@@ -198,7 +198,7 @@ _disk_batch(u3_disk* log_u, c3_d len_d)
   req_u->siz_i = c3_malloc(len_d * sizeof(size_t));
 
   for ( c3_d i_d = 0ULL; i_d < len_d; ++i_d) {
-    c3_assert( (req_u->eve_d + i_d) == tac_u->eve_d );
+    u3_assert( (req_u->eve_d + i_d) == tac_u->eve_d );
 
     req_u->siz_i[i_d] = _disk_serialize_v1(tac_u, &req_u->byt_y[i_d]);
 
@@ -240,11 +240,11 @@ _disk_commit(u3_disk* log_u)
 void
 u3_disk_plan(u3_disk* log_u, u3_fact* tac_u)
 {
-  c3_assert( (1ULL + log_u->sen_d) == tac_u->eve_d );
+  u3_assert( (1ULL + log_u->sen_d) == tac_u->eve_d );
   log_u->sen_d++;
 
   if ( !log_u->put_u.ent_u ) {
-    c3_assert( !log_u->put_u.ext_u );
+    u3_assert( !log_u->put_u.ext_u );
     log_u->put_u.ent_u = log_u->put_u.ext_u = tac_u;
   }
   else {
@@ -265,8 +265,8 @@ u3_disk_boot_plan(u3_disk* log_u, u3_noun job)
   u3_fact* tac_u = u3_fact_init(++log_u->sen_d, 0, job);
 
   if ( !log_u->put_u.ent_u ) {
-    c3_assert( !log_u->put_u.ext_u );
-    c3_assert( 1ULL == log_u->sen_d );
+    u3_assert( !log_u->put_u.ext_u );
+    u3_assert( 1ULL == log_u->sen_d );
 
     log_u->put_u.ent_u = log_u->put_u.ext_u = tac_u;
   }
@@ -285,7 +285,7 @@ u3_disk_boot_plan(u3_disk* log_u, u3_noun job)
 void
 u3_disk_boot_save(u3_disk* log_u)
 {
-  c3_assert( !log_u->dun_d );
+  u3_assert( !log_u->dun_d );
   _disk_commit(log_u);
 }
 
@@ -349,8 +349,8 @@ _disk_read_done_cb(uv_timer_t* tim_u)
   u3_disk* log_u = red_u->log_u;
   u3_info  pay_u = { .ent_u = red_u->ent_u, .ext_u = red_u->ext_u };
 
-  c3_assert( red_u->ent_u );
-  c3_assert( red_u->ext_u );
+  u3_assert( red_u->ent_u );
+  u3_assert( red_u->ext_u );
   red_u->ent_u = 0;
   red_u->ext_u = 0;
 
@@ -395,13 +395,13 @@ _disk_read_one_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
   }
 
   if ( !red_u->ent_u ) {
-    c3_assert( !red_u->ext_u );
+    u3_assert( !red_u->ext_u );
 
-    c3_assert( red_u->eve_d == eve_d );
+    u3_assert( red_u->eve_d == eve_d );
     red_u->ent_u = red_u->ext_u = tac_u;
   }
   else {
-    c3_assert( (1ULL + red_u->ent_u->eve_d) == eve_d );
+    u3_assert( (1ULL + red_u->ent_u->eve_d) == eve_d );
     red_u->ent_u->nex_u = tac_u;
     red_u->ent_u = tac_u;
   }
@@ -485,7 +485,7 @@ u3_disk_save_meta(MDB_env* mdb_u,
                   c3_o     fak_o,
                   c3_w     lif_w)
 {
-  c3_assert( c3y == u3a_is_cat(lif_w) );
+  u3_assert( c3y == u3a_is_cat(lif_w) );
 
   if (  (c3n == _disk_save_meta(mdb_u, "version", 1))
      || (c3n == _disk_save_meta(mdb_u, "who", u3i_chubs(2, who_d)))
@@ -595,7 +595,7 @@ _disk_lock(c3_c* pax_c)
   c3_i  wit_i;
 
   wit_i = snprintf(paf_c, len_w, "%s/.vere.lock", pax_c);
-  c3_assert(wit_i + 1 == len_w);
+  u3_assert(wit_i + 1 == len_w);
   return paf_c;
 }
 
@@ -612,7 +612,8 @@ u3_disk_acquire(c3_c* pax_c)
     if ( 1 != fscanf(loq_u, "%" SCNu32, &pid_w) ) {
       u3l_log("lockfile %s is corrupt!", paf_c);
       kill(getpid(), SIGTERM);
-      sleep(1); c3_assert(0);
+      sleep(1);
+      exit(ENOTRECOVERABLE);
     }
     else if (pid_w != getpid()) {
       c3_w i_w;
@@ -622,7 +623,8 @@ u3_disk_acquire(c3_c* pax_c)
       if ( -1 == ret && errno == EPERM ) {
         u3l_log("disk: permission denied when trying to kill process %d!", pid_w);
         kill(getpid(), SIGTERM);
-        sleep(1); c3_assert(0);
+        sleep(1);
+        exit(EPERM);
       }
 
       if ( -1 != ret ) {
@@ -645,7 +647,7 @@ u3_disk_acquire(c3_c* pax_c)
         }
         if ( 16 == i_w ) {
           u3l_log("disk: process %d seems unkillable!", pid_w);
-          c3_assert(0);
+          exit(ECANCELED);
         }
         u3l_log("disk: stopped old process %u", pid_w);
       }
@@ -655,8 +657,9 @@ u3_disk_acquire(c3_c* pax_c)
   }
 
   if ( NULL == (loq_u = c3_fopen(paf_c, "w")) ) {
+    c3_i err_i = errno;
     u3l_log("disk: unable to open %s", paf_c);
-    c3_assert(0);
+    exit(err_i);
   }
 
   fprintf(loq_u, "%u\n", getpid());

--- a/pkg/vere/foil.c
+++ b/pkg/vere/foil.c
@@ -34,7 +34,7 @@ _foil_fail(const c3_c* why_c, c3_i err_i)
 {
   if ( err_i ) {
     u3l_log("%s: error: %s", why_c, uv_strerror(err_i));
-    c3_assert(0);
+    exit(err_i);
   } else {
     u3l_log("%s: file error", why_c);
   }

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -266,7 +266,8 @@ _conn_poke_bail(u3_ovum* egg_u, u3_noun lud)
   {
     //  wtf?
     //
-    c3_assert(!"not reached");
+    fprintf(stderr, "conn: unreachable\r\n");
+    exit(ECANCELED);
     u3z(lud); return;
   }
   can_u = _conn_find_chan(con_u, sev_l, coq_l);
@@ -661,11 +662,26 @@ _conn_sock_cb(uv_stream_t* sem_u, c3_i tas_i)
   can_u->coq_l = san_u->nex_l++;
   can_u->san_u = san_u;
   err_i = uv_timer_init(u3L, &can_u->mor_u.tim_u);
-  c3_assert(!err_i);
+  if ( err_i != 0 ) {
+    fprintf(stderr,
+            "conn: failed to initialize timer: %s\r\n",
+            uv_strerror(err_i));
+    exit(err_i);
+  }
   err_i = uv_pipe_init(u3L, &can_u->mor_u.pyp_u, 0);
-  c3_assert(!err_i);
+  if ( err_i != 0 ) {
+    fprintf(stderr,
+            "conn: failed to initialize pipe: %s\r\n",
+            uv_strerror(err_i));
+    exit(err_i);
+  }
   err_i = uv_accept(sem_u, (uv_stream_t*)&can_u->mor_u.pyp_u);
-  c3_assert(!err_i);
+  if ( err_i != 0 ) {
+    fprintf(stderr,
+            "conn: failed to accept connection: %s\r\n",
+            uv_strerror(err_i));
+    exit(err_i);
+  }
   u3_newt_read((u3_moat*)&can_u->mor_u);
   can_u->mor_u.nex_u = (u3_moor*)san_u->can_u;
   san_u->can_u = can_u;
@@ -685,14 +701,29 @@ _conn_init_sock(u3_shan* san_u)
 
   u3z(who);
   ret_i = snprintf(pip_c, sizeof(pip_c), "\\\\.\\pipe\\urbit-conn-%s", who_c + 1);
-  c3_assert(19 + strlen(who_c) == ret_i);
+  u3_assert(19 + strlen(who_c) == ret_i);
   c3_free(who_c);
   ret_i = uv_pipe_init(u3L, &san_u->pyp_u, 0);
-  c3_assert(!ret_i);
+  if ( ret_i != 0 ) {
+    fprintf(stderr,
+            "conn: failed to initialize pipe: %s\r\n",
+            uv_strerror(ret_i));
+    exit(ret_i);
+  }
   ret_i = uv_pipe_bind(&san_u->pyp_u, pip_c);
-  c3_assert(!ret_i);
+  if ( ret_i != 0 ) {
+    fprintf(stderr,
+            "conn: failed to bind: %s\r\n",
+            uv_strerror(ret_i));
+    exit(ret_i);
+  }
   ret_i = uv_listen((uv_stream_t*)&san_u->pyp_u, 0, _conn_sock_cb);
-  c3_assert(!ret_i);
+  if ( ret_i != 0 ) {
+    fprintf(stderr,
+            "conn: failed to listen: %s\r\n",
+            uv_strerror(ret_i));
+    exit(ret_i);
+  }
   u3l_log("conn: listening on %s", pip_c);
 
 #else   //  _WIN32
@@ -792,7 +823,9 @@ _conn_io_talk(u3_auto* car_u)
 
   //  initialize server, opening socket.
   //
-  c3_assert(!con_u->san_u);
+  if ( con_u->san_u ) {
+    exit(EINVAL);
+  }
   san_u = c3_calloc(sizeof(*san_u));
   san_u->nex_l = 1;
   san_u->con_u = con_u;
@@ -864,8 +897,8 @@ _conn_io_exit(u3_auto* car_u)
   c3_i              wit_i;
 
   wit_i = snprintf(paf_c, len_w, "%s/%s", pax_c, URB_SOCK_PATH);
-  c3_assert(wit_i > 0);
-  c3_assert(len_w == (c3_w)wit_i + 1);
+  u3_assert(wit_i > 0);
+  u3_assert(len_w == (c3_w)wit_i + 1);
 
   if ( 0 != unlink(paf_c) ) {
     if ( ENOENT != errno ) {

--- a/pkg/vere/io/cttp.c
+++ b/pkg/vere/io/cttp.c
@@ -323,7 +323,7 @@ _cttp_cres_new(u3_creq* ceq_u, c3_w sas_w)
 static void
 _cttp_cres_fire_body(u3_cres* res_u, u3_hbod* bod_u)
 {
-  c3_assert(!bod_u->nex_u);
+  u3_assert(!bod_u->nex_u);
 
   if ( !(res_u->bod_u) ) {
     res_u->bod_u = res_u->dob_u = bod_u;
@@ -589,7 +589,7 @@ _cttp_creq_new(u3_cttp* ctp_u, c3_l num_l, u3_noun hes)
 
   //  XX this should be checked against a whitelist
   //
-  c3_assert( c3y == u3ud(method) );
+  u3_assert(c3y == u3ud(method));
   ceq_u->met_c = u3r_string(method);
   ceq_u->url_c = _cttp_creq_url(u3k(pul));
 
@@ -612,7 +612,7 @@ _cttp_creq_new(u3_cttp* ctp_u, c3_l num_l, u3_noun hes)
 static void
 _cttp_creq_fire_body(u3_creq* ceq_u, u3_hbod *rub_u)
 {
-  c3_assert(!rub_u->nex_u);
+  u3_assert(!rub_u->nex_u);
 
   if ( !(ceq_u->rub_u) ) {
     ceq_u->rub_u = ceq_u->bur_u = rub_u;
@@ -826,7 +826,7 @@ _cttp_creq_on_connect(h2o_http1client_t* cli_u, const c3_c* err_c,
       ceq_u->sat_e = u3_csat_quit;
     }
     else {
-      c3_assert( u3_csat_ripe == ceq_u->sat_e );
+      u3_assert(u3_csat_ripe == ceq_u->sat_e);
       _cttp_creq_fail(ceq_u, err_c);
     }
     return 0;
@@ -853,8 +853,8 @@ _cttp_creq_on_connect(h2o_http1client_t* cli_u, const c3_c* err_c,
 static void
 _cttp_creq_connect(u3_creq* ceq_u)
 {
-  c3_assert( u3_csat_conn == ceq_u->sat_e );
-  c3_assert( ceq_u->ipf_c );
+  u3_assert(u3_csat_conn == ceq_u->sat_e);
+  u3_assert(ceq_u->ipf_c);
 
   //  connect by ip/port, avoiding synchronous getaddrinfo()
   //
@@ -872,7 +872,7 @@ _cttp_creq_connect(u3_creq* ceq_u)
   //  connect() failed, cb invoked synchronously
   //
   if ( u3_csat_conn != ceq_u->sat_e ) {
-    c3_assert( u3_csat_quit == ceq_u->sat_e );
+    u3_assert(u3_csat_quit == ceq_u->sat_e);
     //  only one such failure case
     //
     _cttp_creq_fail(ceq_u, "socket create error");
@@ -885,7 +885,7 @@ _cttp_creq_connect(u3_creq* ceq_u)
     //    must be synchronous, after successfull connect() call
     //
     if ( ceq_u->hot_c && (c3y == ceq_u->sec) ) {
-      c3_assert( ceq_u->cli_u );
+      u3_assert(ceq_u->cli_u);
       c3_free(ceq_u->cli_u->ssl.server_name);
       ceq_u->cli_u->ssl.server_name = strdup(ceq_u->hot_c);
     }
@@ -925,8 +925,8 @@ _cttp_creq_resolve_cb(uv_getaddrinfo_t* adr_u,
 static void
 _cttp_creq_resolve(u3_creq* ceq_u)
 {
-  c3_assert(u3_csat_addr == ceq_u->sat_e);
-  c3_assert(ceq_u->hot_c);
+  u3_assert(u3_csat_addr == ceq_u->sat_e);
+  u3_assert(ceq_u->hot_c);
 
   uv_getaddrinfo_t* adr_u = c3_malloc(sizeof(*adr_u));
   adr_u->data = ceq_u;

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -363,7 +363,7 @@ _http_req_is_auth(u3_hfig* fig_u, h2o_req_t* rec_u)
     }
 
     u3_noun aut = u3kdi_has(u3k(fig_u->ses), u3i_bytes(val_y, (c3_y*)val_c));
-    c3_assert(c3y == aut || c3n == aut);
+    u3_assert(c3y == aut || c3n == aut);
 
     return aut;
   }
@@ -589,7 +589,7 @@ _http_seq_new(u3_hcon* hon_u, h2o_req_t* rec_u)
 static void
 _http_req_dispatch(u3_hreq* req_u, u3_noun req)
 {
-  c3_assert(u3_rsat_init == req_u->sat_e);
+  u3_assert(u3_rsat_init == req_u->sat_e);
   req_u->sat_e = u3_rsat_plan;
 
   {
@@ -630,7 +630,7 @@ _http_hgen_dispose(void* ptr_v)
 static void
 _http_hgen_send(u3_hgen* gen_u)
 {
-  c3_assert( c3y == gen_u->red );
+  u3_assert(c3y == gen_u->red);
 
   u3_hreq* req_u = gen_u->req_u;
   h2o_req_t* rec_u = req_u->rec_u;
@@ -690,7 +690,7 @@ _http_hgen_proceed(h2o_generator_t* neg_u, h2o_req_t* rec_u)
   u3_hreq* req_u = gen_u->req_u;
 
   // sanity check
-  c3_assert( rec_u == req_u->rec_u );
+  u3_assert(rec_u == req_u->rec_u);
 
   gen_u->red = c3y;
 
@@ -812,7 +812,7 @@ _http_continue_respond(u3_hreq* req_u,
   //   return;
   // }
   //
-  // c3_assert( sequence == ++gen_u->sequence );
+  // u3_assert( sequence == ++gen_u->sequence );
 
   gen_u->dun = complete;
 
@@ -881,7 +881,7 @@ _http_rec_sock(h2o_req_t* rec_u)
 
   //  sanity check
   //
-  c3_assert( hon_u->sok_u == &suv_u->sok_u );
+  u3_assert(hon_u->sok_u == &suv_u->sok_u);
 
   return hon_u;
 }
@@ -1054,7 +1054,10 @@ _http_conn_free(uv_handle_t* han_t)
   u3_http* htp_u = hon_u->htp_u;
   u3_h2o_serv* h2o_u = htp_u->h2o_u;
 
-  c3_assert( 0 == hon_u->req_u );
+  if ( 0 != hon_u->req_u ) {
+    fprintf(stderr, "http: unexpected non-NULL request\r\n");
+    exit(ENOTSUP);
+  }
 
 #if 0
   {
@@ -1244,7 +1247,7 @@ _http_h2o_context_dispose(h2o_context_t* ctx)
 static void
 _http_serv_really_free(u3_http* htp_u)
 {
-  c3_assert( 0 == htp_u->hon_u );
+  u3_assert(0 == htp_u->hon_u);
 
   if ( 0 != htp_u->h2o_u ) {
     u3_h2o_serv* h2o_u = htp_u->h2o_u;
@@ -1290,7 +1293,7 @@ _http_serv_free(u3_http* htp_u)
   u3l_log("http serv free %d", htp_u->sev_l);
 #endif
 
-  c3_assert( 0 == htp_u->hon_u );
+  u3_assert(0 == htp_u->hon_u);
 
   if ( 0 == htp_u->h2o_u ) {
     _http_serv_really_free(htp_u);
@@ -1732,8 +1735,10 @@ _http_release_ports_file(c3_c *pax_c)
   c3_i  wit_i;
 
   wit_i = snprintf(paf_c, len_w, "%s/%s", pax_c, nam_c);
-  c3_assert(wit_i > 0);
-  c3_assert(len_w == (c3_w)wit_i + 1);
+  if ( wit_i <= 0 || len_w != wit_i + 1 ) {
+    fprintf(stderr, "http: snprintf() returned %d\r\n", wit_i);
+    exit(ECANCELED);
+  }
 
   c3_unlink(paf_c);
   c3_free(paf_c);
@@ -1786,7 +1791,7 @@ _http_serv_start_all(u3_httd* htd_u)
   u3_noun   dis;
   u3_form*  for_u = htd_u->fig_u.for_u;
 
-  c3_assert( 0 != for_u );
+  u3_assert(0 != for_u);
 
   // if the SSL_CTX existed, it'll be freed with the servers
   htd_u->tls_u = 0;
@@ -1843,7 +1848,7 @@ _http_serv_start_all(u3_httd* htd_u)
 
   //  send listening ports to %eyre
   {
-    c3_assert( u3_none != non );
+    u3_assert(u3_none != non);
 
     //  XX remove [sen]
     //

--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -48,8 +48,9 @@ u3_write_fd(c3_i fid_i, const void* buf_v, size_t len_i)
     //    NB: can't call u3l_log here or we would re-enter u3_write_fd()
     //
     if ( ret_i < 0 ) {
-      fprintf(stderr, "term: write failed %s\r\n", strerror(errno));
-      c3_assert(0);
+      c3_i err_i = errno;
+      fprintf(stderr, "term: write failed %s\r\n", strerror(err_i));
+      exit(err_i);
     }
     //  continue partial writes
     //
@@ -188,7 +189,8 @@ u3_term_log_init(void)
     //  Start raw input.
     //
     if ( c3n == uty_u->sta_f(uty_u) ) {
-      c3_assert(!"init-tcsetattr");
+      fprintf(stderr, "term: failed to start tty\r\n");
+      exit(ECANCELED);
     }
 
     //  initialize spinner timeout
@@ -211,7 +213,8 @@ u3_term_log_exit(void)
     for ( uty_u = u3_Host.uty_u; uty_u; uty_u = uty_u->nex_u ) {
       if ( uty_u->fid_i == -1 ) { continue; }
       if ( c3n == uty_u->sto_f(uty_u) ) {
-        c3_assert(!"exit-tcsetattr");
+        fprintf(stderr, "term: failed to stop tty\r\n");
+        exit(ECANCELED);
       }
       u3_write_fd(uty_u->fid_i, "\r\n", 2);
     }
@@ -603,8 +606,8 @@ _term_io_belt(u3_utty* uty_u, u3_noun blb)
   u3_noun wir = u3nt(c3__term, '1', u3_nul);
   u3_noun cad = u3nc(c3__belt, blb);
 
-  c3_assert( 1 == uty_u->tid_l );
-  c3_assert( uty_u->car_u );
+  u3_assert(1 == uty_u->tid_l);
+  u3_assert(uty_u->car_u);
 
   {
     u3_ovum* egg_u = _term_ovum_plan(uty_u->car_u, wir, cad);
@@ -1072,7 +1075,7 @@ u3_term_ef_winc(void)
     u3_noun wir = u3nt(c3__term, '1', u3_nul);
     u3_noun cad = u3nc(c3__blew, u3_term_get_blew(1));
 
-    c3_assert( 1 == u3_Host.uty_u->tid_l );
+    u3_assert(1 == u3_Host.uty_u->tid_l);
 
     _term_ovum_plan(u3_Host.uty_u->car_u, wir, cad);
   }
@@ -1089,7 +1092,7 @@ u3_term_ef_ctlc(void)
     u3_noun wir = u3nt(c3__term, '1', u3_nul);
     u3_noun cad = u3nq(c3__belt, c3__mod, c3__ctl, 'c');
 
-    c3_assert( 1 == uty_u->tid_l );
+    u3_assert(1 == uty_u->tid_l);
     _term_ovum_plan(uty_u->car_u, wir, cad);
   }
 }
@@ -1465,12 +1468,13 @@ u3_term_io_hija(void)
       //  We *should* in fact, produce some kind of fake FILE* for
       //  non-console terminals.  If we use this interface enough...
       //
-      c3_assert(0);
+      exit(ENOTSUP);
     }
     else {
       if ( c3n == u3_Host.ops_u.tem ) {
         if ( c3y != uty_u->hij_f(uty_u) ) {
-          c3_assert(!"hija-tcsetattr");
+          fprintf(stderr, "term: failed to hijack tty\r\n");
+          exit(ECANCELED);
         }
 
         //  move the cursor to the bottom left corner,
@@ -1496,7 +1500,7 @@ u3_term_io_loja(int x, FILE* f)
       //  We *should* in fact, produce some kind of fake FILE* for
       //  non-console terminals.  If we use this interface enough...
       //
-      c3_assert(0);
+      exit(ENOTSUP);
     }
     else {
       if ( c3y == u3_Host.ops_u.tem ) {
@@ -1505,7 +1509,8 @@ u3_term_io_loja(int x, FILE* f)
       }
       else {
         if ( c3y != uty_u->loj_f(uty_u) ) {
-          c3_assert(!"loja-tcsetattr");
+          fprintf(stderr, "term: failed to release tty\r\n");
+          exit(ECANCELED);
         }
 
         //  push the printfs up one more line,
@@ -1775,7 +1780,9 @@ u3_term_io_init(u3_pier* pir_u)
 {
   u3_auto* car_u = c3_calloc(sizeof(*car_u));
 
-  c3_assert( u3_Host.uty_u );
+  if ( !u3_Host.uty_u ) {
+    return NULL;
+  }
   u3_Host.uty_u->car_u = car_u;
 
   car_u->nam_m = c3__term;

--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -106,8 +106,8 @@ _king_doom(u3_noun doom)
   u3_noun load;
   void (*next)(u3_noun);
 
-  c3_assert(_(u3a_is_cell(doom)));
-  c3_assert(_(u3a_is_cat(u3h(doom))));
+  u3_assert(_(u3a_is_cell(doom)));
+  u3_assert(_(u3a_is_cat(u3h(doom))));
 
   switch ( u3h(doom) ) {
     case c3__boot:
@@ -133,9 +133,9 @@ _king_boot(u3_noun bul)
   u3_noun boot, pill, path;
   void (*next)(u3_noun, u3_noun, u3_noun);
 
-  c3_assert(_(u3a_is_cell(bul)));
+  u3_assert(_(u3a_is_cell(bul)));
   u3x_trel(bul, &boot, &pill, &path);
-  c3_assert(_(u3a_is_cat(u3h(boot))));
+  u3_assert(_(u3a_is_cat(u3h(boot))));
 
   switch ( u3h(boot) ) {
     case c3__fake: {
@@ -319,7 +319,7 @@ _king_get_pace(void)
   c3_i ret_i, fid_i;
 
   ret_i = asprintf(&pat_c, "%s/.bin/pace", u3_Host.dir_c);
-  c3_assert( ret_i > 0 );
+  u3_assert( ret_i > 0 );
 
   fid_i = c3_open(pat_c, O_RDONLY, 0644);
 
@@ -364,7 +364,7 @@ u3_king_next(c3_c* pac_c, c3_c** out_c)
   c3_i  ret_i;
 
   ret_i = asprintf(&url_c, "%s/%s/%s/next", ver_hos_c, pac_c, URBIT_VERSION);
-  c3_assert( ret_i > 0 );
+  u3_assert( ret_i > 0 );
 
   //  skip printfs on failed requests (/next is usually not present)
   //
@@ -372,7 +372,7 @@ u3_king_next(c3_c* pac_c, c3_c** out_c)
     c3_free(url_c);
 
     ret_i = asprintf(&url_c, "%s/%s/last", ver_hos_c, pac_c);
-    c3_assert( ret_i > 0 );
+    u3_assert( ret_i > 0 );
 
     //  enable printfs on failed requests (/last must be present)
     //  XX support channel redirections
@@ -454,7 +454,7 @@ _git_pill_url(c3_c *out_c, c3_c *arv_c)
 {
   c3_c hax_c[11];
 
-  assert(NULL != arv_c);
+  u3_assert(NULL != arv_c);
 
   if ( 0 != system("which git >> /dev/null") ) {
     c3_i err_i = errno;
@@ -487,7 +487,7 @@ _boothack_pill(void)
       _git_pill_url(url_c, u3_Host.ops_u.arv_c);
     }
     else {
-      c3_assert( 0 != u3_Host.ops_u.url_c );
+      u3_assert( 0 != u3_Host.ops_u.url_c );
       strcpy(url_c, u3_Host.ops_u.url_c);
     }
 
@@ -939,7 +939,8 @@ u3_pier*
 u3_king_stub(void)
 {
   if ( !u3K.pir_u ) {
-    c3_assert(!"king: no pier");
+    fprintf(stderr, "king: no pier\r\n");
+    exit(EEXIST);
   }
   else {
     return u3K.pir_u;
@@ -1026,8 +1027,9 @@ _king_make_pace(c3_c* pac_c)
   c3_c* bin_c;
   c3_i  ret_i;
 
-  ret_i = asprintf(&bin_c, "%s/.bin", u3_Host.dir_c);
-  c3_assert( ret_i > 0 );
+  if ( asprintf(&bin_c, "%s/.bin", u3_Host.dir_c) == -1 ) {
+    return -1;
+  }
 
   ret_i = c3_mkdir(bin_c, 0700);
 
@@ -1041,8 +1043,9 @@ _king_make_pace(c3_c* pac_c)
 
   c3_free(bin_c);
 
-  ret_i = asprintf(&bin_c, "%s/.bin/%s/", u3_Host.dir_c, pac_c);
-  c3_assert( ret_i > 0 );
+  if ( asprintf(&bin_c, "%s/.bin/%s/", u3_Host.dir_c, pac_c) == -1 ) {
+    return -1;
+  }
 
   //  XX asserting wrapper conflicts here (and is bypassed for .urb)
   //
@@ -1069,8 +1072,10 @@ static c3_i
 _king_init_pace(c3_c* pac_c)
 {
   c3_c* bin_c;
-  c3_i  fid_i, ret_i = asprintf(&bin_c, "%s/.bin/pace", u3_Host.dir_c);
-  c3_assert( ret_i > 0 );
+  c3_i  fid_i;
+  if ( asprintf(&bin_c, "%s/.bin/pace", u3_Host.dir_c) == -1 ) {
+    return -1;
+  }
 
   if ( (-1 == (fid_i = open(bin_c, O_WRONLY | O_CREAT | O_EXCL, 0644))) ) {
     if ( EEXIST == errno ) {
@@ -1114,8 +1119,9 @@ _king_link_run(c3_c* bin_c)
   c3_c* lin_c;
   c3_i  ret_i;
 
-  ret_i = asprintf(&lin_c, "%s/%s", u3_Host.dir_c, U3_BIN_ALIAS);
-  c3_assert( ret_i > 0 );
+  if ( asprintf(&lin_c, "%s/%s", u3_Host.dir_c, U3_BIN_ALIAS) == -1 ) {
+    return -1;
+  }
 
   ret_i = unlink(lin_c);
 
@@ -1128,9 +1134,11 @@ _king_link_run(c3_c* bin_c)
   ret_i = link(bin_c, lin_c);
 
   if ( ret_i ) {
+    ret_i = errno;
     fprintf(stderr, "vere: link %s -> %s failed: %s\n",
                     lin_c, bin_c, strerror(errno));
     c3_free(lin_c);
+    errno = ret_i;
     return -1;
   }
 
@@ -1152,8 +1160,9 @@ u3_king_vere(c3_c* pac_c,  // pace
   FILE* fil_u;
   c3_i  fid_i, ret_i;
 
-  ret_i = asprintf(&bin_c, "%s/vere-v%s-%s", dir_c, ver_c, arc_c);
-  c3_assert( ret_i > 0 );
+  if ( asprintf(&bin_c, "%s/vere-v%s-%s", dir_c, ver_c, arc_c) == -1 ) {
+    return -1;
+  }
 
   if (   (-1 == (fid_i = open(bin_c, O_WRONLY | O_CREAT | O_EXCL, 0755)))
      || !(fil_u = fdopen(fid_i, "wb")) )
@@ -1170,9 +1179,10 @@ u3_king_vere(c3_c* pac_c,  // pace
     }
   }
 
-  ret_i = asprintf(&url_c, "%s/%s/v%s/vere-v%s-%s",
-                   ver_hos_c, pac_c, ver_c, ver_c, arc_c);
-  c3_assert( ret_i > 0 );
+  if ( asprintf(&url_c, "%s/%s/v%s/vere-v%s-%s",
+                ver_hos_c, pac_c, ver_c, ver_c, arc_c) == -1 ) {
+    return -1;
+  }
 
   if ( (ret_i = _king_save_file(url_c, fil_u)) ) {
     u3l_log("unable to save %s to %s: %d", url_c, bin_c, ret_i);
@@ -1243,9 +1253,10 @@ _king_do_upgrade(c3_c* pac_c, c3_c* ver_c)
     exit(err_i);
   }
 
-  {
-    c3_i ret_i = asprintf(&dir_c, "%s/.bin/%s", u3_Host.dir_c, pac_c);
-    c3_assert( ret_i > 0 );
+  if ( asprintf(&dir_c, "%s/.bin/%s", u3_Host.dir_c, pac_c) == -1 ) {
+    c3_i err_i = errno;
+    fprintf(stderr, "vere: asprintf() failed: %s\r\n", strerror(err_i));
+    exit(err_i);
   }
 
   //  XX get link option
@@ -1437,9 +1448,10 @@ _king_copy_vere(c3_c* pac_c, c3_c* ver_c, c3_c* arc_c, c3_t lin_t)
     return -1; // XX
   }
 
-  ret_i = asprintf(&bin_c, "%s/.bin/%s/vere-v%s-%s",
-                           u3_Host.dir_c, pac_c, ver_c, arc_c);
-  c3_assert( ret_i > 0 );
+  if ( asprintf(&bin_c, "%s/.bin/%s/vere-v%s-%s",
+               u3_Host.dir_c, pac_c, ver_c, arc_c) == -1 ) {
+    return -1;
+  }
 
   ret_i = _king_copy_file(u3_Host.dem_c, bin_c);
 
@@ -1550,7 +1562,7 @@ u3_king_done(void)
           c3_free(ver_c);
         } break;
 
-        default: c3_assert(0);
+        default: exit(ENOTSUP);
       }
 
       c3_free(pac_c);
@@ -1606,7 +1618,7 @@ u3_king_grab(void* vod_p)
   c3_w tot_w = 0;
   FILE* fil_u;
 
-  c3_assert( u3R == &(u3H->rod_u) );
+  u3_assert(u3R == &(u3H->rod_u));
 
 #ifdef U3_MEMORY_LOG
   {

--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -95,7 +95,7 @@ void _king_doom(u3_noun doom);
 void
 _king_defy_fate()
 {
-  exit(1);
+  exit(ECANCELED);
 }
 
 /* _king_doom(): doom parser
@@ -216,7 +216,7 @@ _king_pier(u3_noun pier)
   if ( (c3n == u3du(pier)) ||
        (c3n == u3ud(u3t(pier))) ) {
     u3m_p("daemon: invalid pier", pier);
-    exit(1);
+    exit(EINVAL);
   }
 
   u3K.pir_u = u3_pier_stay(sag_w, u3k(u3t(pier)));
@@ -255,7 +255,7 @@ _king_curl_bytes(c3_c* url_c, c3_w* len_w, c3_y** hun_y, c3_t veb_t)
 
   if ( !(cul_u = curl_easy_init()) ) {
     u3l_log("failed to initialize libcurl");
-    exit(1);
+    exit(ECANCELED);
   }
 
   u3K.ssl_curl_f(cul_u);
@@ -300,7 +300,7 @@ _king_get_atom(c3_c* url_c)
 
   if ( _king_curl_bytes(url_c, &len_w, &hun_y, 1) ) {
     u3_king_bail();
-    exit(1);
+    exit(ECANCELED);
   }
 
   pro = u3i_bytes(len_w, hun_y);
@@ -418,13 +418,14 @@ _get_cmd_output(c3_c *cmd_c, c3_c *out_c, c3_w len_c)
 {
   FILE *fp = popen(cmd_c, "r");
   if ( NULL == fp ) {
-    u3l_log("'%s' failed", cmd_c);
-    exit(1);
+    c3_i err_i = errno;
+    u3l_log("'%s' failed: %s", cmd_c, strerror(err_i));
+    exit(err_i);
   }
 
   if ( NULL == fgets(out_c, len_c, fp) ) {
     u3l_log("'%s' produced no output", cmd_c);
-    exit(1);
+    exit(ECANCELED);
   }
 
   pclose(fp);
@@ -456,8 +457,9 @@ _git_pill_url(c3_c *out_c, c3_c *arv_c)
   assert(NULL != arv_c);
 
   if ( 0 != system("which git >> /dev/null") ) {
-    u3l_log("boot: could not find git executable");
-    exit(1);
+    c3_i err_i = errno;
+    u3l_log("boot: could not find git executable: %s", strerror(err_i));
+    exit(err_i);
   }
 
   _arvo_hash(hax_c, arv_c);
@@ -517,7 +519,7 @@ _boothack_key(u3_noun kef)
       c3_c* kef_c = u3r_string(kef);
       u3l_log("dawn: invalid private keys: %s", kef_c);
       c3_free(kef_c);
-      exit(1);
+      exit(ECANCELED);
     }
 
     //  +feed:able:jael: keyfile
@@ -525,7 +527,7 @@ _boothack_key(u3_noun kef)
     u3_noun pro = u3m_soft(0, u3ke_cue, u3k(u3t(des)));
     if ( u3_blip != u3h(pro) ) {
       u3l_log("dawn: unable to cue keyfile");
-      exit(1);
+      exit(EPROTO);
     }
     seed = u3k(u3t(pro));
     u3z(pro);
@@ -549,7 +551,7 @@ _boothack_key(u3_noun kef)
     if ( u3_nul == whu ) {
       u3l_log("dawn: invalid ship specified with -w %s",
               u3_Host.ops_u.who_c);
-      exit(1);
+      exit(EINVAL);
     }
 
     if ( (u3_none != ship) &&
@@ -562,7 +564,7 @@ _boothack_key(u3_noun kef)
 
       u3z(how);
       c3_free(how_c);
-      exit(1);
+      exit(ECANCELED);
     }
 
     u3z(woh);
@@ -623,7 +625,7 @@ _boothack_doom(void)
     }
     else {
       u3l_log("boot: must specify a key with -k or -G");
-      exit(1);
+      exit(EINVAL);
     }
 
     bot = u3nc(c3__dawn, _boothack_key(kef));
@@ -835,9 +837,10 @@ _king_boot_ivory(void)
 
   if ( u3_Host.ops_u.lit_c ) {
     if ( c3n == u3u_mmap_read("lite", u3_Host.ops_u.lit_c, &len_d, &byt_y) ) {
+      c3_i err_i = errno;
       u3l_log("lite: unable to load ivory pill at %s",
               u3_Host.ops_u.lit_c);
-      exit(1);
+      exit(err_i);
     }
   }
   else {
@@ -851,22 +854,23 @@ _king_boot_ivory(void)
 
     if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) {
       u3l_log("lite: unable to cue ivory pill");
-      exit(1);
+      exit(EPROTO);
     }
 
     u3s_cue_xeno_done(sil_u);
 
     if ( c3n == u3v_boot_lite(pil)) {
       u3l_log("lite: boot failed");
-      exit(1);
+      exit(ECANCELED);
     }
   }
 
   if ( u3_Host.ops_u.lit_c ) {
     if ( c3n == u3u_munmap(len_d, byt_y) ) {
+      c3_i err_i = errno;
       u3l_log("lite: unable to unmap ivory pill at %s",
               u3_Host.ops_u.lit_c);
-      exit(1);
+      exit(err_i);
     }
   }
 }
@@ -915,8 +919,9 @@ u3_king_commence()
     rlm.rlim_cur = 0;
 
     if ( 0 != setrlimit(RLIMIT_CORE, &rlm) ) {
-      u3l_log("king: unable to disable core dumps: %s", strerror(errno));
-      exit(1);
+      c3_i err_i = errno;
+      u3l_log("king: unable to disable core dumps: %s", strerror(err_i));
+      exit(err_i);
     }
   }
 
@@ -988,7 +993,7 @@ _king_save_file(c3_c* url_c, FILE* fil_u)
 
   if ( !(cul_u = curl_easy_init()) ) {
     u3l_log("failed to initialize libcurl");
-    exit(1);
+    exit(ECANCELED);
   }
 
   u3K.ssl_curl_f(cul_u);
@@ -1027,8 +1032,10 @@ _king_make_pace(c3_c* pac_c)
   ret_i = c3_mkdir(bin_c, 0700);
 
   if ( ret_i && (EEXIST != errno) ) {
-    fprintf(stderr, "vere: mkdir %s failed: %s\n", bin_c, strerror(errno));
+    c3_i err_i = errno;
+    fprintf(stderr, "vere: mkdir %s failed: %s\n", bin_c, strerror(err_i));
     c3_free(bin_c);
+    errno = err_i;
     return -1;
   }
 
@@ -1042,8 +1049,10 @@ _king_make_pace(c3_c* pac_c)
   ret_i = mkdir(bin_c, 0700);
 
   if ( ret_i && (EEXIST != errno) ) {
-    fprintf(stderr, "vere: mkdir %s failed: %s\n", bin_c, strerror(errno));
+    c3_i err_i = errno;
+    fprintf(stderr, "vere: mkdir %s failed: %s\n", bin_c, strerror(err_i));
     c3_free(bin_c);
+    errno = err_i;
     return -1;
   }
 
@@ -1228,9 +1237,10 @@ _king_do_upgrade(c3_c* pac_c, c3_c* ver_c)
 #endif
 
   if ( _king_make_pace(pac_c) ) {
+    c3_i err_i = errno;
     u3l_log("vere: unable to make pace (%s) directory in pier", pac_c);
     u3_king_bail();
-    exit(1);
+    exit(err_i);
   }
 
   {
@@ -1243,7 +1253,7 @@ _king_do_upgrade(c3_c* pac_c, c3_c* ver_c)
   if ( u3_king_vere(pac_c, ver_c, arc_c, dir_c, 1) ) {
     u3l_log("vere: upgrade failed");
     u3_king_bail();
-    exit(1);
+    exit(ECANCELED);
   }
 
   c3_free(dir_c);
@@ -1470,7 +1480,7 @@ u3_king_dock(c3_c* pac_c)
   if ( _king_copy_vere(pac_c, URBIT_VERSION, arc_c, 1) ) {
     u3l_log("vere: binary copy failed");
     u3_king_bail();
-    exit(1);
+    exit(ECANCELED);
   }
   else {
     //  NB: failure ignored

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -74,7 +74,7 @@ static void
 _lord_writ_free(u3_writ* wit_u)
 {
   switch ( wit_u->typ_e ) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
 
     case u3_writ_work: {
       //  XX confirm
@@ -170,7 +170,9 @@ _lord_writ_pop(u3_lord* god_u)
 {
   u3_writ* wit_u = god_u->ext_u;
 
-  c3_assert( wit_u );
+  if ( !wit_u ) {
+    return NULL;
+  }
 
   if ( !wit_u->nex_u ) {
     god_u->ent_u = god_u->ext_u = 0;
@@ -191,7 +193,7 @@ static inline const c3_c*
 _lord_writ_str(u3_writ_type typ_e)
 {
   switch ( typ_e ) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
 
     case u3_writ_work: return "work";
     case u3_writ_peek: return "peek";
@@ -530,7 +532,9 @@ _lord_work_spin(u3_lord* god_u)
 
   //  complete spinner
   //
-  c3_assert( c3y == god_u->pin_o );
+  if ( c3y != god_u->pin_o ) {
+    return;
+  }
   god_u->cb_u.spun_f(god_u->cb_u.ptr_v);
   god_u->pin_o = c3n;
 
@@ -764,7 +768,7 @@ _lord_writ_make(u3_lord* god_u, u3_writ* wit_u)
   u3_noun msg;
 
   switch ( wit_u->typ_e ) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
 
     case u3_writ_work: {
       u3_noun mil = u3i_words(1, &wit_u->wok_u.egg_u->mil_w);
@@ -855,8 +859,8 @@ static void
 _lord_writ_plan(u3_lord* god_u, u3_writ* wit_u)
 {
   if ( !god_u->ent_u ) {
-    c3_assert( !god_u->ext_u );
-    c3_assert( !god_u->dep_w );
+    u3_assert( !god_u->ext_u );
+    u3_assert( !god_u->dep_w );
     god_u->dep_w = 1;
     god_u->ent_u = god_u->ext_u = wit_u;
   }
@@ -886,7 +890,7 @@ u3_lord_peek(u3_lord* god_u, u3_pico* pic_u)
   {
     u3_noun sam;
     switch ( pic_u->typ_e ) {
-      default: c3_assert(0);
+      default: exit(ENOTSUP);
 
       case u3_pico_full: {
         sam = u3k(pic_u->ful);
@@ -919,7 +923,7 @@ u3_lord_play(u3_lord* god_u, u3_info fon_u)
 
   //  XX wat do?
   //
-  // c3_assert( !pay_u.ent_u->nex_u );
+  // u3_assert( !pay_u.ent_u->nex_u );
 
   _lord_writ_plan(god_u, wit_u);
 }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -120,7 +120,7 @@ _main_repath(c3_c* pax_c)
   c3_w  len_w;
   c3_i  wit_i;
 
-  c3_assert(pax_c);
+  assert(pax_c);
   if ( 0 != (rel_c = realpath(pax_c, 0)) ) {
     return rel_c;
   }
@@ -128,11 +128,13 @@ _main_repath(c3_c* pax_c)
   if ( !fas_c ) {
     c3_c rec_c[2048];
 
-    wit_i = snprintf(rec_c, sizeof(rec_c), "./%s", pax_c);
-    c3_assert(sizeof(rec_c) > wit_i);
+    assert(sizeof(rec_c) > snprintf(rec_c, sizeof(rec_c), "./%s", pax_c));
     return _main_repath(rec_c);
   }
-  c3_assert(u3_unix_cane(fas_c + 1));
+  if ( !u3_unix_cane(fas_c + 1) ) {
+    fprintf(stderr, "main: path %s is not canonical\r\n", fas_c + 1);
+    exit(ECANCELED);
+  }
   *fas_c = 0;
   dir_c = realpath(pax_c, 0);
   *fas_c = '/';
@@ -142,7 +144,7 @@ _main_repath(c3_c* pax_c)
   len_w = strlen(dir_c) + strlen(fas_c) + 1;
   rel_c = c3_malloc(len_w);
   wit_i = snprintf(rel_c, len_w, "%s%s", dir_c, fas_c);
-  c3_assert(len_w == wit_i + 1);
+  assert(len_w == wit_i + 1);
   c3_free(dir_c);
   return rel_c;
 }
@@ -1021,13 +1023,34 @@ _cw_init_io(uv_loop_t* lup_u)
   {
     c3_i err_i;
     err_i = uv_timer_init(lup_u, &inn_u.tim_u);
-    c3_assert(!err_i);
+    if ( err_i != 0 ) {
+      fprintf(stderr,
+              "main: failed to initialize timer: %s\r\n",
+              uv_strerror(err_i));
+      exit(err_i);
+    }
     err_i = uv_pipe_init(lup_u, &inn_u.pyp_u, 0);
-    c3_assert(!err_i);
+    if ( err_i != 0 ) {
+      fprintf(stderr,
+              "main: failed to initialize pipe: %s\r\n",
+              uv_strerror(err_i));
+      exit(err_i);
+    }
     uv_pipe_open(&inn_u.pyp_u, inn_i);
     err_i = uv_pipe_init(lup_u, &out_u.pyp_u, 0);
-    c3_assert(!err_i);
+    if ( err_i != 0 ) {
+      fprintf(stderr,
+              "main: failed to failed to initialize pipe: %s\r\n",
+              uv_strerror(err_i));
+      exit(err_i);
+    }
     uv_pipe_open(&out_u.pyp_u, out_i);
+    if ( err_i != 0 ) {
+      fprintf(stderr,
+              "main: failed to failed to open pipe: %s\r\n",
+              uv_strerror(err_i));
+      exit(err_i);
+    }
 
     uv_stream_set_blocking((uv_stream_t*)&out_u.pyp_u, 1);
   }
@@ -1320,7 +1343,12 @@ _cw_eval(c3_i argc, c3_c* argv[])
   {
     c3_i err_i;
     err_i = uv_pipe_init(uv_default_loop(), &std_u.pyp_u, 0);
-    c3_assert(!err_i);
+    if ( err_i != 0 ) {
+      fprintf(stderr,
+              "conn: failed to initialize pipe: %s\r\n",
+              uv_strerror(err_i));
+      exit(err_i);
+    }
     uv_pipe_open(&std_u.pyp_u, 1);
 
     std_u.ptr_v = NULL;
@@ -2239,7 +2267,7 @@ _cw_vere(c3_i argc, c3_c* argv[])
         fprintf(stderr, "vere: next (%%%s): %s\n", pac_c, ver_c);
       } break;
 
-      default: c3_assert(0);
+      default: exit(ENOTSUP);
     }
   }
 
@@ -2311,7 +2339,7 @@ _cw_vile(c3_i argc, c3_c* argv[])
 
 
   switch ( u3h(res) ) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
 
     case c3n: {
       fprintf(stderr, "vile: unable to retrieve key file\r\n");
@@ -2426,7 +2454,7 @@ main(c3_i   argc,
   //  parse for subcommands
   //
   switch ( _cw_utils(argc, argv) ) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
 
     //  no matching subcommand, parse arguments
     //

--- a/pkg/vere/noun_tests.c
+++ b/pkg/vere/noun_tests.c
@@ -1761,7 +1761,7 @@ main(int argc, char* argv[])
 
   if ( !_test_noun() ) {
     fprintf(stderr, "test noun: failed\r\n");
-    exit(1);
+    exit(ECANCELED);
   }
 
   //  GC

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -20,7 +20,7 @@ static void
 _pier_peek_plan(u3_pier* pir_u, u3_pico* pic_u)
 {
   if (!pir_u->pec_u.ent_u) {
-    c3_assert( !pir_u->pec_u.ext_u );
+    u3_assert(!pir_u->pec_u.ext_u);
     pir_u->pec_u.ent_u = pir_u->pec_u.ext_u = pic_u;
   }
   else {
@@ -128,7 +128,7 @@ _pier_work_send(u3_work* wok_u)
 static void
 _pier_gift_plan(u3_work* wok_u, u3_gift* gif_u)
 {
-  c3_assert( gif_u->eve_d > wok_u->fec_u.rel_d );
+  u3_assert(gif_u->eve_d > wok_u->fec_u.rel_d);
 
 #ifdef VERBOSE_PIER
   fprintf(stderr, "pier: (%" PRIu64 "): compute: complete\r\n", gif_u->eve_d);
@@ -137,7 +137,7 @@ _pier_gift_plan(u3_work* wok_u, u3_gift* gif_u)
   gif_u->nex_u = 0;
 
   if ( !wok_u->fec_u.ent_u ) {
-    c3_assert( !wok_u->fec_u.ext_u );
+    u3_assert(!wok_u->fec_u.ext_u);
     wok_u->fec_u.ent_u = wok_u->fec_u.ext_u = gif_u;
   }
   else {
@@ -165,7 +165,7 @@ _pier_gift_next(u3_work* wok_u)
       wok_u->fec_u.ent_u = 0;
     }
 
-    c3_assert( (1ULL + wok_u->fec_u.rel_d) == gif_u->eve_d );
+    u3_assert((1ULL + wok_u->fec_u.rel_d) == gif_u->eve_d);
     wok_u->fec_u.rel_d = gif_u->eve_d;
 
     return gif_u;
@@ -195,7 +195,7 @@ static void
 _pier_wall_plan(u3_pier* pir_u, c3_d eve_d,
                 void* ptr_v, void (*wal_f)(void*, c3_d))
 {
-  c3_assert( u3_psat_work == pir_u->sat_e );
+  u3_assert(u3_psat_work == pir_u->sat_e);
 
   u3_wall* wal_u = c3_malloc(sizeof(*wal_u));
   wal_u->ptr_v = ptr_v;
@@ -271,7 +271,7 @@ _pier_work(u3_work* wok_u)
     _pier_work_send(wok_u);
   }
   else {
-    c3_assert( u3_psat_done == pir_u->sat_e );
+    u3_assert(u3_psat_done == pir_u->sat_e);
   }
 }
 
@@ -282,7 +282,7 @@ _pier_on_lord_work_spin(void* ptr_v, u3_atom pin, c3_o del_o)
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert(  (u3_psat_wyrd == pir_u->sat_e)
+  u3_assert((u3_psat_wyrd == pir_u->sat_e)
            || (u3_psat_work == pir_u->sat_e)
            || (u3_psat_done == pir_u->sat_e) );
 
@@ -296,7 +296,7 @@ _pier_on_lord_work_spun(void* ptr_v)
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert(  (u3_psat_wyrd == pir_u->sat_e)
+  u3_assert((u3_psat_wyrd == pir_u->sat_e)
            || (u3_psat_work == pir_u->sat_e)
            || (u3_psat_done == pir_u->sat_e) );
 
@@ -313,8 +313,7 @@ _pier_on_lord_work_done(void*    ptr_v,
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert(  (u3_psat_work == pir_u->sat_e)
-           || (u3_psat_done == pir_u->sat_e) );
+  u3_assert(u3_psat_work == pir_u->sat_e || u3_psat_done == pir_u->sat_e);
 
 #ifdef VERBOSE_PIER
   fprintf(stderr, "pier (%" PRIu64 "): work: done\r\n", tac_u->eve_d);
@@ -341,8 +340,7 @@ _pier_on_lord_work_bail(void* ptr_v, u3_ovum* egg_u, u3_noun lud)
   fprintf(stderr, "pier: work: bail\r\n");
 #endif
 
-  c3_assert(  (u3_psat_work == pir_u->sat_e)
-           || (u3_psat_done == pir_u->sat_e) );
+  u3_assert(u3_psat_work == pir_u->sat_e || u3_psat_done == pir_u->sat_e);
 
   u3_auto_bail(egg_u, lud);
 
@@ -537,7 +535,7 @@ _pier_work_init(u3_pier* pir_u)
 {
   u3_work* wok_u;
 
-  c3_assert( u3_psat_wyrd == pir_u->sat_e );
+  u3_assert(u3_psat_wyrd == pir_u->sat_e);
 
   pir_u->sat_e = u3_psat_work;
   pir_u->wok_u = wok_u = c3_calloc(sizeof(*wok_u));
@@ -728,7 +726,13 @@ _pier_on_lord_wyrd_done(void*    ptr_v,
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert( u3_psat_wyrd == pir_u->sat_e );
+  if ( u3_psat_wyrd != pir_u->sat_e ) {
+    fprintf(stderr,
+            "pier: unsupported state %u, expected %u\r\n",
+            pir_u->sat_e,
+            u3_psat_wyrd);
+    exit(ENOTSUP);
+  }
 
   //  arvo's side of version negotiation succeeded
   //  traverse [gif_y] and validate
@@ -764,7 +768,14 @@ _pier_on_lord_wyrd_bail(void* ptr_v, u3_ovum* egg_u, u3_noun lud)
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert( u3_psat_wyrd == pir_u->sat_e );
+  if ( u3_psat_wyrd != pir_u->sat_e ) {
+    fprintf(stderr,
+            "pier: unsupported state %u, expected %u\r\n",
+            pir_u->sat_e,
+            u3_psat_wyrd);
+    exit(ENOTSUP);
+  }
+
 
   //  XX add cli argument to bypass negotiation failure
   //
@@ -851,7 +862,7 @@ _pier_wyrd_init(u3_pier* pir_u)
     god_u->cb_u.work_done_f = _pier_on_lord_wyrd_done;
     god_u->cb_u.work_bail_f = _pier_on_lord_wyrd_bail;
 
-    c3_assert( u3_auto_next(car_u, &ovo) == egg_u );
+    u3_assert( u3_auto_next(car_u, &ovo) == egg_u );
 
     {
       struct timeval tim_tv;
@@ -870,7 +881,7 @@ _pier_play_plan(u3_play* pay_u, u3_info fon_u)
   c3_d      old_d;
 
   if ( !pay_u->ext_u ) {
-    c3_assert( !pay_u->ent_u );
+    u3_assert( !pay_u->ent_u );
     ext_u = &pay_u->ext_u;
     old_d = pay_u->sen_d;
   }
@@ -886,7 +897,7 @@ _pier_play_plan(u3_play* pay_u, u3_info fon_u)
                   old_d);
 #endif
 
-  c3_assert( (1ULL + old_d) == fon_u.ext_u->eve_d );
+  u3_assert( (1ULL + old_d) == fon_u.ext_u->eve_d );
 
   *ext_u = fon_u.ext_u;
   pay_u->ent_u = fon_u.ent_u;
@@ -1055,7 +1066,7 @@ _pier_play(u3_play* pay_u)
     }
   }
   else {
-    c3_assert( god_u->eve_d < pay_u->eve_d );
+    u3_assert( god_u->eve_d < pay_u->eve_d );
     _pier_play_send(pay_u);
     _pier_play_read(pay_u);
   }
@@ -1070,7 +1081,7 @@ _pier_on_lord_play_done(void* ptr_v, u3_info fon_u, c3_l mug_l)
   u3_fact* tac_u = fon_u.ent_u;
   u3_fact* nex_u;
 
-  c3_assert( u3_psat_play == pir_u->sat_e );
+  u3_assert( u3_psat_play == pir_u->sat_e );
 
   u3l_log("pier: (%" PRIu64 "): play: done", tac_u->eve_d);
 
@@ -1107,7 +1118,7 @@ _pier_on_lord_play_bail(void* ptr_v, u3_info fon_u,
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert( u3_psat_play == pir_u->sat_e );
+  u3_assert( u3_psat_play == pir_u->sat_e );
 
   {
     u3_fact* tac_u = fon_u.ext_u;
@@ -1182,11 +1193,11 @@ _pier_play_init(u3_pier* pir_u, c3_d eve_d)
   u3_disk* log_u = pir_u->log_u;
   u3_play* pay_u;
 
-  c3_assert(  (u3_psat_init == pir_u->sat_e)
+  u3_assert(  (u3_psat_init == pir_u->sat_e)
            || (u3_psat_boot == pir_u->sat_e) );
 
-  c3_assert( eve_d >  god_u->eve_d );
-  c3_assert( eve_d <= log_u->dun_d );
+  u3_assert( eve_d >  god_u->eve_d );
+  u3_assert( eve_d <= log_u->dun_d );
 
   pir_u->sat_e = u3_psat_play;
   pir_u->pay_u = pay_u = c3_calloc(sizeof(*pay_u));
@@ -1216,7 +1227,7 @@ _pier_on_disk_read_done(void* ptr_v, u3_info fon_u)
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert( u3_psat_play == pir_u->sat_e );
+  u3_assert( u3_psat_play == pir_u->sat_e );
 
   _pier_play_plan(pir_u->pay_u, fon_u);
   _pier_play(pir_u->pay_u);
@@ -1229,7 +1240,7 @@ _pier_on_disk_read_bail(void* ptr_v, c3_d eve_d)
 {
   u3_pier* pir_u = ptr_v;
 
-  c3_assert( u3_psat_play == pir_u->sat_e );
+  u3_assert( u3_psat_play == pir_u->sat_e );
 
   //  XX s/b play_bail_cb
   //
@@ -1261,7 +1272,7 @@ _pier_on_disk_write_done(void* ptr_v, c3_d eve_d)
     }
   }
   else {
-    c3_assert(  (u3_psat_work == pir_u->sat_e)
+    u3_assert(  (u3_psat_work == pir_u->sat_e)
              || (u3_psat_done == pir_u->sat_e) );
 
     _pier_work(pir_u->wok_u);
@@ -1394,7 +1405,7 @@ _pier_on_lord_live(void* ptr_v)
   fprintf(stderr, "pier: (%" PRIu64 "): boot at mug %x\r\n", god_u->eve_d, god_u->mug_l);
 #endif
 
-  c3_assert( god_u->eve_d <= log_u->dun_d );
+  u3_assert( god_u->eve_d <= log_u->dun_d );
 
   if ( u3_psat_boot == pir_u->sat_e ) {
     //  boot-sequence commit complete
@@ -1408,8 +1419,8 @@ _pier_on_lord_live(void* ptr_v)
     }
   }
   else {
-    c3_assert( u3_psat_init == pir_u->sat_e );
-    c3_assert( log_u->sen_d == log_u->dun_d );
+    u3_assert( u3_psat_init == pir_u->sat_e );
+    u3_assert( log_u->sen_d == log_u->dun_d );
 
     if ( god_u->eve_d < log_u->dun_d ) {
       c3_d eve_d;
@@ -1737,7 +1748,7 @@ _pier_pill_parse(u3_noun pil)
   u3_boot bot_u;
   u3_noun pil_p, pil_q;
 
-  c3_assert( c3y == u3du(pil) );
+  u3_assert( c3y == u3du(pil) );
   u3x_cell(pil, &pil_p, &pil_q);
 
   {
@@ -1803,7 +1814,7 @@ _pier_pill_parse(u3_noun pil)
 
       u3_noun tag = u3h(u3t(ovo));
       if ( ( c3__into == tag ) || ( c3__park == tag ) ) {
-        c3_assert( 0 == len_w );
+        u3_assert( 0 == len_w );
         len_w++;
         ovo = u3t(pil_q);
       }
@@ -1812,7 +1823,7 @@ _pier_pill_parse(u3_noun pil)
       ova = u3t(ova);
     }
 
-    c3_assert( 1 == len_w );
+    u3_assert( 1 == len_w );
 
     u3z(bot_u.use);
     bot_u.use = u3kb_flop(new);
@@ -1874,7 +1885,7 @@ _pier_boot_make(u3_noun who,
     //  XX do something about this wire
     //  XX route directly to %jael?
     //
-    c3_assert( c3y == u3a_is_cell(ven) );
+    u3_assert( c3y == u3a_is_cell(ven) );
 
     u3_noun wir = u3nq(c3__d, c3__term, '1', u3_nul);
     u3_noun cad = u3nt(c3__boot, u3_Host.ops_u.lit, ven); // transfer
@@ -2163,7 +2174,7 @@ _pier_done(u3_pier* pir_u)
 static void
 _pier_exit(u3_pier* pir_u)
 {
-  c3_assert( u3_psat_done == pir_u->sat_e );
+  u3_assert( u3_psat_done == pir_u->sat_e );
 
   if ( pir_u->log_u ) {
     u3_disk_exit(pir_u->log_u);
@@ -2221,7 +2232,7 @@ u3_pier_exit(u3_pier* pir_u)
   switch ( pir_u->sat_e ) {
     default: {
       fprintf(stderr, "pier: unknown exit: %u\r\n", pir_u->sat_e);
-      c3_assert(0);
+      exit(ECANCELED);
     }
 
     case u3_psat_done: return;

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1715,7 +1715,7 @@ u3_pier_stay(c3_w wag_w, u3_noun pax)
     //  XX dispose
     //
     u3_pier_bail(pir_u);
-    exit(1);
+    exit(ECANCELED);
   }
 
   if ( c3y == u3_Host.ops_u.veb ) {
@@ -1752,13 +1752,13 @@ _pier_pill_parse(u3_noun pil)
       u3m_p("mot", u3h(pro));
       fprintf(stderr, "boot: failed: unable to parse pill\r\n");
       u3_king_bail();
-      exit(1);
+      exit(ECANCELED);
     }
 
     if ( c3y == u3r_sing_c("ivory", tag) ) {
       fprintf(stderr, "boot: failed: unable to boot from ivory pill\r\n");
       u3_king_bail();
-      exit(1);
+      exit(ECANCELED);
     }
     else if ( c3__pill != tag ) {
       if ( c3y == u3a_is_atom(tag) ) {
@@ -1766,7 +1766,7 @@ _pier_pill_parse(u3_noun pil)
       }
       fprintf(stderr, "boot: failed: unrecognized pill\r\n");
       u3_king_bail();
-      exit(1);
+      exit(ECANCELED);
     }
 
     {
@@ -1776,7 +1776,7 @@ _pier_pill_parse(u3_noun pil)
       if ( c3n == u3r_qual(dat, &typ, &bot_u.bot, &bot_u.mod, &bot_u.use) ) {
         fprintf(stderr, "boot: failed: unable to extract pill\r\n");
         u3_king_bail();
-        exit(1);
+        exit(ECANCELED);
       }
 
       if ( c3y == u3a_is_atom(typ) ) {
@@ -1994,7 +1994,7 @@ u3_pier_boot(c3_w  wag_w,                   //  config flags
     //  XX dispose
     //
     u3_pier_bail(pir_u);
-    exit(1);
+    exit(ECANCELED);
   }
 
   u3z(pax);

--- a/pkg/vere/platform/darwin/daemon.c
+++ b/pkg/vere/platform/darwin/daemon.c
@@ -31,7 +31,9 @@ static void _on_boot_completed_cb() {
   }
 
   if ( 0 == write(_child_process_booted_signal_fd, buf, 1) ) {
-    c3_assert(!"_on_boot_completed_cb: Can't write to parent FD");
+    c3_i err_i = errno;
+    fprintf(stderr, "daemon: write() failed: %s\r\n", strerror(err_i));
+    exit(err_i);
   }
 
   close(_child_process_booted_signal_fd);
@@ -65,7 +67,11 @@ u3_daemon_init()
   c3_i pipefd[2];
 
   if ( 0 != pipe(pipefd) ) {
-    c3_assert(!"Failed to create pipe");
+    c3_i err_i = errno;
+    fprintf(stderr,
+            "daemon: failed to create pipe: %s\r\n",
+            strerror(err_i));
+    exit(err_i);
   }
 
   pid_t childpid = fork();

--- a/pkg/vere/platform/darwin/ptty.c
+++ b/pkg/vere/platform/darwin/ptty.c
@@ -47,7 +47,11 @@ _ttyf_start_raw_input(u3_utty* uty_u)
     return c3n;
   }
   if ( -1 == fcntl(uty_u->fid_i, F_SETFL, pty_u->nob_i) ) {
-    c3_assert(!"init-fcntl");
+    c3_i err_i = errno;
+    fprintf(stderr,
+            "ptty: failed to set file status flags: %s\r\n",
+            strerror(err_i));
+    exit(err_i);
   }
   return c3y;
 }
@@ -62,7 +66,11 @@ _ttyf_end_raw_input(u3_utty* uty_u)
     return c3n;
   }
   if ( -1 == fcntl(uty_u->fid_i, F_SETFL, pty_u->cug_i) ) {
-    c3_assert(!"exit-fcntl");
+    c3_i err_i = errno;
+    fprintf(stderr,
+            "ptty: failed to set file status flags: %s\r\n",
+            strerror(err_i));
+    exit(err_i);
   }
   return c3y;
 }
@@ -75,19 +83,19 @@ _ttyf_hija(u3_utty* uty_u)
   u3_ptty* pty_u = (u3_ptty*)uty_u;
   if ( 0 != _term_tcsetattr(1, TCSADRAIN, &pty_u->bak_u) ) {
     perror("hija-tcsetattr-1");
-    c3_assert(!"hija-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(1, F_SETFL, pty_u->cug_i) ) {
     perror("hija-fcntl-1");
-    c3_assert(!"hija-fcntl");
+    exit(errno);
   }
   if ( 0 != _term_tcsetattr(0, TCSADRAIN, &pty_u->bak_u) ) {
     perror("hija-tcsetattr-0");
-    c3_assert(!"hija-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(0, F_SETFL, pty_u->cug_i) ) {
     perror("hija-fcntl-0");
-    c3_assert(!"hija-fcntl");
+    exit(errno);
   }
   return c3y;
 }
@@ -100,19 +108,19 @@ _ttyf_loja(u3_utty* uty_u)
   u3_ptty* pty_u = (u3_ptty*)uty_u;
   if ( 0 != _term_tcsetattr(1, TCSADRAIN, &pty_u->raw_u) ) {
     perror("loja-tcsetattr-1");
-    c3_assert(!"loja-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(1, F_SETFL, pty_u->nob_i) ) {
     perror("hija-fcntl-1");
-    c3_assert(!"loja-fcntl");
+    exit(errno);
   }
   if ( 0 != _term_tcsetattr(0, TCSADRAIN, &pty_u->raw_u) ) {
     perror("loja-tcsetattr-0");
-    c3_assert(!"loja-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(0, F_SETFL, pty_u->nob_i) ) {
     perror("hija-fcntl-0");
-    c3_assert(!"loja-fcntl");
+    exit(errno);
   }
   return c3y;
 }
@@ -156,10 +164,10 @@ u3_ptty_init(uv_loop_t* lup_u, const c3_c** err_c)
   //
   {
     if ( 0 != tcgetattr(uty_u->fid_i, &pty_u->bak_u) ) {
-      c3_assert(!"init-tcgetattr");
+      exit(errno);
     }
     if ( -1 == fcntl(uty_u->fid_i, F_GETFL, &pty_u->cug_i) ) {
-      c3_assert(!"init-fcntl");
+      exit(errno);
     }
     pty_u->cug_i &= ~O_NONBLOCK;                // could fix?
     pty_u->nob_i = pty_u->cug_i | O_NONBLOCK;   // O_NDELAY on older unix

--- a/pkg/vere/platform/linux/daemon.c
+++ b/pkg/vere/platform/linux/daemon.c
@@ -31,7 +31,9 @@ static void _on_boot_completed_cb() {
   }
 
   if ( 0 == write(_child_process_booted_signal_fd, buf, 1) ) {
-    c3_assert(!"_on_boot_completed_cb: Can't write to parent FD");
+    c3_i err_i = errno;
+    fprintf(stderr, "daemon: write() failed: %s\r\n", strerror(err_i));
+    exit(err_i);
   }
 
   close(_child_process_booted_signal_fd);
@@ -65,7 +67,11 @@ u3_daemon_init()
   c3_i pipefd[2];
 
   if ( 0 != pipe(pipefd) ) {
-    c3_assert(!"Failed to create pipe");
+    c3_i err_i = errno;
+    fprintf(stderr,
+            "daemon: failed to create pipe: %s\r\n",
+            strerror(err_i));
+    exit(err_i);
   }
 
   pid_t childpid = fork();

--- a/pkg/vere/platform/linux/ptty.c
+++ b/pkg/vere/platform/linux/ptty.c
@@ -47,7 +47,11 @@ _ttyf_start_raw_input(u3_utty* uty_u)
     return c3n;
   }
   if ( -1 == fcntl(uty_u->fid_i, F_SETFL, pty_u->nob_i) ) {
-    c3_assert(!"init-fcntl");
+    c3_i err_i = errno;
+    fprintf(stderr,
+            "ptty: failed to set file status flags: %s\r\n",
+            strerror(err_i));
+    exit(err_i);
   }
   return c3y;
 }
@@ -62,7 +66,11 @@ _ttyf_end_raw_input(u3_utty* uty_u)
     return c3n;
   }
   if ( -1 == fcntl(uty_u->fid_i, F_SETFL, pty_u->cug_i) ) {
-    c3_assert(!"exit-fcntl");
+    c3_i err_i = errno;
+    fprintf(stderr,
+            "ptty: failed to set file status flags: %s\r\n",
+            strerror(err_i));
+    exit(err_i);
   }
   return c3y;
 }
@@ -75,19 +83,19 @@ _ttyf_hija(u3_utty* uty_u)
   u3_ptty* pty_u = (u3_ptty*)uty_u;
   if ( 0 != _term_tcsetattr(1, TCSADRAIN, &pty_u->bak_u) ) {
     perror("hija-tcsetattr-1");
-    c3_assert(!"hija-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(1, F_SETFL, pty_u->cug_i) ) {
     perror("hija-fcntl-1");
-    c3_assert(!"hija-fcntl");
+    exit(errno);
   }
   if ( 0 != _term_tcsetattr(0, TCSADRAIN, &pty_u->bak_u) ) {
     perror("hija-tcsetattr-0");
-    c3_assert(!"hija-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(0, F_SETFL, pty_u->cug_i) ) {
     perror("hija-fcntl-0");
-    c3_assert(!"hija-fcntl");
+    exit(errno);
   }
   return c3y;
 }
@@ -100,19 +108,19 @@ _ttyf_loja(u3_utty* uty_u)
   u3_ptty* pty_u = (u3_ptty*)uty_u;
   if ( 0 != _term_tcsetattr(1, TCSADRAIN, &pty_u->raw_u) ) {
     perror("loja-tcsetattr-1");
-    c3_assert(!"loja-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(1, F_SETFL, pty_u->nob_i) ) {
     perror("hija-fcntl-1");
-    c3_assert(!"loja-fcntl");
+    exit(errno);
   }
   if ( 0 != _term_tcsetattr(0, TCSADRAIN, &pty_u->raw_u) ) {
     perror("loja-tcsetattr-0");
-    c3_assert(!"loja-tcsetattr");
+    exit(errno);
   }
   if ( -1 == fcntl(0, F_SETFL, pty_u->nob_i) ) {
     perror("hija-fcntl-0");
-    c3_assert(!"loja-fcntl");
+    exit(errno);
   }
   return c3y;
 }
@@ -156,10 +164,14 @@ u3_ptty_init(uv_loop_t* lup_u, const c3_c** err_c)
   //
   {
     if ( 0 != tcgetattr(uty_u->fid_i, &pty_u->bak_u) ) {
-      c3_assert(!"init-tcgetattr");
+      exit(errno);
     }
     if ( -1 == fcntl(uty_u->fid_i, F_GETFL, &pty_u->cug_i) ) {
-      c3_assert(!"init-fcntl");
+      c3_i err_i = errno;
+      fprintf(stderr,
+              "ptty: failed to set file status flags: %s\r\n",
+              strerror(err_i));
+      exit(err_i);
     }
     pty_u->cug_i &= ~O_NONBLOCK;                // could fix?
     pty_u->nob_i = pty_u->cug_i | O_NONBLOCK;   // O_NDELAY on older unix

--- a/pkg/vere/save.c
+++ b/pkg/vere/save.c
@@ -27,10 +27,10 @@ u3_save_ef_chld(u3_pier *pir_u)
   u3l_log("checkpoint: complete %d", sav_u->pid_w);
   pid_w = wait(&loc_i);
   if (0 != sav_u->pid_w) {
-    c3_assert(pid_w == sav_u->pid_w);
+    u3_assert(pid_w == sav_u->pid_w);
   }
   else {
-    c3_assert(pid_w > 0);
+    u3_assert(pid_w > 0);
   }
   sav_u->pid_w = 0;
 }

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -880,7 +880,7 @@ _serf_writ_live_save(u3_serf* sef_u, c3_d eve_d)
     fprintf(stderr, "serf (%" PRIu64 "): save failed: %" PRIu64 "\r\n",
                     sef_u->dun_d,
                     eve_d);
-    exit(1);
+    exit(EINVAL);
   }
 
   u3e_save();

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -222,7 +222,7 @@ _serf_grab(u3_noun sac)
     }
 #endif
 
-    c3_assert( u3R == &(u3H->rod_u) );
+    u3_assert(u3R == &(u3H->rod_u));
     fprintf(fil_u, "\r\n");
 
     tot_w += u3a_maid(fil_u, "total userspace", _serf_prof(fil_u, 0, sac));
@@ -254,7 +254,7 @@ u3_serf_grab(void)
 {
   u3_noun sac = u3_nul;
 
-  c3_assert( u3R == &(u3H->rod_u) );
+  u3_assert(u3R == &(u3H->rod_u));
 
   {
     u3_noun sam, gon;
@@ -550,7 +550,7 @@ _serf_work(u3_serf* sef_u, c3_w mil_w, u3_noun job)
 
   //  event numbers must be continuous
   //
-  c3_assert( sef_u->sen_d == sef_u->dun_d);
+  u3_assert(sef_u->sen_d == sef_u->dun_d);
   sef_u->sen_d++;
 
   gon = _serf_poke(sef_u, "work", mil_w, job);  // retain
@@ -639,7 +639,7 @@ u3_serf_work(u3_serf* sef_u, c3_w mil_w, u3_noun job)
 
   //  %work must be performed against an extant kernel
   //
-  c3_assert( 0 != sef_u->mug_l);
+  u3_assert(0 != sef_u->mug_l);
 
   pro = u3nc(c3__work, _serf_work(sef_u, mil_w, job));
 
@@ -657,11 +657,11 @@ _serf_play_life(u3_serf* sef_u, u3_noun eve)
 {
   u3_noun gon;
 
-  c3_assert( 0ULL == sef_u->sen_d );
+  u3_assert(0ULL == sef_u->sen_d);
 
   {
     u3_noun len = u3qb_lent(eve);
-    c3_assert( c3y == u3r_safe_chub(len, &sef_u->sen_d) );
+    u3_assert(c3y == u3r_safe_chub(len, &sef_u->sen_d));
     u3z(len);
   }
 
@@ -787,7 +787,7 @@ _serf_play_list(u3_serf* sef_u, u3_noun eve)
 u3_noun
 u3_serf_play(u3_serf* sef_u, c3_d eve_d, u3_noun lit)
 {
-  c3_assert( eve_d == 1ULL + sef_u->sen_d );
+  u3_assert(eve_d == 1ULL + sef_u->sen_d);
 
   //  XX better condition for no kernel?
   //

--- a/pkg/vere/time.c
+++ b/pkg/vere/time.c
@@ -24,7 +24,7 @@ u3_time_sec_out(c3_d urs_d)
 
   if ( adj_d > 0xffffffffULL ) {
     fprintf(stderr, "Agh! It's 2106! And no one's fixed this shite!\n");
-    exit(1);
+    exit(EINVAL);
   }
   return (c3_w)adj_d;
 }

--- a/pkg/vere/unix_tests.c
+++ b/pkg/vere/unix_tests.c
@@ -59,7 +59,7 @@ main(int argc, char* argv[])
 
   if ( !_test_safe() ) {
     fprintf(stderr, "test unix: failed\r\n");
-    exit(1);
+    return ECANCELED;
   }
 
   fprintf(stderr, "test unix: ok\r\n");

--- a/pkg/vere/ward.c
+++ b/pkg/vere/ward.c
@@ -170,7 +170,7 @@ u3_pico_free(u3_pico* pic_u)
   u3z(pic_u->gan);
 
   switch ( pic_u->typ_e ) {
-    default: c3_assert(0);
+    default: exit(ENOTSUP);
 
     case u3_pico_full: {
       u3z(pic_u->ful);


### PR DESCRIPTION
Resolves #273.

This PR is a step toward more robust error handling. It renames `c3_assert()` as `u3_assert()` and replaces a number of `c3_assert()` calls designed to signal fatal errors with `exit()` and an appropriate `errno`-based status code. Some `c3_assert()` calls should not result in `exit()` but instead in `u3m_bail(c3__oops)`. To the best of my knowledge, the changes maintain the original error handling intent of the code.

## Testing

```console
$ bazel build :urbit
$ ./urbit -F zod -B path/to/solid/pill
<snip>
~zod:dojo> |exit
$ ./urbit zod
$ bazel test --build_tests_only ...
```
