### PR TITLE
http: track scry request lifecycle

### DIFF
--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -692,7 +692,7 @@ _http_cache_scry_cb(void* vod_p, u3_noun nun)
 {
   cache_scry_cb_t* cbt = vod_p;
   u3_httd* htd_u = cbt->req_u->hon_u->htp_u->htd_u;
-  u3h_put(htd_u->nax_p, cbt->pax, nun);
+  u3h_put(htd_u->nax_p, cbt->pax, u3k(nun));
   u3z(cbt->pax);
   _http_cache_respond(cbt->req_u, nun);
   c3_free(cbt);

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -723,6 +723,7 @@ _http_req_cache(u3_hreq* req_u)
                       u3_nul, sac, cbt, _http_cache_scry_cb);
     return c3y;
   }
+  u3z(sac);
   _http_cache_respond(req_u, nac);
   return c3y;
 }

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -611,11 +611,9 @@ _http_req_new(u3_hcon* hon_u, h2o_req_t* rec_u)
 {
   u3_hreq* req_u = h2o_mem_alloc_shared(&rec_u->pool, sizeof(*req_u),
                                         _http_req_done);
+  memset(req_u, 0, sizeof(*req_u));
   req_u->rec_u = rec_u;
   req_u->sat_e = u3_rsat_init;
-  req_u->tim_u = 0;
-  req_u->gen_u = 0;
-  req_u->pre_u = 0;
 
   _http_req_link(hon_u, req_u);
 
@@ -629,11 +627,9 @@ _http_seq_new(u3_hcon* hon_u, h2o_req_t* rec_u)
 {
   u3_hreq* req_u = h2o_mem_alloc_shared(&rec_u->pool, sizeof(*req_u),
                                         _http_seq_done);
+  memset(req_u, 0, sizeof(*req_u));
   req_u->rec_u = rec_u;
   req_u->sat_e = u3_rsat_plan;
-  req_u->tim_u = 0;
-  req_u->gen_u = 0;
-  req_u->pre_u = 0;
 
   _http_seq_link(hon_u, req_u);
 


### PR DESCRIPTION
Building on #391, this PR fixes a couple refcounting issues in http noun-cache functionality. It also adds request lifecycle tracking to ensure that timeouts are handled correctly.
