### PR TITLE
u3: check that snapshot fits in *current* loom size 

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1167,7 +1167,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
 
       //  detect snapshots from a larger loom
       //
-      if ( (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w + 1) >= u3a_pages ) {
+      if ( (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w + 1) >= u3P.pag_w ) {
         fprintf(stderr, "boot: snapshot too big for loom\r\n");
         exit(1);
       }


### PR DESCRIPTION
... and not just the compile-time maximum.

Helps with #235, urbit/urbit#6508.
