### PR TITLE
vere: fix "queu" command argument parsing

### DIFF
--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1592,22 +1592,28 @@ _cw_cram(c3_i argc, c3_c* argv[])
 static void
 _cw_queu(c3_i argc, c3_c* argv[])
 {
-  c3_i ch_i, lid_i;
-  c3_w arg_w;
+  c3_i  lid_i, ch_i;
+  c3_w  arg_w;
+  c3_c* roc_c = 0;
 
   static struct option lop_u[] = {
-    { "loom", required_argument, NULL, c3__loom },
+    { "loom",        required_argument, NULL, c3__loom },
+    { "replay-from", required_argument, NULL, 'r' },
     { NULL, 0, NULL, 0 }
   };
 
   u3_Host.dir_c = _main_pier_run(argv[0]);
 
-  while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
+  while ( -1 != (ch_i=getopt_long(argc, argv, "r:", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
         if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
+      } break;
+
+      case 'r': {
+        roc_c = strdup(optarg);
       } break;
 
       case '?': {
@@ -1617,9 +1623,13 @@ _cw_queu(c3_i argc, c3_c* argv[])
     }
   }
 
+  if ( !roc_c ) {
+    fprintf(stderr, "invalid command, -r $EVENT required\r\n");
+    exit(1);
+  }
+
   //  argv[optind] is always "queu"
   //
-
   if ( !u3_Host.dir_c ) {
     if ( optind + 1 < argc ) {
       u3_Host.dir_c = argv[optind + 1];
@@ -1637,11 +1647,10 @@ _cw_queu(c3_i argc, c3_c* argv[])
     exit(1);
   }
 
-  c3_c* eve_c;
-  c3_d  eve_d;
+  c3_d eve_d;
 
-  if ( 1 != sscanf(eve_c, "%" PRIu64 "", &eve_d) ) {
-    fprintf(stderr, "urbit: queu: invalid number '%s'\r\n", eve_c);
+  if ( 1 != sscanf(roc_c, "%" PRIu64 "", &eve_d) ) {
+    fprintf(stderr, "urbit: queu: invalid number '%s'\r\n", roc_c);
     exit(1);
   }
   else {


### PR DESCRIPTION
This argument parsing for this command has been broken for a long time. This PR forward-ports the fix from v1.14 (reverted, urbit/urbit@4b5494fb85c29cddf2d4a8dc663c42b33198fd77).
