### PR TITLE
docker: fix all deployments tagged as 'once'

### DIFF
--- a/.github/workflows/docker-shared.yml
+++ b/.github/workflows/docker-shared.yml
@@ -40,6 +40,9 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: bazel run //bazel/toolchain:x86_64-linux-musl-gcc
 
+      - name: Set pace
+        run: echo "${{ inputs.pace }}" > ./PACE
+
       #
       # UPLOAD TO DOCKER
       #


### PR DESCRIPTION
Resolves [missing tags on DockerHub](https://hub.docker.com/r/tloncorp/vere/tags) (no issue exists for this, but multiple people have mentioned noticing it). This is also responsible for the missing `2.2` tag.