### PR TITLE
ames: fix fine cache lookup

### DIFF
--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -1164,6 +1164,7 @@ _fine_put_cache(u3_ames* sam_u, u3_noun pax, c3_w lop_w, u3_noun lis)
   }
 }
 
+
 /* _ames_ef_send(): send packet to network (v4).
 */
 static void
@@ -1741,8 +1742,8 @@ _fine_hear_request(u3_pact* req_u, c3_w cur_w)
 
   //  look up request in scry cache
   //
-  c3_w  lop_w = _fine_lop(res_u->pur_u.pep_u.fra_w);
-  u3_weak cac = _fine_get_cache(sam_u, key, lop_w);
+  c3_w  fra_w = res_u->pur_u.pep_u.fra_w;
+  u3_weak cac = _fine_get_cache(sam_u, key, fra_w);
 
   //  already pending; drop
   //
@@ -1761,6 +1762,7 @@ _fine_hear_request(u3_pact* req_u, c3_w cur_w)
                                   res_u->pur_u.pep_u.pat_c);
     }
 
+    c3_w  lop_w = _fine_lop(fra_w);
     u3_noun pax =
       u3nc(c3__fine,
       u3nq(c3__hunk,

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -1131,6 +1131,17 @@ _ames_czar(u3_pact* pac_u)
   }
 }
 
+/* _fine_put_cache(): get packet list or status from cache. RETAIN
+ */
+static u3_weak
+_fine_get_cache(u3_ames* sam_u, u3_noun pax, c3_w lop_w)
+{
+  u3_noun key = u3nc(u3k(pax), u3i_word(lop_w));
+  u3_weak pro = u3h_git(sam_u->fin_s.sac_p, key);
+  u3z(key);
+  return pro;
+}
+
 /* _fine_put_cache(): put packet list or status into cache. RETAIN.
  */
 static void
@@ -1730,7 +1741,9 @@ _fine_hear_request(u3_pact* req_u, c3_w cur_w)
 
   //  look up request in scry cache
   //
-  u3_weak cac = u3h_git(res_u->sam_u->fin_s.sac_p, key);
+  c3_w  lop_w = _fine_lop(res_u->pur_u.pep_u.fra_w);
+  u3_weak cac = _fine_get_cache(sam_u, key, lop_w);
+
   //  already pending; drop
   //
   if ( FINE_PEND == cac ) {
@@ -1748,7 +1761,6 @@ _fine_hear_request(u3_pact* req_u, c3_w cur_w)
                                   res_u->pur_u.pep_u.pat_c);
     }
 
-    c3_w lop_w = _fine_lop(res_u->pur_u.pep_u.fra_w);
     u3_noun pax =
       u3nc(c3__fine,
       u3nq(c3__hunk,

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -1134,9 +1134,9 @@ _ames_czar(u3_pact* pac_u)
 /* _fine_put_cache(): get packet list or status from cache. RETAIN
  */
 static u3_weak
-_fine_get_cache(u3_ames* sam_u, u3_noun pax, c3_w lop_w)
+_fine_get_cache(u3_ames* sam_u, u3_noun pax, c3_w fra_w)
 {
-  u3_noun key = u3nc(u3k(pax), u3i_word(lop_w));
+  u3_noun key = u3nc(u3k(pax), u3i_word(fra_w));
   u3_weak pro = u3h_git(sam_u->fin_s.sac_p, key);
   u3z(key);
   return pro;


### PR DESCRIPTION
I broke the fine cache in #367, (specifically in a86724f12fcf79ac3048fd10452098834cda0bf1, refactoring the cache key refcounts). 
