### PR TITLE
`urbit play`: updated with working batch size / loom settings

### DIFF
--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1987,28 +1987,25 @@ u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
 {
   u3_assert( 0 != fil_u );
 
-  c3_z byt_z = ((c3_z)wor_w * 4);
-  c3_z gib_z = (byt_z / 1000000000);
-  c3_z mib_z = (byt_z % 1000000000) / 1000000;
-  c3_z kib_z = (byt_z % 1000000) / 1000;
-  c3_z bib_z = (byt_z % 1000);
+  c3_w byt_w = (wor_w * 4);
+  c3_w gib_w = (byt_w / 1000000000);
+  c3_w mib_w = (byt_w % 1000000000) / 1000000;
+  c3_w kib_w = (byt_w % 1000000) / 1000;
+  c3_w bib_w = (byt_w % 1000);
 
-  if ( byt_z ) {
-    if ( gib_z ) {
-      fprintf(fil_u, "%s: GB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
-              cap_c, gib_z, mib_z, kib_z, bib_z);
+  if ( byt_w ) {
+    if ( gib_w ) {
+      fprintf(fil_u, "%s: GB/%d.%03d.%03d.%03d\r\n",
+              cap_c, gib_w, mib_w, kib_w, bib_w);
     }
-    else if ( mib_z ) {
-      fprintf(fil_u, "%s: MB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
-              cap_c, mib_z, kib_z, bib_z);
+    else if ( mib_w ) {
+      fprintf(fil_u, "%s: MB/%d.%03d.%03d\r\n", cap_c, mib_w, kib_w, bib_w);
     }
-    else if ( kib_z ) {
-      fprintf(fil_u, "%s: KB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
-              cap_c, kib_z, bib_z);
+    else if ( kib_w ) {
+      fprintf(fil_u, "%s: KB/%d.%03d\r\n", cap_c, kib_w, bib_w);
     }
-    else if ( bib_z ) {
-      fprintf(fil_u, "%s: B/%" PRIc3_z "\r\n",
-              cap_c, bib_z);
+    else if ( bib_w ) {
+      fprintf(fil_u, "%s: B/%d\r\n", cap_c, bib_w);
     }
   }
 }

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -7,7 +7,7 @@
 //!   - page: 16KB chunk of the loom.
 //!   - north segment (u3e_image, north.bin): low contiguous loom pages,
 //!     (in practice, the home road heap). indexed from low to high:
-//!     in-order on disk. in a file-backed mapping by default.
+//!     in-order on disk.
 //!   - south segment (u3e_image, south.bin): high contiguous loom pages,
 //!     (in practice, the home road stack). indexed from high to low:
 //!     reversed on disk.
@@ -20,8 +20,8 @@
 //!   - with the loom already mapped, all pages are marked dirty in a bitmap.
 //!   - if snapshot is missing or partial, empty segments are created.
 //!   - if a patch is present, it's applied (crash recovery).
-//!   - snapshot segments are mapped or copied onto the loom;
-//!     all included pages are marked clean and protected (read-only).
+//!   - snapshot segments are copied onto the loom; all included pages
+//!     are marked clean and protected (read-only).
 //!
 //! #### page faults (u3e_fault())
 //!
@@ -47,48 +47,28 @@
 //!       contiguous free space).
 //!   - patch pages are written to memory.bin, metadata to control.bin.
 //!   - the patch is applied to the snapshot segments, in-place.
-//!   - segments are fsync'd; patch files are deleted.
-//!   - memory protections (and file-backed mappings) are re-established.
-//!
-//! ### invariants
-//!
-//!  definitions:
-//!    - a clean page is PROT_READ and 0 in the bitmap
-//!    - a dirty page is (PROT_READ|PROT_WRITE) and 1 in the bitmap
-//!    - the guard page is PROT_NONE and 1 in the bitmap
-//!
-//!  assumptions:
-//!    - all memory access patterns are outside-in, a page at a time
-//!      - ad-hoc exceptions are supported by calling u3e_ward()
-//!
-//!  - there is a single guard page, between the segments
-//!  - dirty pages only become clean by being:
-//!    - loaded from a snapshot during initialization
-//!    - present in a snapshot after save
-//!  - clean pages only become dirty by being:
-//!    - modified (and caught by the fault handler)
-//!    - orphaned due to segment truncation (explicitly dirtied)
-//!  - at points of quiescence (initialization, after save)
-//!    - all pages of the north and south segments are clean
-//!    - all other pages are dirty
+//!   - patch files are deleted.
 //!
 //! ### limitations
 //!
 //!   - loom page size is fixed (16 KB), and must be a multiple of the
-//!     system page size.
-//!   - update atomicity is crucial:
-//!     - patch application must either completely succeed or
-//!       leave on-disk segments (memory image) intact.
-//!     - unapplied patches can be discarded (triggering event replay),
-//!       but once patch application begins it must succeed.
-//!     - may require integration into the overall signal-handling regime.
-//!   - any errors are handled with assertions; error messages are poor;
-//!     failed/partial writes are not retried.
+//!     system page size. (can the size vary at runtime give south.bin's
+//!     reversed order? alternately, if system page size > ours, the fault
+//!     handler could dirty N pages at a time.)
+//!   - update atomicity is suspect: patch application must either
+//!     completely succeed or leave on-disk segments intact. unapplied
+//!     patches can be discarded (triggering event replay), but once
+//!     patch application begins it must succeed (can fail if disk is full).
+//!     may require integration into the overall signal-handling regime.
+//!   - any errors are handled with assertions; failed/partial writes are not
+//!     retried.
 //!
 //! ### enhancements
 //!
 //!   - use platform specific page fault mechanism (mach rpc, userfaultfd, &c).
-//!   - parallelism (conflicts with demand paging)
+//!   - implement demand paging / heuristic page-out.
+//!   - add a guard page in the middle of the loom to reactively handle stack overflow.
+//!   - parallelism
 //!
 
 #include "events.h"
@@ -103,28 +83,17 @@
 #include "retrieve.h"
 #include "types.h"
 
-#define U3_SNAPSHOT_VALIDATION
-
-/* _ce_len:       byte length of pages
-** _ce_len_words: word length of pages
-** _ce_page:      byte length of a single page
-** _ce_ptr:       void pointer to a page
-*/
-#define _ce_len(i)        ((size_t)(i) << (u3a_page + 2))
-#define _ce_len_words(i)  ((size_t)(i) << u3a_page)
-#define _ce_page          _ce_len(1)
-#define _ce_ptr(i)        ((void *)((c3_c*)u3_Loom + _ce_len(i)))
-
 /// Snapshotting system.
 u3e_pool u3e_Pool;
 
-static c3_l
-_ce_mug_page(void* ptr_v)
-{
-  //  XX trailing zeros
-  // return u3r_mug_bytes(ptr_v, _ce_page);
-  return u3r_mug_words(ptr_v, _ce_len_words(1));
-}
+// Base loom offset of the guard page.
+static u3p(c3_w) gar_pag_p;
+
+//! Urbit page size in 4-byte words.
+static const size_t pag_wiz_i = 1 << u3a_page;
+
+//! Urbit page size in bytes.
+static const size_t pag_siz_i = sizeof(c3_w) * pag_wiz_i;
 
 #ifdef U3_SNAPSHOT_VALIDATION
 /* Image check.
@@ -135,6 +104,17 @@ struct {
   c3_w mug_w[u3a_pages];
 } u3K;
 
+/* _ce_check_page(): checksum page.
+*/
+static c3_w
+_ce_check_page(c3_w pag_w)
+{
+  c3_w* mem_w = u3_Loom + (pag_w << u3a_page);
+  c3_w  mug_w = u3r_mug_words(mem_w, (1 << u3a_page));
+
+  return mug_w;
+}
+
 /* u3e_check(): compute a checksum on all memory within the watermarks.
 */
 void
@@ -144,28 +124,29 @@ u3e_check(c3_c* cap_c)
   c3_w sou_w = 0;
 
   {
-    u3_post low_p, hig_p;
-    u3m_water(&low_p, &hig_p);
+    c3_w nwr_w, swu_w;
 
-    nor_w = (low_p + (_ce_len_words(1) - 1)) >> u3a_page;
-    sou_w = u3P.pag_w - (hig_p >> u3a_page);
+    u3m_water(&nwr_w, &swu_w);
+
+    nor_w = (nwr_w + ((1 << u3a_page) - 1)) >> u3a_page;
+    sou_w = (swu_w + ((1 << u3a_page) - 1)) >> u3a_page;
   }
 
-  /* compute checksum over active pages.
+  /* Count dirty pages.
   */
   {
     c3_w i_w, sum_w, mug_w;
 
     sum_w = 0;
     for ( i_w = 0; i_w < nor_w; i_w++ ) {
-      mug_w = _ce_mug_page(_ce_ptr(i_w));
+      mug_w = _ce_check_page(i_w);
       if ( strcmp(cap_c, "boot") ) {
         u3_assert(mug_w == u3K.mug_w[i_w]);
       }
       sum_w += mug_w;
     }
     for ( i_w = 0; i_w < sou_w; i_w++ ) {
-      mug_w = _ce_mug_page(_ce_ptr((u3P.pag_w - (i_w + 1))));
+      mug_w = _ce_check_page((u3P.pag_w - (i_w + 1)));
       if ( strcmp(cap_c, "boot") ) {
         u3_assert(mug_w == u3K.mug_w[(u3P.pag_w - (i_w + 1))]);
       }
@@ -174,144 +155,156 @@ u3e_check(c3_c* cap_c)
     u3l_log("%s: sum %x (%x, %x)", cap_c, sum_w, nor_w, sou_w);
   }
 }
+
+/* _ce_maplloc(): crude off-loom allocator.
+*/
+static void*
+_ce_maplloc(c3_w len_w)
+{
+  void* map_v;
+
+  map_v = mmap(0,
+               len_w,
+               (PROT_READ | PROT_WRITE),
+               (MAP_ANON | MAP_PRIVATE),
+               -1, 0);
+
+  if ( -1 == (c3_ps)map_v ) {
+    u3_assert(0);
+  }
+  else {
+    c3_w* map_w = map_v;
+
+    map_w[0] = len_w;
+
+    return map_w + 1;
+  }
+}
+
+/* _ce_mapfree(): crude off-loom allocator.
+*/
+static void
+_ce_mapfree(void* map_v)
+{
+  c3_w* map_w = map_v;
+  c3_i res_i;
+
+  map_w -= 1;
+  res_i = munmap(map_w, map_w[0]);
+
+  u3_assert(0 == res_i);
+}
 #endif
 
-/* _ce_flaw_protect(): protect page after fault.
-*/
-static inline c3_i
-_ce_flaw_protect(c3_w pag_w)
-{
-  if ( 0 != mprotect(_ce_ptr(pag_w), _ce_page, (PROT_READ | PROT_WRITE)) ) {
-    fprintf(stderr, "loom: fault mprotect (%u): %s\r\n",
-                     pag_w, strerror(errno));
-    return 1;
-  }
-
-  return 0;
-}
-
 #ifdef U3_GUARD_PAGE
-/* _ce_ward_protect(): protect the guard page.
-*/
-static inline c3_i
-_ce_ward_protect(void)
+//! Place a guard page at the (approximate) middle of the free space between
+//! the heap and stack of the current road, bailing if memory has been
+//! exhausted.
+static c3_i
+_ce_center_guard_page(void)
 {
-  if ( 0 != mprotect(_ce_ptr(u3P.gar_w), _ce_page, PROT_NONE) ) {
-    fprintf(stderr, "loom: failed to protect guard page (%u): %s\r\n",
-                    u3P.gar_w, strerror(errno));
-    return 1;
+  u3p(c3_w) bot_p, top_p;
+  if ( !u3R ) {
+    top_p = u3a_outa(u3_Loom + u3C.wor_i);
+    bot_p = u3a_outa(u3_Loom);
+  }
+  else if ( c3y == u3a_is_north(u3R) ) {
+    top_p = c3_rod(u3R->cap_p, pag_wiz_i);
+    bot_p = c3_rop(u3R->hat_p, pag_wiz_i);
+  }
+  else {
+    top_p = c3_rod(u3R->hat_p, pag_wiz_i);
+    bot_p = c3_rop(u3R->cap_p, pag_wiz_i);
   }
 
+  if ( top_p < bot_p + pag_wiz_i ) {
+    fprintf(stderr,
+            "loom: not enough memory to recenter the guard page\r\n");
+    goto bail;
+  }
+  const u3p(c3_w) old_gar_p = gar_pag_p;
+  const c3_w      mid_p     = (top_p - bot_p) / 2;
+  gar_pag_p                 = bot_p + c3_rod(mid_p, pag_wiz_i);
+  if ( old_gar_p == gar_pag_p ) {
+    fprintf(stderr,
+            "loom: can't move the guard page to the same location"
+            " (base address %p)\r\n",
+            u3a_into(gar_pag_p));
+    goto bail;
+  }
+
+  if ( -1 == mprotect(u3a_into(gar_pag_p), pag_siz_i, PROT_NONE) ) {
+    fprintf(stderr,
+            "loom: failed to protect the guard page "
+            "(base address %p): %s\r\n",
+            u3a_into(gar_pag_p),
+            strerror(errno));
+    goto fail;
+  }
+
+  return 1;
+
+bail:
+  u3m_signal(c3__meme);
+fail:
   return 0;
-}
-
-/* _ce_ward_post(): set the guard page.
-*/
-static inline c3_i
-_ce_ward_post(c3_w nop_w, c3_w sop_w)
-{
-  u3P.gar_w = nop_w + ((sop_w - nop_w) / 2);
-  return _ce_ward_protect();
-}
-
-/* _ce_ward_clip(): hit the guard page.
-*/
-static inline u3e_flaw
-_ce_ward_clip(c3_w nop_w, c3_w sop_w)
-{
-  c3_w old_w = u3P.gar_w;
-
-  if ( !u3P.gar_w || ((nop_w < u3P.gar_w) && (sop_w > u3P.gar_w)) ) {
-    fprintf(stderr, "loom: ward bogus (>%u %u %u<)\r\n",
-                    nop_w, u3P.gar_w, sop_w);
-    return u3e_flaw_sham;
-  }
-
-  if ( sop_w <= (nop_w + 1) ) {
-    return u3e_flaw_meme;
-  }
-
-  if ( _ce_ward_post(nop_w, sop_w) ) {
-    return u3e_flaw_base;
-  }
-
-  u3_assert( old_w != u3P.gar_w );
-
-  return u3e_flaw_good;
 }
 #endif /* ifdef U3_GUARD_PAGE */
 
-/* u3e_fault(): handle a memory fault.
+/* u3e_fault(): handle a memory event with libsigsegv protocol.
 */
-u3e_flaw
-u3e_fault(u3_post low_p, u3_post hig_p, u3_post off_p)
+c3_i
+u3e_fault(void* adr_v, c3_i ser_i)
 {
-  c3_w pag_w = off_p >> u3a_page;
-  c3_w blk_w = pag_w >> 5;
-  c3_w bit_w = pag_w & 31;
+  //  Let the stack overflow handler run.
+  if ( 0 == ser_i ) {
+    return 0;
+  }
+
+  //  XX u3l_log avoid here, as it can
+  //  cause problems when handling errors
+
+  c3_w* adr_w = (c3_w*) adr_v;
+
+  if ( (adr_w < u3_Loom) || (adr_w >= (u3_Loom + u3C.wor_i)) ) {
+    fprintf(stderr, "address %p out of loom!\r\n", adr_w);
+    fprintf(stderr, "loom: [%p : %p)\r\n", u3_Loom, u3_Loom + u3C.wor_i);
+    u3_assert(0);
+    return 0;
+  }
+
+  u3p(c3_w) adr_p  = u3a_outa(adr_w);
+  c3_w      pag_w  = adr_p >> u3a_page;
+  c3_w      blk_w  = (pag_w >> 5);
+  c3_w      bit_w  = (pag_w & 31);
 
 #ifdef U3_GUARD_PAGE
-  if ( pag_w == u3P.gar_w ) {
-    u3e_flaw fal_e = _ce_ward_clip(low_p >> u3a_page, hig_p >> u3a_page);
-
-    if ( u3e_flaw_good != fal_e ) {
-      return fal_e;
-    }
-
-    if ( !(u3P.dit_w[blk_w] & (1 << bit_w)) ) {
-      fprintf(stderr, "loom: strange guard (%d)\r\n", pag_w);
-      return u3e_flaw_sham;
+  // The fault happened in the guard page.
+  if ( gar_pag_p <= adr_p && adr_p < gar_pag_p + pag_wiz_i ) {
+    if ( 0 == _ce_center_guard_page() ) {
+      return 0;
     }
   }
   else
-#endif
-  if ( u3P.dit_w[blk_w] & (1 << bit_w) ) {
-    fprintf(stderr, "loom: strange page (%d): %x\r\n", pag_w, off_p);
-    return u3e_flaw_sham;
+#endif /* ifdef U3_GUARD_PAGE */
+  if ( 0 != (u3P.dit_w[blk_w] & (1 << bit_w)) ) {
+    fprintf(stderr, "strange page: %d, at %p, off %x\r\n", pag_w, adr_w, adr_p);
+    u3_assert(0);
+    return 0;
   }
 
   u3P.dit_w[blk_w] |= (1 << bit_w);
 
-  if ( _ce_flaw_protect(pag_w) ) {
-    return u3e_flaw_base;
-  }
-
-  return u3e_flaw_good;
-}
-
-/* _ce_image_stat(): measure image.
-*/
-static c3_o
-_ce_image_stat(u3e_image* img_u, c3_w* pgs_w)
-{
-  struct stat buf_u;
-
-  if ( -1 == fstat(img_u->fid_i, &buf_u) ) {
-    fprintf(stderr, "loom: stat %s: %s\r\n", img_u->nam_c, strerror(errno));
+  if ( -1 == mprotect((void *)(u3_Loom + (pag_w << u3a_page)),
+                      pag_siz_i,
+                      (PROT_READ | PROT_WRITE)) )
+  {
+    fprintf(stderr, "loom: fault mprotect: %s\r\n", strerror(errno));
     u3_assert(0);
-    return c3n;
+    return 0;
   }
-  else {
-    c3_z siz_z = buf_u.st_size;
-    c3_z pgs_z = (siz_z + (_ce_page - 1)) >> (u3a_page + 2);
 
-    if ( !siz_z ) {
-      *pgs_w = 0;
-      return c3y;
-    }
-    else if ( siz_z != _ce_len(pgs_z) ) {
-      fprintf(stderr, "loom: %s corrupt size %zu\r\n", img_u->nam_c, siz_z);
-      return c3n;
-    }
-    else if ( pgs_z > UINT32_MAX ) {
-      fprintf(stderr, "loom: %s overflow %zu\r\n", img_u->nam_c, siz_z);
-      return c3n;
-    }
-    else {
-      *pgs_w = (c3_w)pgs_z;
-      return c3y;
-    }
-  }
+  return 1;
 }
 
 /* _ce_image_open(): open or create image.
@@ -336,11 +329,33 @@ _ce_image_open(u3e_image* img_u)
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
     return c3n;
   }
-  else if ( c3n == _ce_image_stat(img_u, &img_u->pgs_w) ) {
-    return c3n;
-  }
   else {
-    return c3y;
+    struct stat buf_u;
+
+    if ( -1 == fstat(img_u->fid_i, &buf_u) ) {
+      fprintf(stderr, "loom: stat %s: %s\r\n", ful_c, strerror(errno));
+      u3_assert(0);
+      return c3n;
+    }
+    else {
+      c3_d siz_d = buf_u.st_size;
+      c3_d pgs_d = (siz_d + (c3_d)(pag_siz_i - 1)) >>
+                   (c3_d)(u3a_page + 2);
+
+      if ( !siz_d ) {
+        return c3y;
+      }
+      else {
+        if ( siz_d != (pgs_d << (c3_d)(u3a_page + 2)) ) {
+          fprintf(stderr, "%s: corrupt size %" PRIx64 "\r\n", ful_c, siz_d);
+          return c3n;
+        }
+        img_u->pgs_w = (c3_w) pgs_d;
+        u3_assert(pgs_d == (c3_d)img_u->pgs_w);
+
+        return c3y;
+      }
+    }
   }
 }
 
@@ -427,7 +442,7 @@ _ce_patch_delete(void)
 {
   c3_c ful_c[8193];
 
-  snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
+   snprintf(ful_c, 8192, "%s/.urb/chk/control.bin", u3P.dir_c);
   if ( unlink(ful_c) ) {
     fprintf(stderr, "loom: failed to delete control.bin: %s\r\n",
                     strerror(errno));
@@ -445,45 +460,45 @@ _ce_patch_delete(void)
 static c3_o
 _ce_patch_verify(u3_ce_patch* pat_u)
 {
-  c3_w  pag_w, mug_w;
-  c3_y  buf_y[_ce_page];
-  c3_zs ret_zs;
+  ssize_t ret_i;
+  c3_w      i_w;
 
-  if ( U3E_VERLAT != pat_u->con_u->ver_w ) {
-    fprintf(stderr, "loom: patch version mismatch: have %"PRIc3_w", need %u\r\n",
-                    pat_u->con_u->ver_w,
-                    U3E_VERLAT);
+  if ( u3e_version != pat_u->con_u->ver_y ) {
+    fprintf(stderr, "loom: patch version mismatch: have %u, need %u\r\n",
+                    pat_u->con_u->ver_y,
+                    u3e_version);
     return c3n;
   }
 
-  for ( c3_z i_z = 0; i_z < pat_u->con_u->pgs_w; i_z++ ) {
-    pag_w = pat_u->con_u->mem_u[i_z].pag_w;
-    mug_w = pat_u->con_u->mem_u[i_z].mug_w;
+  for ( i_w = 0; i_w < pat_u->con_u->pgs_w; i_w++ ) {
+    c3_w pag_w = pat_u->con_u->mem_u[i_w].pag_w;
+    c3_w mug_w = pat_u->con_u->mem_u[i_w].mug_w;
+    c3_w mem_w[1 << u3a_page];
 
-    if ( _ce_page !=
-         (ret_zs = pread(pat_u->mem_i, buf_y, _ce_page, _ce_len(i_z))) )
-    {
-      if ( 0 < ret_zs ) {
-        fprintf(stderr, "loom: patch partial read: %"PRIc3_zs"\r\n", ret_zs);
+    if ( -1 == lseek(pat_u->mem_i, (i_w << (u3a_page + 2)), SEEK_SET) ) {
+      fprintf(stderr, "loom: patch seek: %s\r\n", strerror(errno));
+      return c3n;
+    }
+    if ( pag_siz_i != (ret_i = read(pat_u->mem_i, mem_w, pag_siz_i)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: patch partial read: %zu\r\n", (size_t)ret_i);
       }
       else {
-        fprintf(stderr, "loom: patch read: fail %s\r\n", strerror(errno));
+        fprintf(stderr, "loom: patch read fail: %s\r\n", strerror(errno));
       }
       return c3n;
     }
-
     {
-      c3_w nug_w = _ce_mug_page(buf_y);
+      c3_w nug_w = u3r_mug_words(mem_w, pag_wiz_i);
 
       if ( mug_w != nug_w ) {
-        fprintf(stderr, "loom: patch mug mismatch"
-                        " %"PRIc3_w"/%"PRIc3_z"; (%"PRIxc3_w", %"PRIxc3_w")\r\n",
-                        pag_w, i_z, mug_w, nug_w);
+        fprintf(stderr, "loom: patch mug mismatch %d/%d; (%x, %x)\r\n",
+                        pag_w, i_w, mug_w, nug_w);
         return c3n;
       }
 #if 0
       else {
-        u3l_log("verify: patch %"PRIc3_w"/%"PRIc3_z", %"PRIxc3_w"\r\n", pag_w, i_z, mug_w);
+        u3l_log("verify: patch %d/%d, %x", pag_w, i_w, mug_w);
       }
 #endif
     }
@@ -557,16 +572,20 @@ _ce_patch_write_page(u3_ce_patch* pat_u,
                      c3_w         pgc_w,
                      c3_w*        mem_w)
 {
-  c3_zs ret_zs;
+  ssize_t ret_i;
 
-  if ( _ce_page !=
-       (ret_zs = pwrite(pat_u->mem_i, mem_w, _ce_page, _ce_len(pgc_w))) )
-  {
-    if ( 0 < ret_zs ) {
-      fprintf(stderr, "loom: patch partial write: %"PRIc3_zs"\r\n", ret_zs);
+  if ( -1 == lseek(pat_u->mem_i, pgc_w * pag_siz_i, SEEK_SET) ) {
+    fprintf(stderr, "loom: patch page seek: %s\r\n", strerror(errno));
+    u3_assert(0);
+  }
+
+  if ( pag_siz_i != (ret_i = write(pat_u->mem_i, mem_w, pag_siz_i)) ) {
+    if ( 0 < ret_i ) {
+      fprintf(stderr, "loom: patch page partial write: %zu\r\n",
+                      (size_t)ret_i);
     }
     else {
-      fprintf(stderr, "loom: patch write: fail: %s\r\n", strerror(errno));
+      fprintf(stderr, "loom: patch page write: %s\r\n", strerror(errno));
     }
     u3_assert(0);
   }
@@ -594,21 +613,29 @@ _ce_patch_save_page(u3_ce_patch* pat_u,
                     c3_w         pag_w,
                     c3_w         pgc_w)
 {
-  c3_w  blk_w = (pag_w >> 5);
-  c3_w  bit_w = (pag_w & 31);
+  c3_w blk_w = (pag_w >> 5);
+  c3_w bit_w = (pag_w & 31);
 
   if ( u3P.dit_w[blk_w] & (1 << bit_w) ) {
-    c3_w* mem_w = _ce_ptr(pag_w);
+    c3_w* mem_w = u3_Loom + (pag_w << u3a_page);
 
     pat_u->con_u->mem_u[pgc_w].pag_w = pag_w;
-    pat_u->con_u->mem_u[pgc_w].mug_w = _ce_mug_page(mem_w);
+    pat_u->con_u->mem_u[pgc_w].mug_w = u3r_mug_words(mem_w, pag_wiz_i);
 
 #if 0
-    fprintf(stderr, "loom: save page %d %x\r\n",
-                    pag_w, pat_u->con_u->mem_u[pgc_w].mug_w);
+    u3l_log("protect a: page %d", pag_w);
 #endif
     _ce_patch_write_page(pat_u, pgc_w, mem_w);
 
+    if ( -1 == mprotect(u3_Loom + (pag_w << u3a_page),
+                        pag_siz_i,
+                        PROT_READ) )
+    {
+      fprintf(stderr, "loom: patch mprotect: %s\r\n", strerror(errno));
+      u3_assert(0);
+    }
+
+    u3P.dit_w[blk_w] &= ~(1 << bit_w);
     pgc_w += 1;
   }
   return pgc_w;
@@ -617,9 +644,25 @@ _ce_patch_save_page(u3_ce_patch* pat_u,
 /* _ce_patch_compose(): make and write current patch.
 */
 static u3_ce_patch*
-_ce_patch_compose(c3_w nor_w, c3_w sou_w)
+_ce_patch_compose(void)
 {
   c3_w pgs_w = 0;
+  c3_w nor_w = 0;
+  c3_w sou_w = 0;
+
+  /* Calculate number of saved pages, north and south.
+  */
+  {
+    c3_w nwr_w, swu_w;
+
+    u3m_water(&nwr_w, &swu_w);
+
+    nor_w = (nwr_w + (pag_wiz_i - 1)) >> u3a_page;
+    sou_w = (swu_w + (pag_wiz_i - 1)) >> u3a_page;
+
+    u3_assert(  ((gar_pag_p >> u3a_page) >= nor_w)
+             && ((gar_pag_p >> u3a_page) <= (u3a_pages - (sou_w + 1))) );
+  }
 
 #ifdef U3_SNAPSHOT_VALIDATION
   u3K.nor_w = nor_w;
@@ -648,7 +691,7 @@ _ce_patch_compose(c3_w nor_w, c3_w sou_w)
 
     _ce_patch_create(pat_u);
     pat_u->con_u = c3_malloc(sizeof(u3e_control) + (pgs_w * sizeof(u3e_line)));
-    pat_u->con_u->ver_w = U3E_VERLAT;
+    pat_u->con_u->ver_y = u3e_version;
     pgc_w = 0;
 
     for ( i_w = 0; i_w < nor_w; i_w++ ) {
@@ -657,8 +700,6 @@ _ce_patch_compose(c3_w nor_w, c3_w sou_w)
     for ( i_w = 0; i_w < sou_w; i_w++ ) {
       pgc_w = _ce_patch_save_page(pat_u, (u3P.pag_w - (i_w + 1)), pgc_w);
     }
-
-    u3_assert( pgc_w == pgs_w );
 
     pat_u->con_u->nor_w = nor_w;
     pat_u->con_u->sou_w = sou_w;
@@ -694,7 +735,8 @@ _ce_image_sync(u3e_image* img_u)
 {
   if ( -1 == c3_sync(img_u->fid_i) ) {
     fprintf(stderr, "loom: image (%s) sync failed: %s\r\n",
-                    img_u->nam_c, strerror(errno));
+                    img_u->nam_c,
+                    strerror(errno));
     u3_assert(!"loom: image sync");
   }
 }
@@ -704,20 +746,11 @@ _ce_image_sync(u3e_image* img_u)
 static void
 _ce_image_resize(u3e_image* img_u, c3_w pgs_w)
 {
-  c3_z  off_z = _ce_len(pgs_w);
-  off_t off_i = (off_t)off_z;
-
   if ( img_u->pgs_w > pgs_w ) {
-    if ( off_z != (size_t)off_i ) {
-      fprintf(stderr, "loom: image (%s) truncate: "
-                      "offset overflow (%" PRId64 ") for page %u\r\n",
-                      img_u->nam_c, (c3_ds)off_i, pgs_w);
-      u3_assert(0);
-    }
-
-    if ( ftruncate(img_u->fid_i, off_i) ) {
+    if ( ftruncate(img_u->fid_i, pgs_w << (u3a_page + 2)) ) {
       fprintf(stderr, "loom: image (%s) truncate: %s\r\n",
-                      img_u->nam_c, strerror(errno));
+                      img_u->nam_c,
+                      strerror(errno));
       u3_assert(0);
     }
   }
@@ -730,18 +763,21 @@ _ce_image_resize(u3e_image* img_u, c3_w pgs_w)
 static void
 _ce_patch_apply(u3_ce_patch* pat_u)
 {
-  c3_zs ret_zs;
-  c3_w     i_w;
+  ssize_t ret_i;
+  c3_w      i_w;
 
   //  resize images
   //
   _ce_image_resize(&u3P.nor_u, pat_u->con_u->nor_w);
   _ce_image_resize(&u3P.sou_u, pat_u->con_u->sou_w);
 
-  //  seek to begining of patch
+  //  seek to begining of patch and images
   //
-  if ( -1 == lseek(pat_u->mem_i, 0, SEEK_SET) ) {
-    fprintf(stderr, "loom: patch apply seek: %s\r\n", strerror(errno));
+  if (  (-1 == lseek(pat_u->mem_i, 0, SEEK_SET))
+     || (-1 == lseek(u3P.nor_u.fid_i, 0, SEEK_SET))
+     || (-1 == lseek(u3P.sou_u.fid_i, 0, SEEK_SET)) )
+  {
+    fprintf(stderr, "loom: patch apply seek 0: %s\r\n", strerror(errno));
     u3_assert(0);
   }
 
@@ -749,23 +785,23 @@ _ce_patch_apply(u3_ce_patch* pat_u)
   //
   for ( i_w = 0; i_w < pat_u->con_u->pgs_w; i_w++ ) {
     c3_w pag_w = pat_u->con_u->mem_u[i_w].pag_w;
-    c3_y buf_y[_ce_page];
+    c3_w mem_w[pag_wiz_i];
     c3_i fid_i;
-    c3_z off_z;
+    c3_w off_w;
 
     if ( pag_w < pat_u->con_u->nor_w ) {
       fid_i = u3P.nor_u.fid_i;
-      off_z = _ce_len(pag_w);
+      off_w = pag_w;
     }
     else {
       fid_i = u3P.sou_u.fid_i;
-      off_z = _ce_len((u3P.pag_w - (pag_w + 1)));
+      off_w = (u3P.pag_w - (pag_w + 1));
     }
 
-    if ( _ce_page != (ret_zs = read(pat_u->mem_i, buf_y, _ce_page)) ) {
-      if ( 0 < ret_zs ) {
-        fprintf(stderr, "loom: patch apply partial read: %"PRIc3_zs"\r\n",
-                        ret_zs);
+    if ( pag_siz_i != (ret_i = read(pat_u->mem_i, mem_w, pag_siz_i)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: patch apply partial read: %zu\r\n",
+                        (size_t)ret_i);
       }
       else {
         fprintf(stderr, "loom: patch apply read: %s\r\n", strerror(errno));
@@ -773,12 +809,14 @@ _ce_patch_apply(u3_ce_patch* pat_u)
       u3_assert(0);
     }
     else {
-      if ( _ce_page !=
-           (ret_zs = pwrite(fid_i, buf_y, _ce_page, off_z)) )
-      {
-        if ( 0 < ret_zs ) {
-          fprintf(stderr, "loom: patch apply partial write: %"PRIc3_zs"\r\n",
-                          ret_zs);
+      if ( -1 == lseek(fid_i, (off_w << (u3a_page + 2)), SEEK_SET) ) {
+        fprintf(stderr, "loom: patch apply seek: %s\r\n", strerror(errno));
+        u3_assert(0);
+      }
+      if ( pag_siz_i != (ret_i = write(fid_i, mem_w, pag_siz_i)) ) {
+        if ( 0 < ret_i ) {
+          fprintf(stderr, "loom: patch apply partial write: %zu\r\n",
+                          (size_t)ret_i);
         }
         else {
           fprintf(stderr, "loom: patch apply write: %s\r\n", strerror(errno));
@@ -787,370 +825,111 @@ _ce_patch_apply(u3_ce_patch* pat_u)
       }
     }
 #if 0
-    u3l_log("apply: %d, %x", pag_w, _ce_mug_page(buf_y));
+    u3l_log("apply: %d, %x", pag_w, u3r_mug_words(mem_w, pag_wiz_i));
 #endif
   }
 }
 
-/* _ce_loom_track_sane(): quiescent page state invariants.
-*/
-static c3_o
-_ce_loom_track_sane(void)
-{
-  c3_w blk_w, bit_w, max_w, i_w = 0;
-  c3_o san_o = c3y;
-
-  max_w = u3P.nor_u.pgs_w;
-
-  for ( ; i_w < max_w; i_w++ ) {
-    blk_w = i_w >> 5;
-    bit_w = i_w & 31;
-
-    if ( u3P.dit_w[blk_w] & (1 << bit_w) ) {
-      fprintf(stderr, "loom: insane north %u\r\n", i_w);
-      san_o = c3n;
-    }
-  }
-
-  max_w = u3P.pag_w - u3P.sou_u.pgs_w;
-
-  for ( ; i_w < max_w; i_w++ ) {
-    blk_w = i_w >> 5;
-    bit_w = i_w & 31;
-
-    if ( !(u3P.dit_w[blk_w] & (1 << bit_w)) ) {
-      fprintf(stderr, "loom: insane open %u\r\n", i_w);
-      san_o = c3n;
-    }
-  }
-
-  max_w = u3P.pag_w;
-
-  for ( ; i_w < max_w; i_w++ ) {
-    blk_w = i_w >> 5;
-    bit_w = i_w & 31;
-
-    if ( u3P.dit_w[blk_w] & (1 << bit_w) ) {
-      fprintf(stderr, "loom: insane south %u\r\n", i_w);
-      san_o = c3n;
-    }
-  }
-
-  return san_o;
-}
-
-/* _ce_loom_track_north(): [pgs_w] clean, followed by [dif_w] dirty.
-*/
-void
-_ce_loom_track_north(c3_w pgs_w, c3_w dif_w)
-{
-  c3_w blk_w, bit_w, i_w = 0, max_w = pgs_w;
-
-  for ( ; i_w < max_w; i_w++ ) {
-    blk_w = i_w >> 5;
-    bit_w = i_w & 31;
-    u3P.dit_w[blk_w] &= ~(1 << bit_w);
-  }
-
-  max_w += dif_w;
-
-  for ( ; i_w < max_w; i_w++ ) {
-    blk_w = i_w >> 5;
-    bit_w = i_w & 31;
-    u3P.dit_w[blk_w] |= (1 << bit_w);
-  }
-}
-
-/* _ce_loom_track_south(): [pgs_w] clean, preceded by [dif_w] dirty.
-*/
-void
-_ce_loom_track_south(c3_w pgs_w, c3_w dif_w)
-{
-  c3_w blk_w, bit_w, i_w = u3P.pag_w - 1, max_w = u3P.pag_w - pgs_w;
-
-  for ( ; i_w >= max_w; i_w-- ) {
-    blk_w = i_w >> 5;
-    bit_w = i_w & 31;
-    u3P.dit_w[blk_w] &= ~(1 << bit_w);
-  }
-
-  max_w -= dif_w;
-
-  for ( ; i_w >= max_w; i_w-- ) {
-    blk_w = i_w >> 5;
-    bit_w = i_w & 31;
-    u3P.dit_w[blk_w] |= (1 << bit_w);
-  }
-}
-
-/* _ce_loom_protect_north(): protect/track pages from the bottom of memory.
+/* _ce_image_blit(): apply image to memory.
 */
 static void
-_ce_loom_protect_north(c3_w pgs_w, c3_w old_w)
+_ce_image_blit(u3e_image* img_u,
+               c3_w*        ptr_w,
+               c3_ws        stp_ws)
 {
-  c3_w dif_w = 0;
-
-  if ( pgs_w ) {
-    if ( 0 != mprotect(_ce_ptr(0), _ce_len(pgs_w), PROT_READ) ) {
-      fprintf(stderr, "loom: pure north (%u pages): %s\r\n",
-                      pgs_w, strerror(errno));
-      u3_assert(0);
-    }
+  if ( 0 == img_u->pgs_w ) {
+    return;
   }
 
-  if ( old_w > pgs_w ) {
-    dif_w = old_w - pgs_w;
-
-    if ( 0 != mprotect(_ce_ptr(pgs_w),
-                       _ce_len(dif_w),
-                       (PROT_READ | PROT_WRITE)) )
-    {
-      fprintf(stderr, "loom: foul north (%u pages, %u old): %s\r\n",
-                      pgs_w, old_w, strerror(errno));
-      u3_assert(0);
-    }
-
-#ifdef U3_GUARD_PAGE
-    //  protect guard page if clobbered
-    //
-    //    NB: < pgs_w is precluded by assertion in u3e_save()
-    //
-    if ( u3P.gar_w < old_w ) {
-      fprintf(stderr, "loom: guard on reprotect\r\n");
-      u3_assert( !_ce_ward_protect() );
-    }
-#endif
-  }
-
-  _ce_loom_track_north(pgs_w, dif_w);
-}
-
-/* _ce_loom_protect_south(): protect/track pages from the top of memory.
-*/
-static void
-_ce_loom_protect_south(c3_w pgs_w, c3_w old_w)
-{
-  c3_w dif_w = 0;
-
-  if ( pgs_w ) {
-    if ( 0 != mprotect(_ce_ptr(u3P.pag_w - pgs_w),
-                       _ce_len(pgs_w),
-                       PROT_READ) )
-    {
-      fprintf(stderr, "loom: pure south (%u pages): %s\r\n",
-                      pgs_w, strerror(errno));
-      u3_assert(0);
-    }
-  }
-
-  if ( old_w > pgs_w ) {
-    c3_w off_w = u3P.pag_w - old_w;
-    dif_w = old_w - pgs_w;
-
-    if ( 0 != mprotect(_ce_ptr(off_w),
-                       _ce_len(dif_w),
-                       (PROT_READ | PROT_WRITE)) )
-    {
-      fprintf(stderr, "loom: foul south (%u pages, %u old): %s\r\n",
-                      pgs_w, old_w, strerror(errno));
-      u3_assert(0);
-    }
-
-#ifdef U3_GUARD_PAGE
-    //  protect guard page if clobbered
-    //
-    //    NB: >= pgs_w is precluded by assertion in u3e_save()
-    //
-    if ( u3P.gar_w >= off_w ) {
-      fprintf(stderr, "loom: guard on reprotect\r\n");
-      u3_assert( !_ce_ward_protect() );
-    }
-#endif
-  }
-
-  _ce_loom_track_south(pgs_w, dif_w);
-}
-
-/* _ce_loom_mapf_north(): map [pgs_w] of [fid_i] into the bottom of memory
-**                        (and anonymize [old_w - pgs_w] after if needed).
-**
-**   NB: _ce_loom_mapf_south() is possible, but it would make separate mappings
-**       for each page since the south segment is reversed on disk.
-**       in practice, the south segment is a single page (and always dirty);
-**       a file-backed mapping for it is just not worthwhile.
-*/
-static void
-_ce_loom_mapf_north(c3_i fid_i, c3_w pgs_w, c3_w old_w)
-{
-  c3_w dif_w = 0;
-
-  if ( pgs_w ) {
-    if ( MAP_FAILED == mmap(_ce_ptr(0),
-                            _ce_len(pgs_w),
-                            PROT_READ,
-                            (MAP_FIXED | MAP_PRIVATE),
-                            fid_i, 0) )
-    {
-      fprintf(stderr, "loom: file-backed mmap failed (%u pages): %s\r\n",
-                      pgs_w, strerror(errno));
-      u3_assert(0);
-    }
-  }
-
-  if ( old_w > pgs_w ) {
-    dif_w = old_w - pgs_w;
-
-    if ( MAP_FAILED == mmap(_ce_ptr(pgs_w),
-                            _ce_len(dif_w),
-                            (PROT_READ | PROT_WRITE),
-                            (MAP_ANON | MAP_FIXED | MAP_PRIVATE),
-                            -1, 0) )
-    {
-      fprintf(stderr, "loom: anonymous mmap failed (%u pages, %u old): %s\r\n",
-                      pgs_w, old_w, strerror(errno));
-      u3_assert(0);
-    }
-
-#ifdef U3_GUARD_PAGE
-    //  protect guard page if clobbered
-    //
-    //    NB: < pgs_w is precluded by assertion in u3e_save()
-    //
-    if ( u3P.gar_w < old_w ) {
-      fprintf(stderr, "loom: guard on remap\r\n");
-      u3_assert( !_ce_ward_protect() );
-    }
-#endif
-  }
-
-  _ce_loom_track_north(pgs_w, dif_w);
-}
-
-/* _ce_loom_blit_north(): apply pages, in order, from the bottom of memory.
-*/
-static void
-_ce_loom_blit_north(c3_i fid_i, c3_w pgs_w)
-{
-  c3_w    i_w;
-  void* ptr_v;
-  c3_zs ret_zs;
-
-  for ( i_w = 0; i_w < pgs_w; i_w++ ) {
-    ptr_v = _ce_ptr(i_w);
-
-    if ( _ce_page != (ret_zs = pread(fid_i, ptr_v, _ce_page, _ce_len(i_w))) ) {
-      if ( 0 < ret_zs ) {
-        fprintf(stderr, "loom: blit north partial read: %"PRIc3_zs"\r\n",
-                        ret_zs);
-      }
-      else {
-        fprintf(stderr, "loom: blit north read %s\r\n", strerror(errno));
-      }
-      u3_assert(0);
-    }
-  }
-
-  _ce_loom_protect_north(pgs_w, 0);
-}
-
-/* _ce_loom_blit_south(): apply pages, reversed, from the top of memory.
-*/
-static void
-_ce_loom_blit_south(c3_i fid_i, c3_w pgs_w)
-{
-  c3_w    i_w;
-  void* ptr_v;
-  c3_zs ret_zs;
-
-  for ( i_w = 0; i_w < pgs_w; i_w++ ) {
-    ptr_v = _ce_ptr(u3P.pag_w - (i_w + 1));
-
-    if ( _ce_page != (ret_zs = pread(fid_i, ptr_v, _ce_page, _ce_len(i_w))) ) {
-      if ( 0 < ret_zs ) {
-        fprintf(stderr, "loom: blit south partial read: %"PRIc3_zs"\r\n",
-                        ret_zs);
-      }
-      else {
-        fprintf(stderr, "loom: blit south read: %s\r\n", strerror(errno));
-      }
-      u3_assert(0);
-    }
-  }
-
-  _ce_loom_protect_south(pgs_w, 0);
-}
-
-#ifdef U3_SNAPSHOT_VALIDATION
-/* _ce_page_fine(): compare page in memory and on disk.
-*/
-static c3_o
-_ce_page_fine(u3e_image* img_u, c3_w pag_w, c3_z off_z)
-{
   ssize_t ret_i;
-  c3_y    buf_y[_ce_page];
+  c3_w      i_w;
+  c3_w    siz_w = pag_siz_i;
 
-  if ( _ce_page !=
-       (ret_i = pread(img_u->fid_i, buf_y, _ce_page, off_z)) )
-  {
-    if ( 0 < ret_i ) {
-      fprintf(stderr, "loom: image (%s) fine partial read: %zu\r\n",
-                      img_u->nam_c, (size_t)ret_i);
-    }
-    else {
-      fprintf(stderr, "loom: image (%s) fine read: %s\r\n",
-                      img_u->nam_c, strerror(errno));
-    }
+  if ( -1 == lseek(img_u->fid_i, 0, SEEK_SET) ) {
+    fprintf(stderr, "loom: image (%s) blit seek 0: %s\r\n",
+                    img_u->nam_c, strerror(errno));
     u3_assert(0);
   }
 
-  {
-    c3_w mug_w = _ce_mug_page(_ce_ptr(pag_w));
-    c3_w fug_w = _ce_mug_page(buf_y);
-
-    if ( mug_w != fug_w ) {
-      fprintf(stderr, "loom: image (%s) mismatch: "
-                      "page %d, mem_w %x, fil_w %x, K %x\r\n",
-                      img_u->nam_c, pag_w, mug_w, fug_w, u3K.mug_w[pag_w]);
-      return c3n;
+  for ( i_w = 0; i_w < img_u->pgs_w; i_w++ ) {
+    if ( siz_w != (ret_i = read(img_u->fid_i, ptr_w, siz_w)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: image (%s) blit partial read: %zu\r\n",
+                        img_u->nam_c, (size_t)ret_i);
+      }
+      else {
+        fprintf(stderr, "loom: image (%s) blit read: %s\r\n",
+                        img_u->nam_c, strerror(errno));
+      }
+      u3_assert(0);
     }
-  }
 
-  return c3y;
+    if ( 0 != mprotect(ptr_w, siz_w, PROT_READ) ) {
+      fprintf(stderr, "loom: live mprotect: %s\r\n", strerror(errno));
+      u3_assert(0);
+    }
+
+    c3_w pag_w = u3a_outa(ptr_w) >> u3a_page;
+    c3_w blk_w = pag_w >> 5;
+    c3_w bit_w = pag_w & 31;
+    u3P.dit_w[blk_w] &= ~(1 << bit_w);
+
+    ptr_w += stp_ws;
+  }
 }
 
-/* _ce_loom_fine(): compare clean pages in memory and on disk.
+#ifdef U3_SNAPSHOT_VALIDATION
+/* _ce_image_fine(): compare image to memory.
 */
-static c3_o
-_ce_loom_fine(void)
+static void
+_ce_image_fine(u3e_image* img_u,
+               c3_w*        ptr_w,
+               c3_ws        stp_ws)
 {
-  c3_w blk_w, bit_w, pag_w, i_w;
-  c3_o fin_o = c3y;
+  ssize_t ret_i;
+  c3_w      i_w;
+  c3_w    buf_w[pag_wiz_i];
 
-  for ( i_w = 0; i_w < u3P.nor_u.pgs_w; i_w++ ) {
-    pag_w = i_w;
-    blk_w = pag_w >> 5;
-    bit_w = pag_w & 31;
-
-    if ( !(u3P.dit_w[blk_w] & (1 << bit_w)) ) {
-      fin_o = c3a(fin_o, _ce_page_fine(&u3P.nor_u, pag_w, _ce_len(pag_w)));
-    }
+  if ( -1 == lseek(img_u->fid_i, 0, SEEK_SET) ) {
+    fprintf(stderr, "loom: image fine seek 0: %s\r\n", strerror(errno));
+    u3_assert(0);
   }
 
-  for ( i_w = 0; i_w < u3P.sou_u.pgs_w; i_w++ ) {
-    pag_w = u3P.pag_w - (i_w + 1);
-    blk_w = pag_w >> 5;
-    bit_w = pag_w & 31;
+  for ( i_w=0; i_w < img_u->pgs_w; i_w++ ) {
+    c3_w mem_w, fil_w;
 
-    if ( !(u3P.dit_w[blk_w] & (1 << bit_w)) ) {
-      fin_o = c3a(fin_o, _ce_page_fine(&u3P.sou_u, pag_w, _ce_len(i_w)));
+    if ( pag_siz_i != (ret_i = read(img_u->fid_i, buf_w, pag_siz_i)) ) {
+      if ( 0 < ret_i ) {
+        fprintf(stderr, "loom: image (%s) fine partial read: %zu\r\n",
+                        img_u->nam_c, (size_t)ret_i);
+      }
+      else {
+        fprintf(stderr, "loom: image (%s) fine read: %s\r\n",
+                        img_u->nam_c, strerror(errno));
+      }
+      u3_assert(0);
     }
-  }
+    mem_w = u3r_mug_words(ptr_w, pag_wiz_i);
+    fil_w = u3r_mug_words(buf_w, pag_wiz_i);
 
-  return fin_o;
+    if ( mem_w != fil_w ) {
+      c3_w pag_w = (ptr_w - u3_Loom) >> u3a_page;
+
+      fprintf(stderr, "loom: image (%s) mismatch: "
+                      "page %d, mem_w %x, fil_w %x, K %x\r\n",
+                      img_u->nam_c,
+                      pag_w,
+                      mem_w,
+                      fil_w,
+                      u3K.mug_w[pag_w]);
+      abort();
+    }
+    ptr_w += stp_ws;
+  }
 }
 #endif
 
-/* _ce_image_copy(): copy all of [fom_u] to [tou_u]
+/* _ce_image_copy():
 */
 static c3_o
 _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
@@ -1176,10 +955,10 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
   //  copy pages into destination image
   //
   for ( i_w = 0; i_w < fom_u->pgs_w; i_w++ ) {
-    c3_y buf_y[_ce_page];
+    c3_w mem_w[pag_wiz_i];
     c3_w off_w = i_w;
 
-    if ( _ce_page != (ret_i = read(fom_u->fid_i, buf_y, _ce_page)) ) {
+    if ( pag_siz_i != (ret_i = read(fom_u->fid_i, mem_w, pag_siz_i)) ) {
       if ( 0 < ret_i ) {
         fprintf(stderr, "loom: image (%s) copy partial read: %zu\r\n",
                         fom_u->nam_c, (size_t)ret_i);
@@ -1191,12 +970,12 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
       return c3n;
     }
     else {
-      if ( -1 == lseek(tou_u->fid_i, _ce_len(off_w), SEEK_SET) ) {
+      if ( -1 == lseek(tou_u->fid_i, (off_w << (u3a_page + 2)), SEEK_SET) ) {
         fprintf(stderr, "loom: image (%s) copy seek: %s\r\n",
                         tou_u->nam_c, strerror(errno));
         return c3n;
       }
-      if ( _ce_page != (ret_i = write(tou_u->fid_i, buf_y, _ce_page)) ) {
+      if ( pag_siz_i != (ret_i = write(tou_u->fid_i, mem_w, pag_siz_i)) ) {
         if ( 0 < ret_i ) {
           fprintf(stderr, "loom: image (%s) copy partial write: %zu\r\n",
                           tou_u->nam_c, (size_t)ret_i);
@@ -1213,37 +992,37 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
   return c3y;
 }
 
-/* u3e_backup(): copy snapshot to .urb/bhk (if it doesn't exist yet).
+/* _ce_backup();
 */
-c3_o
-u3e_backup(c3_o ovw_o)
+static void
+_ce_backup(void)
 {
   u3e_image nop_u = { .nam_c = "north", .pgs_w = 0 };
   u3e_image sop_u = { .nam_c = "south", .pgs_w = 0 };
-  c3_i mod_i = O_RDWR | O_CREAT; // XX O_TRUNC ?
+  c3_i mod_i = O_RDWR | O_CREAT;
   c3_c ful_c[8193];
 
   snprintf(ful_c, 8192, "%s/.urb/bhk", u3P.dir_c);
 
-  if ( (c3n == ovw_o) && c3_mkdir(ful_c, 0700) ) {
+  if ( c3_mkdir(ful_c, 0700) ) {
     if ( EEXIST != errno ) {
       fprintf(stderr, "loom: image backup: %s\r\n", strerror(errno));
     }
-    return c3n;
+    return;
   }
 
   snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, nop_u.nam_c);
 
   if ( -1 == (nop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
-    return c3n;
+    return;
   }
 
   snprintf(ful_c, 8192, "%s/.urb/bhk/%s.bin", u3P.dir_c, sop_u.nam_c);
 
   if ( -1 == (sop_u.fid_i = c3_open(ful_c, mod_i, 0666)) ) {
     fprintf(stderr, "loom: c3_open %s: %s\r\n", ful_c, strerror(errno));
-    return c3n;
+    return;
   }
 
   if (  (c3n == _ce_image_copy(&u3P.nor_u, &nop_u))
@@ -1255,14 +1034,10 @@ u3e_backup(c3_o ovw_o)
     c3_unlink(ful_c);
     snprintf(ful_c, 8192, "%s/.urb/bhk", u3P.dir_c);
     c3_rmdir(ful_c);
-    fprintf(stderr, "loom: image backup failed\r\n");
-    return c3n;
   }
 
   close(nop_u.fid_i);
   close(sop_u.fid_i);
-  fprintf(stderr, "loom: image backup complete\r\n");
-  return c3y;
 }
 
 /*
@@ -1286,35 +1061,19 @@ u3e_backup(c3_o ovw_o)
   before we try to make another snapshot.
 */
 void
-u3e_save(u3_post low_p, u3_post hig_p)
+u3e_save(void)
 {
   u3_ce_patch* pat_u;
-  c3_w nod_w = u3P.nor_u.pgs_w;
-  c3_w sod_w = u3P.sou_u.pgs_w;
 
   if ( u3C.wag_w & u3o_dryrun ) {
     return;
   }
 
-  {
-    c3_w nop_w = (low_p >> u3a_page);
-    c3_w nor_w = (low_p + (_ce_len_words(1) - 1)) >> u3a_page;
-    c3_w sop_w = hig_p >> u3a_page;
-
-    u3_assert( (u3P.gar_w > nop_w) && (u3P.gar_w < sop_w) );
-
-    if ( !(pat_u = _ce_patch_compose(nor_w, u3P.pag_w - sop_w)) ) {
-      return;
-    }
+  if ( !(pat_u = _ce_patch_compose()) ) {
+    return;
   }
 
-  //  attempt to avoid propagating anything insane to disk
-  //
-  u3a_loom_sane();
-
-  if ( u3C.wag_w & u3o_verbose ) {
-    u3a_print_memory(stderr, "sync: save", pat_u->con_u->pgs_w << u3a_page);
-  }
+  // u3a_print_memory(stderr, "sync: save", 4096 * pat_u->con_u->pgs_w);
 
   _ce_patch_sync(pat_u);
 
@@ -1322,64 +1081,29 @@ u3e_save(u3_post low_p, u3_post hig_p)
     u3_assert(!"loom: save failed");
   }
 
-#ifdef U3_SNAPSHOT_VALIDATION
-  //  check that clean pages are correct
-  //
-  u3_assert( c3y == _ce_loom_fine() );
-#endif
-
   _ce_patch_apply(pat_u);
+
+#ifdef U3_SNAPSHOT_VALIDATION
+  {
+    _ce_image_fine(&u3P.nor_u,
+                   u3_Loom,
+                   pag_wiz_i);
+
+    _ce_image_fine(&u3P.sou_u,
+                   (u3_Loom + u3C.wor_i) - pag_wiz_i,
+                   -(ssize_t)pag_wiz_i);
+
+    u3_assert(u3P.nor_u.pgs_w == u3K.nor_w);
+    u3_assert(u3P.sou_u.pgs_w == u3K.sou_w);
+  }
+#endif
 
   _ce_image_sync(&u3P.nor_u);
   _ce_image_sync(&u3P.sou_u);
   _ce_patch_free(pat_u);
   _ce_patch_delete();
 
-#ifdef U3_SNAPSHOT_VALIDATION
-  {
-    c3_w pgs_w;
-    u3_assert( c3y   == _ce_image_stat(&u3P.nor_u, &pgs_w) );
-    u3_assert( pgs_w == u3P.nor_u.pgs_w );
-    u3_assert( c3y   == _ce_image_stat(&u3P.sou_u, &pgs_w) );
-    u3_assert( pgs_w == u3P.sou_u.pgs_w );
-  }
-#endif
-
-  _ce_loom_protect_south(u3P.sou_u.pgs_w, sod_w);
-
-#ifdef U3_SNAPSHOT_VALIDATION
-  //  check that all pages in the north/south segments are clean,
-  //  all between are dirty, and clean pages are *fine*
-  //
-  //    since total finery requires total cleanliness,
-  //    pages of the north segment are protected twice.
-  //
-  _ce_loom_protect_north(u3P.nor_u.pgs_w, nod_w);
-
-  u3_assert( c3y == _ce_loom_track_sane() );
-  u3_assert( c3y == _ce_loom_fine() );
-#endif
-
-  if ( u3C.wag_w & u3o_no_demand ) {
-#ifndef U3_SNAPSHOT_VALIDATION
-    _ce_loom_protect_north(u3P.nor_u.pgs_w, nod_w);
-#endif
-  }
-  else {
-    _ce_loom_mapf_north(u3P.nor_u.fid_i, u3P.nor_u.pgs_w, nod_w);
-  }
-
-  {
-    void* ptr_v = _ce_ptr(u3P.nor_u.pgs_w);
-    c3_w  pgs_w = u3P.pag_w - (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w);
-
-    if ( -1 == madvise(ptr_v, _ce_len(pgs_w), MADV_DONTNEED) ) {
-        fprintf(stderr, "loom: madvise() failed for %u pages at %p: %s\r\n",
-                        pgs_w, ptr_v, strerror(errno));
-    }
-  }
-
-  u3e_backup(c3n);
+  _ce_backup();
 }
 
 /* u3e_live(): start the checkpointing system.
@@ -1392,7 +1116,7 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
   {
     size_t sys_i = sysconf(_SC_PAGESIZE);
 
-    if ( _ce_page % sys_i ) {
+    if ( pag_siz_i % sys_i ) {
       fprintf(stderr, "loom: incompatible system page size (%zuKB)\r\n",
                       sys_i >> 10);
       exit(1);
@@ -1422,7 +1146,6 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
     }
     else {
       u3_ce_patch* pat_u;
-      c3_w nor_w, sou_w;
 
       /* Load any patch files; apply them to images.
       */
@@ -1434,12 +1157,9 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
         _ce_patch_delete();
       }
 
-      nor_w = u3P.nor_u.pgs_w;
-      sou_w = u3P.sou_u.pgs_w;
-
       //  detect snapshots from a larger loom
       //
-      if ( (nor_w + sou_w + 1) >= u3P.pag_w ) {
+      if ( (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w + 1) >= u3a_pages ) {
         fprintf(stderr, "boot: snapshot too big for loom\r\n");
         exit(1);
       }
@@ -1451,35 +1171,27 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
       /* Write image files to memory; reinstate protection.
       */
       {
-        if ( u3C.wag_w & u3o_no_demand ) {
-          _ce_loom_blit_north(u3P.nor_u.fid_i, nor_w);
-        }
-        else {
-          _ce_loom_mapf_north(u3P.nor_u.fid_i, nor_w, 0);
-        }
+        _ce_image_blit(&u3P.nor_u,
+                       u3_Loom,
+                       pag_wiz_i);
 
-        _ce_loom_blit_south(u3P.sou_u.fid_i, sou_w);
+        _ce_image_blit(&u3P.sou_u,
+                       (u3_Loom + u3C.wor_i) - pag_wiz_i,
+                       -(ssize_t)pag_wiz_i);
 
         u3l_log("boot: protected loom");
       }
 
       /* If the images were empty, we are logically booting.
       */
-      if ( !nor_w && !sou_w ) {
+      if ( (0 == u3P.nor_u.pgs_w) && (0 == u3P.sou_u.pgs_w) ) {
         u3l_log("live: logical boot");
         nuu_o = c3y;
       }
-      else if ( u3C.wag_w & u3o_no_demand ) {
-        u3a_print_memory(stderr, "live: loaded", _ce_len_words(nor_w + sou_w));
-      }
       else {
-        u3a_print_memory(stderr, "live: mapped", nor_w << u3a_page);
-        u3a_print_memory(stderr, "live: loaded", sou_w << u3a_page);
+        u3a_print_memory(stderr, "live: loaded",
+                         (u3P.nor_u.pgs_w + u3P.sou_u.pgs_w) << u3a_page);
       }
-
-#ifdef U3_GUARD_PAGE
-      u3_assert( !_ce_ward_post(nor_w, u3P.pag_w - sou_w) );
-#endif
     }
   }
 
@@ -1493,8 +1205,8 @@ u3e_yolo(void)
 {
   //  NB: u3e_save() will reinstate protection flags
   //
-  if ( 0 != mprotect(_ce_ptr(0),
-                     _ce_len(u3P.pag_w),
+  if ( 0 != mprotect((void *)u3_Loom,
+                     u3C.wor_i << 2,
                      (PROT_READ | PROT_WRITE)) )
   {
     //  XX confirm recoverable errors
@@ -1503,7 +1215,11 @@ u3e_yolo(void)
     return c3n;
   }
 
-  u3_assert( !_ce_ward_protect() );
+  if ( 0 != mprotect(u3a_into(gar_pag_p), pag_siz_i, PROT_NONE) ) {
+    fprintf(stderr, "loom: failed to protect guard page: %s\r\n",
+                    strerror(errno));
+    u3_assert(0);
+  }
 
   return c3y;
 }
@@ -1516,17 +1232,15 @@ u3e_foul(void)
   memset((void*)u3P.dit_w, 0xff, sizeof(u3P.dit_w));
 }
 
-/* u3e_init(): initialize guard page tracking, dirty loom
+/* u3e_init(): initialize guard page tracking.
 */
 void
 u3e_init(void)
 {
   u3P.pag_w = u3C.wor_i >> u3a_page;
 
-  u3e_foul();
-
 #ifdef U3_GUARD_PAGE
-  u3_assert( !_ce_ward_post(0, u3P.pag_w) );
+  _ce_center_guard_page();
 #endif
 }
 
@@ -1536,14 +1250,8 @@ void
 u3e_ward(u3_post low_p, u3_post hig_p)
 {
 #ifdef U3_GUARD_PAGE
-  c3_w nop_w = low_p >> u3a_page;
-  c3_w sop_w = hig_p >> u3a_page;
-  c3_w pag_w = u3P.gar_w;
-
-  if ( !((pag_w > nop_w) && (pag_w < hig_p)) ) {
-    u3_assert( !_ce_ward_post(nop_w, sop_w) );
-    u3_assert( !_ce_flaw_protect(pag_w) );
-    u3_assert( u3P.dit_w[pag_w >> 5] & (1 << (pag_w & 31)) );
+  if ( (low_p > gar_pag_p) || (hig_p < gar_pag_p) ) {
+    _ce_center_guard_page();
   }
 #endif
 }

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -5,7 +5,6 @@
 
 #include "c3.h"
 #include "allocate.h"
-#include "version.h"
 
   /** Data structures.
   **/
@@ -19,11 +18,11 @@
     /* u3e_control: memory change, control file.
     */
       typedef struct _u3e_control {
-        u3e_version ver_w;                  //  version number
-        c3_w        nor_w;                  //  new page count north
-        c3_w        sou_w;                  //  new page count south
-        c3_w        pgs_w;                  //  number of changed pages
-        u3e_line    mem_u[0];               //  per page
+        c3_w     ver_y;                     //  version number
+        c3_w     nor_w;                     //  new page count north
+        c3_w     sou_w;                     //  new page count south
+        c3_w     pgs_w;                     //  number of changed pages
+        u3e_line mem_u[0];                  //  per page
       } u3e_control;
 
     /* u3_cs_patch: memory change, top level.
@@ -70,23 +69,23 @@
 
   /** Constants.
   **/
+#     define u3e_version 1
 
   /** Functions.
   **/
-    /* u3e_backup(): copy the snapshot from chk to bhk. 
+    /* _ce_backup(): copy the snapshot from chk to bhk. 
     */
-      c3_o 
-      u3e_backup(c3_o ovw_o);
-
-    /* u3e_fault(): handle a memory fault.
+      static void
+      _ce_backup();
+    /* u3e_fault(): handle a memory event with libsigsegv protocol.
     */
-      u3e_flaw
-      u3e_fault(u3_post low_p, u3_post hig_p, u3_post off_p);
+      c3_i
+      u3e_fault(void* adr_v, c3_i ser_i);
 
-    /* u3e_save(): update the checkpoint.
+    /* u3e_save():
     */
       void
-      u3e_save(u3_post low_p, u3_post hig_p);
+      u3e_save(void);
 
     /* u3e_live(): start the persistence system.  Return c3y if no image.
     */

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -40,20 +40,10 @@
         c3_i
         u3m_bail(c3_m how_m) __attribute__((noreturn));
 
-      /* u3m_fault(): handle a memory event with libsigsegv protocol.
-      */
-        c3_i
-        u3m_fault(void* adr_v, c3_i ser_i);
-
       /* u3m_foul(): dirty all pages and disable tracking.
       */
         void
         u3m_foul(void);
-
-      /* u3m_backup(): copy snapshot to .urb/bhk (if it doesn't exist yet).
-      */
-        c3_o
-        u3m_backup(c3_o);
 
       /* u3m_save(): update the checkpoint.
       */

--- a/pkg/noun/noun.h
+++ b/pkg/noun/noun.h
@@ -15,6 +15,7 @@
 #include "types.h"
 #include "vortex.h"
 #include "zave.h"
+#include "events.h"
 #include "imprison.h"
 #include "log.h"
 #include "nock.h"

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -35,16 +35,17 @@
     **  _check flags are set inside u3 and heard outside it.
     */
       enum u3o_flag {                         //  execution flags
-        u3o_debug_ram     = 1 << 0,           //  debug: gc
-        u3o_debug_cpu     = 1 << 1,           //  debug: profile
-        u3o_check_corrupt = 1 << 2,           //  check: gc memory
-        u3o_check_fatal   = 1 << 3,           //  check: unrecoverable
-        u3o_verbose       = 1 << 4,           //  be remarkably wordy
-        u3o_dryrun        = 1 << 5,           //  don't touch checkpoint
-        u3o_quiet         = 1 << 6,           //  disable ~&
-        u3o_hashless      = 1 << 7,           //  disable hashboard
-        u3o_trace         = 1 << 8,           //  enables trace dumping
-        u3o_no_demand     = 1 << 9            // disables demand paging
+        u3o_debug_ram =     1 <<  0,          //  debug: gc
+        u3o_debug_cpu =     1 <<  1,          //  debug: profile
+        u3o_check_corrupt = 1 <<  2,          //  check: gc memory
+        u3o_check_fatal =   1 <<  3,          //  check: unrecoverable
+        u3o_verbose =       1 <<  4,          //  be remarkably wordy
+        u3o_dryrun =        1 <<  5,          //  don't touch checkpoint
+        u3o_quiet =         1 <<  6,          //  disable ~&
+        u3o_hashless =      1 <<  7,          //  disable hashboard
+        u3o_trace =         1 <<  8,          //  enables trace dumping
+        u3o_no_demand     = 1 << 9,            // disables demand paging
+        u3o_auto_meld =     1 <<  10           //  enables meld under pressure
       };
 
   /** Globals.

--- a/pkg/noun/urth.c
+++ b/pkg/noun/urth.c
@@ -434,15 +434,17 @@ _cu_realloc(FILE* fil_u, ur_root_t** tor_u, ur_nvec_t* doc_u)
 /* u3u_meld(): globally deduplicate memory.
 */
 #ifdef U3_MEMORY_DEBUG
-void
+c3_w
 u3u_meld(void)
 {
   fprintf(stderr, "u3: unable to meld under U3_MEMORY_DEBUG\r\n");
+  return 0;
 }
 #else
-void
+c3_w
 u3u_meld(void)
 {
+  c3_w       pre_w = u3a_open(u3R);
   ur_root_t* rot_u;
   ur_nvec_t  cod_u;
 

--- a/pkg/noun/urth.h
+++ b/pkg/noun/urth.h
@@ -9,7 +9,7 @@
     **/
       /* u3u_meld(): globally deduplicate memory.
       */
-        void
+        c3_w
         u3u_meld(void);
 
       /* u3u_cram(): globably deduplicate memory, and write a rock to disk.

--- a/pkg/noun/vortex.c
+++ b/pkg/noun/vortex.c
@@ -38,9 +38,18 @@ u3v_life(u3_noun eve)
 c3_o
 u3v_boot(u3_noun eve)
 {
+  c3_d len_d;
+
+  {
+    u3_noun len = u3qb_lent(eve);
+    u3_assert( c3y == u3r_safe_chub(len, &len_d) );
+    u3z(len);
+  }
+
   //  ensure zero-initialized kernel
   //
-  u3A->roc = 0;
+  u3A->roc   = 0;
+  u3A->eve_d = 0;
 
   {
     u3_noun pro = u3m_soft(0, u3v_life, eve);
@@ -50,7 +59,8 @@ u3v_boot(u3_noun eve)
       return c3n;
     }
 
-    u3A->roc = u3k(u3t(pro));
+    u3A->roc   = u3k(u3t(pro));
+    u3A->eve_d = len_d;
     u3z(pro);
   }
 
@@ -298,6 +308,61 @@ u3v_poke(u3_noun ovo)
   return pro;
 }
 
+/* _cv_poke_eve(): u3v_poke w/out u3A->now XX replace
+*/
+static u3_noun
+_cv_poke_eve(u3_noun sam)
+{
+  u3_noun fun = u3n_nock_on(u3k(u3A->roc), u3k(u3x_at(_CVX_POKE, u3A->roc)));
+  u3_noun pro;
+
+  {
+# ifdef  U3_MEMORY_DEBUG
+    c3_w cod_w = u3a_lush(u3h(u3t(u3t(sam))));
+# endif
+
+    pro = u3n_slam_on(fun, sam);
+
+# ifdef  U3_MEMORY_DEBUG
+    u3a_lop(cod_w);
+# endif
+  }
+
+  return pro;
+}
+
+/* u3v_poke_sure(): inject an event, saving new state if successful.
+*/
+c3_o
+u3v_poke_sure(c3_w mil_w, u3_noun eve, u3_noun* pro)
+{
+  u3_noun gon = u3m_soft(mil_w, _cv_poke_eve, eve);
+  u3_noun tag, dat;
+  u3x_cell(gon, &tag, &dat);
+
+  //  event failed, produce trace
+  //
+  if ( u3_blip != tag ) {
+    *pro = gon;
+    return c3n;
+  }
+
+  //  event succeeded, persist state and produce effects
+  //
+  {
+    u3_noun vir, cor;
+    u3x_cell(dat, &vir, &cor);
+
+    u3z(u3A->roc);
+    u3A->roc = u3k(cor);
+    u3A->eve_d++;
+
+    *pro = u3k(vir);
+    u3z(gon);
+    return c3y;
+  }
+}
+
 /* u3v_tank(): dump single tank.
 */
 void
@@ -384,4 +449,3 @@ u3v_rewrite_compact()
   arv_u->now = u3a_rewritten_noun(arv_u->now);
   arv_u->yot = u3a_rewritten_noun(arv_u->yot);
 }
-

--- a/pkg/noun/vortex.h
+++ b/pkg/noun/vortex.h
@@ -101,6 +101,11 @@
       u3_noun
       u3v_poke(u3_noun ovo);
 
+    /* u3v_poke_sure(): inject an event, saving new state if successful.
+    */
+      c3_o
+      u3v_poke_sure(c3_w mil_w, u3_noun eve, u3_noun* pro);
+
     /* u3v_tank(): dump single tank.
     */
       void

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -22,6 +22,12 @@ struct _cd_save {
   struct _u3_disk* log_u;
 };
 
+struct _u3_disk_walk {
+  u3_lmdb_walk  itr_u;
+  u3_disk*      log_u;
+  c3_o          liv_o;
+};
+
 #undef VERBOSE_DISK
 #undef DISK_TRACE_JAM
 #undef DISK_TRACE_CUE
@@ -149,34 +155,45 @@ _disk_commit_start(struct _cd_save* req_u)
                                     _disk_commit_after_cb);
 }
 
-/* _disk_serialize_v1(): serialize events in format v1.
+/* u3_disk_etch(): serialize an event for persistence. RETAIN [eve]
 */
-static c3_w
-_disk_serialize_v1(u3_fact* tac_u, c3_y** out_y)
+size_t
+u3_disk_etch(u3_disk* log_u,
+             u3_noun    eve,
+             c3_l     mug_l,
+             c3_y**   out_y)
 {
+  size_t len_i;
+  c3_y*  dat_y;
 #ifdef DISK_TRACE_JAM
-  u3t_event_trace("king disk jam", 'B');
+  u3t_event_trace("disk etch", 'B');
 #endif
 
+  //  XX check version number in log_u
+  //  XX needs api redesign to limit allocations
+  //
   {
-    u3_atom mat = u3qe_jam(tac_u->job);
+    u3_atom mat = u3qe_jam(eve);
     c3_w  len_w = u3r_met(3, mat);
-    c3_y* dat_y = c3_malloc(4 + len_w);
-    dat_y[0] = tac_u->mug_l & 0xff;
-    dat_y[1] = (tac_u->mug_l >> 8) & 0xff;
-    dat_y[2] = (tac_u->mug_l >> 16) & 0xff;
-    dat_y[3] = (tac_u->mug_l >> 24) & 0xff;
+
+    len_i = 4 + len_w;
+    dat_y = c3_malloc(len_i);
+
+    dat_y[0] = mug_l & 0xff;
+    dat_y[1] = (mug_l >> 8) & 0xff;
+    dat_y[2] = (mug_l >> 16) & 0xff;
+    dat_y[3] = (mug_l >> 24) & 0xff;
     u3r_bytes(0, len_w, dat_y + 4, mat);
 
+    u3z(mat);
+  }
+
 #ifdef DISK_TRACE_JAM
-    u3t_event_trace("king disk jam", 'E');
+    u3t_event_trace("disk etch", 'E');
 #endif
 
-    u3z(mat);
-
-    *out_y = dat_y;
-    return len_w + 4;
-  }
+  *out_y = dat_y;
+  return len_i;
 }
 
 /* _disk_batch(): create a write batch
@@ -200,7 +217,8 @@ _disk_batch(u3_disk* log_u, c3_d len_d)
   for ( c3_d i_d = 0ULL; i_d < len_d; ++i_d) {
     u3_assert( (req_u->eve_d + i_d) == tac_u->eve_d );
 
-    req_u->siz_i[i_d] = _disk_serialize_v1(tac_u, &req_u->byt_y[i_d]);
+    req_u->siz_i[i_d] = u3_disk_etch(log_u, tac_u->job,
+                                     tac_u->mug_l, &req_u->byt_y[i_d]);
 
     tac_u = tac_u->nex_u;
   }
@@ -358,6 +376,41 @@ _disk_read_done_cb(uv_timer_t* tim_u)
   _disk_read_close(red_u);
 }
 
+/* u3_disk_sift(): parse a persisted event buffer.
+*/
+c3_o
+u3_disk_sift(u3_disk* log_u,
+             size_t   len_i,
+             c3_y*    dat_y,
+             c3_l*    mug_l,
+             u3_noun*   job)
+{
+  if ( 4 >= len_i ) {
+    return c3n;
+  }
+
+#ifdef DISK_TRACE_CUE
+  u3t_event_trace("disk sift", 'B');
+#endif
+
+  //  XX check version in log_u
+  //
+  *mug_l = dat_y[0]
+         ^ (dat_y[1] <<  8)
+         ^ (dat_y[2] << 16)
+         ^ (dat_y[3] << 24);
+
+  //  XX u3m_soft?
+  //
+  *job = u3ke_cue(u3i_bytes(len_i - 4, dat_y + 4));
+
+#ifdef DISK_TRACE_CUE
+  u3t_event_trace("disk sift", 'E');
+#endif
+
+  return c3y;
+}
+
 /* _disk_read_one_cb(): lmdb read callback, invoked for each event in order
 */
 static c3_o
@@ -390,6 +443,9 @@ _disk_read_one_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
 #ifdef DISK_TRACE_CUE
     u3t_event_trace("king disk cue", 'E');
 #endif
+    if ( c3n == u3_disk_sift(log_u, val_i, (c3_y*)val_p, &mug_l, &job) ) {
+      return c3n;
+    }
 
     tac_u = u3_fact_init(eve_d, mug_l, job);
   }
@@ -461,17 +517,131 @@ u3_disk_read(u3_disk* log_u, c3_d eve_d, c3_d len_d)
   uv_timer_start(&red_u->tim_u, _disk_read_start_cb, 0, 0);
 }
 
+struct _cd_list {
+  u3_disk* log_u;
+  u3_noun    eve;
+  c3_l     mug_l;
+};
+
+/* _disk_read_list_cb(): lmdb read callback, invoked for each event in order
+*/
+static c3_o
+_disk_read_list_cb(void* ptr_v, c3_d eve_d, size_t val_i, void* val_p)
+{
+  struct _cd_list* ven_u = ptr_v;
+  u3_disk* log_u = ven_u->log_u;
+
+  {
+    u3_noun job;
+    c3_l  mug_l;
+
+    if ( c3n == u3_disk_sift(log_u, val_i, (c3_y*)val_p, &mug_l, &job) ) {
+      return c3n;
+    }
+
+    ven_u->mug_l = mug_l;
+    ven_u->eve   = u3nc(job, ven_u->eve);
+  }
+
+  return c3y;
+}
+
+/* u3_disk_read_list(): synchronously read a cons list of events.
+*/
+u3_weak
+u3_disk_read_list(u3_disk* log_u, c3_d eve_d, c3_d len_d, c3_l* mug_l)
+{
+  struct _cd_list ven_u = { log_u, u3_nul, 0 };
+
+  if ( c3n == u3_lmdb_read(log_u->mdb_u, &ven_u,
+                           eve_d, len_d, _disk_read_list_cb) )
+  {
+    return u3_none;
+  }
+
+  *mug_l = ven_u.mug_l;
+  return u3kb_flop(ven_u.eve);
+}
+
+/* u3_disk_walk_init(): init iterator.
+*/
+u3_disk_walk*
+u3_disk_walk_init(u3_disk* log_u,
+                  c3_d     eve_d,
+                  c3_d     len_d)
+{
+  u3_disk_walk* wok_u = c3_malloc(sizeof(*wok_u));
+  c3_d          max_d = eve_d + len_d - 1;
+
+  wok_u->log_u = log_u;
+  wok_u->liv_o = u3_lmdb_walk_init(log_u->mdb_u,
+                                  &wok_u->itr_u,
+                                   eve_d,
+                                   c3_min(max_d, log_u->dun_d));
+
+  return wok_u;
+}
+
+/* u3_disk_walk_live(): check if live.
+*/
+c3_o
+u3_disk_walk_live(u3_disk_walk* wok_u)
+{
+  if ( wok_u->itr_u.nex_d > wok_u->itr_u.las_d ) {
+    wok_u->liv_o = c3n;
+  }
+
+  return wok_u->liv_o;
+}
+
+/* u3_disk_walk_step(): get next fact.
+*/
+c3_o
+u3_disk_walk_step(u3_disk_walk* wok_u, u3_fact* tac_u)
+{
+  u3_disk* log_u = wok_u->log_u;
+  size_t   len_i;
+  void*    buf_v;
+
+  tac_u->eve_d = wok_u->itr_u.nex_d;
+
+  if ( c3n == u3_lmdb_walk_next(&wok_u->itr_u, &len_i, &buf_v) ) {
+    fprintf(stderr, "disk: (%" PRIu64 "): read fail\r\n", tac_u->eve_d);
+    return wok_u->liv_o = c3n;
+  }
+
+  if ( c3n == u3_disk_sift(log_u, len_i,
+                           (c3_y*)buf_v,
+                           &tac_u->mug_l,
+                           &tac_u->job) )
+  {
+    fprintf(stderr, "disk: (%" PRIu64 "): sift fail\r\n", tac_u->eve_d);
+    return wok_u->liv_o = c3n;
+  }
+
+  return c3y;
+}
+
+/* u3_disk_walk_done(): close iterator.
+*/
+void
+u3_disk_walk_done(u3_disk_walk* wok_u)
+{
+  u3_lmdb_walk_done(&wok_u->itr_u);
+  c3_free(wok_u);
+}
+
 /* _disk_save_meta(): serialize atom, save as metadata at [key_c].
 */
 static c3_o
-_disk_save_meta(MDB_env* mdb_u, const c3_c* key_c, u3_atom dat)
+_disk_save_meta(u3_disk* log_u, const c3_c* key_c, u3_atom dat)
 {
   c3_w  len_w = u3r_met(3, dat);
   c3_y* byt_y = c3_malloc(len_w);
   u3r_bytes(0, len_w, byt_y, dat);
 
   {
-    c3_o ret_o = u3_lmdb_save_meta(mdb_u, key_c, len_w, byt_y);
+    c3_o ret_o = u3_lmdb_save_meta(log_u, key_c, len_w, byt_y);
     c3_free(byt_y);
     return ret_o;
   }
@@ -480,17 +650,17 @@ _disk_save_meta(MDB_env* mdb_u, const c3_c* key_c, u3_atom dat)
 /* u3_disk_save_meta(): save metadata.
 */
 c3_o
-u3_disk_save_meta(MDB_env* mdb_u,
+u3_disk_save_meta(u3_disk* log_u,
                   c3_d     who_d[2],
                   c3_o     fak_o,
                   c3_w     lif_w)
 {
   u3_assert( c3y == u3a_is_cat(lif_w) );
 
-  if (  (c3n == _disk_save_meta(mdb_u, "version", 1))
-     || (c3n == _disk_save_meta(mdb_u, "who", u3i_chubs(2, who_d)))
-     || (c3n == _disk_save_meta(mdb_u, "fake", fak_o))
-     || (c3n == _disk_save_meta(mdb_u, "life", lif_w)) )
+  if (  (c3n == _disk_save_meta(log_u, "version", 1))
+     || (c3n == _disk_save_meta(log_u, "who", u3i_chubs(2, who_d)))
+     || (c3n == _disk_save_meta(log_u, "fake", fak_o))
+     || (c3n == _disk_save_meta(log_u, "life", lif_w)) )
   {
     return c3n;
   }
@@ -513,36 +683,36 @@ _disk_meta_read_cb(void* ptr_v, size_t val_i, void* val_p)
 /* _disk_read_meta(): read metadata at [key_c], deserialize.
 */
 static u3_weak
-_disk_read_meta(MDB_env* mdb_u, const c3_c* key_c)
+_disk_read_meta(u3_disk* log_u, const c3_c* key_c)
 {
   u3_weak dat = u3_none;
-  u3_lmdb_read_meta(mdb_u, &dat, key_c, _disk_meta_read_cb);
+  u3_lmdb_read_meta(log_u->mdb_u, &dat, key_c, _disk_meta_read_cb);
   return dat;
 }
 
 /* u3_disk_read_meta(): read metadata.
 */
 c3_o
-u3_disk_read_meta(MDB_env* mdb_u,
+u3_disk_read_meta(u3_disk* log_u,
                   c3_d*    who_d,
                   c3_o*    fak_o,
                   c3_w*    lif_w)
 {
   u3_weak ver, who, fak, lif;
 
-  if ( u3_none == (ver = _disk_read_meta(mdb_u, "version")) ) {
+  if ( u3_none == (ver = _disk_read_meta(log_u, "version")) ) {
     fprintf(stderr, "disk: read meta: no version\r\n");
     return c3n;
   }
-  if ( u3_none == (who = _disk_read_meta(mdb_u, "who")) ) {
+  if ( u3_none == (who = _disk_read_meta(log_u, "who")) ) {
     fprintf(stderr, "disk: read meta: no indentity\r\n");
     return c3n;
   }
-  if ( u3_none == (fak = _disk_read_meta(mdb_u, "fake")) ) {
+  if ( u3_none == (fak = _disk_read_meta(log_u, "fake")) ) {
     fprintf(stderr, "disk: read meta: no fake bit\r\n");
     return c3n;
   }
-  if ( u3_none == (lif = _disk_read_meta(mdb_u, "life")) ) {
+  if ( u3_none == (lif = _disk_read_meta(log_u, "life")) ) {
     fprintf(stderr, "disk: read meta: no lifecycle length\r\n");
     return c3n;
   }

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -1099,9 +1099,7 @@ _lord_on_serf_bail(void*       ptr_v,
   u3_lord* god_u = ptr_v;
 
   if ( UV_EOF == err_i ) {
-    // u3l_log("pier: serf unexpectedly shut down");
-    u3l_log("pier: EOF");
-    return;
+    u3l_log("pier: serf unexpectedly shut down");
   }
   else {
     u3l_log("pier: serf error: %s", err_c);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2091,6 +2091,7 @@ fprintf(stderr, "pier: %s\r\n", u3_Host.dir_c);
       .dir_c = u3_Host.dir_c,
       .sen_d = u3A->eve_d,
       .dun_d = u3A->eve_d,
+      .bat_c  = u3_Host.ops_u.batch_sz_c,
       .mug_l = u3r_mug(u3A->roc)
     };
     c3_d    eve_d = 0;

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1,0 +1,272 @@
+/* worker/mars.c
+**
+**  the main loop of a mars process.
+*/
+#include "c3.h"
+#include "noun.h"
+#include "types.h"
+#include "vere.h"
+#include "db/lmdb.h"
+#include <mars.h>
+#include <stdio.h>
+
+/* _mars_step_trace(): initialize or rotate trace file.
+*/
+static void
+_mars_step_trace(const c3_c* dir_c)
+{
+  if ( u3C.wag_w & u3o_trace ) {
+    c3_w trace_cnt_w = u3t_trace_cnt();
+    if ( trace_cnt_w == 0  && u3t_file_cnt() == 0 ) {
+      u3t_trace_open(dir_c);
+    }
+    else if ( trace_cnt_w >= 100000 ) {
+      u3t_trace_close();
+      u3t_trace_open(dir_c);
+    }
+  }
+}
+
+/* _mars_poke_play(): replay an event.
+*/
+static u3_weak
+_mars_poke_play(u3_mars* mar_u, c3_d eve_d, u3_noun job)
+{
+  u3_noun vir;
+
+  if ( c3n == u3v_poke_sure(0, job, &vir) ) {
+    return vir;
+  }
+
+  u3z(vir);
+  return u3_none;
+}
+
+typedef enum {
+  _play_yes_e,  //  success
+  _play_mem_e,  //  %meme
+  _play_int_e,  //  %intr
+  _play_log_e,  //  event log fail
+  _play_mug_e,  //  mug mismatch
+  _play_bad_e   //  total failure
+} _mars_play_e;
+
+/* _mars_play_batch(): replay a batch of events.
+*/
+static _mars_play_e
+_mars_play_batch(u3_mars* mar_u, c3_o mug_o, c3_w bat_w)
+{
+  u3_disk*      log_u = mar_u->log_u;
+  u3_disk_walk* wok_u = u3_disk_walk_init(log_u, mar_u->dun_d + 1, bat_w);
+  u3_fact       tac_u;
+  u3_noun         dud;
+
+  while ( c3y == u3_disk_walk_live(wok_u) ) {
+    if ( c3n == u3_disk_walk_step(wok_u, &tac_u) ) {
+      u3_disk_walk_done(wok_u);
+      return _play_log_e;
+    }
+
+    u3_assert( ++mar_u->sen_d == tac_u.eve_d );
+
+    if ( u3_none != (dud = _mars_poke_play(mar_u, tac_u.eve_d, tac_u.job)) ) {
+      c3_m mot_m;
+
+      mar_u->sen_d = mar_u->dun_d;
+      u3_disk_walk_done(wok_u);
+
+      u3_assert( c3y == u3r_safe_word(u3h(dud), &mot_m) );
+
+      switch ( mot_m ) {
+        case c3__meme: {
+          fprintf(stderr, "play (%" PRIu64 "): %%meme\r\n", tac_u.eve_d);
+          u3z(dud);
+          return _play_mem_e;
+        }
+
+        case c3__intr: {
+          fprintf(stderr, "play (%" PRIu64 "): %%intr\r\n", tac_u.eve_d);
+          u3z(dud);
+          return _play_int_e;
+        }
+
+        default: {
+          fprintf(stderr, "play (%" PRIu64 "): failed\r\n", tac_u.eve_d);
+          u3_pier_punt_goof("play", dud);
+          //  XX say something uplifting
+          //
+          return _play_bad_e;
+        }
+      }
+    }
+
+    mar_u->mug_l = u3r_mug(u3A->roc);
+
+    if ( tac_u.mug_l && (mar_u->mug_l != tac_u.mug_l) ) {
+      fprintf(stderr, "play (%" PRIu64 "): mug mismatch "
+                      "expected %08x, actual %08x\r\n",
+                      tac_u.eve_d, tac_u.mug_l, mar_u->mug_l);
+
+      if ( c3y == mug_o ) {
+        mar_u->sen_d = mar_u->dun_d;
+        u3_disk_walk_done(wok_u);
+        return _play_mug_e;
+      }
+    }
+
+    mar_u->dun_d = mar_u->sen_d;
+  }
+
+  u3_disk_walk_done(wok_u);
+
+  return _play_yes_e;
+}
+
+static c3_o
+_mars_do_boot(u3_disk* log_u, c3_d eve_d)
+{
+  u3_weak eve;
+  c3_l  mug_l;
+
+  if ( u3_none == (eve = u3_disk_read_list(log_u, 1, eve_d, &mug_l)) ) {
+    fprintf(stderr, "boot: read failed\r\n");
+    return c3n;
+  }
+
+  u3l_log("--------------- bootstrap starting ----------------\r\n");
+
+  u3l_log("boot: 1-%u\r\n", u3qb_lent(eve));
+
+  if ( c3n == u3v_boot(eve) ) {
+    return c3n;
+  }
+
+  u3l_log("--------------- bootstrap complete ----------------\r\n");
+  return c3y;
+}
+
+/* u3_mars_play(): replay logged events up to [eve_d].
+*/
+void
+u3_mars_play(u3_mars* mar_u, c3_d eve_d)
+{
+  u3_disk* log_u = mar_u->log_u;
+
+  if ( !eve_d ) {
+    eve_d = log_u->dun_d;
+  }
+  else if ( eve_d <= mar_u->dun_d ) {
+    u3l_log("mars: already computed %" PRIu64 "\r\n", eve_d);
+    u3l_log("      state=%" PRIu64 ", log=%" PRIu64 "\r\n",
+            mar_u->dun_d, log_u->dun_d);
+    return;
+  }
+  else {
+    eve_d = c3_min(eve_d, log_u->dun_d);
+  }
+
+  if ( !mar_u->dun_d ) {
+    c3_w lif_w;
+
+    if ( c3n == u3_disk_read_meta(log_u, 0, 0, &lif_w) ) {
+      fprintf(stderr, "mars: disk read meta fail\r\n");
+      //  XX exit code, cb
+      //
+      exit(1);
+    }
+
+    if ( c3n == _mars_do_boot(mar_u->log_u, lif_w) ) {
+      fprintf(stderr, "mars: boot fail\r\n");
+      //  XX exit code, cb
+      //
+      exit(1);
+    }
+
+    mar_u->sen_d = mar_u->dun_d = lif_w;
+  }
+
+  if ( mar_u->dun_d == log_u->dun_d ) {
+    u3l_log("mars: nothing to do!\r\n");
+    return;
+  }
+
+  u3l_log("---------------- playback starting ----------------\r\n");
+
+  if ( (1ULL + eve_d) == log_u->dun_d ) {
+    u3l_log("play: event %" PRIu64 "\r\n", log_u->dun_d);
+  }
+  else if ( eve_d != log_u->dun_d ) {
+    u3l_log("play: events %" PRIu64 "-%" PRIu64 " of %" PRIu64 "\r\n",
+            (c3_d)(1ULL + mar_u->dun_d),
+            eve_d,
+            log_u->dun_d);
+  }
+  else {
+    u3l_log("play: events %" PRIu64 "-%" PRIu64 "\r\n",
+            (c3_d)(1ULL + mar_u->dun_d),
+            eve_d);
+  }
+
+  {
+    c3_d mem_d = 0;             // last event to meme
+    c3_w try_w = 0;             // [mem_d] retry count
+
+    while ( mar_u->dun_d < eve_d ) {
+      _mars_step_trace(mar_u->dir_c);
+
+      //  XX get batch from args
+      //
+      switch ( _mars_play_batch(mar_u, c3y, 1024) ) {
+        case _play_yes_e: {
+          u3l_log("play (%" PRIu64 "): done\r\n", mar_u->dun_d);
+          u3m_reclaim();
+
+          //  XX save a snapshot every N events?
+          //
+        } break;
+
+        case _play_mem_e: {
+          if ( mem_d != mar_u->dun_d ) {
+            mem_d = mar_u->dun_d;
+            try_w = 0;
+          }
+          else if ( 3 == ++try_w ) {
+            fprintf(stderr, "play (%" PRIu64 "): failed\r\n", mar_u->dun_d + 1);
+            u3e_save();
+            //  XX check loom size, suggest --loom X
+            //  XX exit code, cb
+            //
+            u3_disk_exit(log_u);
+            exit(1);
+          }
+
+          //  XX pack before meld?
+          //
+          if ( u3C.wag_w & u3o_auto_meld ) {
+            u3a_print_memory(stderr, "mars: meld: gained", u3u_meld());
+          }
+          else {
+            u3a_print_memory(stderr, "mars: pack: gained", u3m_pack());
+          }
+        } break;
+
+        //  XX handle any specifically?
+        //
+        case _play_int_e:
+        case _play_log_e:
+        case _play_mug_e:
+        case _play_bad_e: {
+          fprintf(stderr, "play (%" PRIu64 "): failed\r\n", mar_u->dun_d + 1);
+          u3e_save();
+          //  XX exit code, cb
+          //
+          u3_disk_exit(log_u);
+          exit(1);
+        }
+      }
+    }
+  }
+
+  u3l_log("---------------- playback complete ----------------\r\n");
+  u3e_save();
+}

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -54,10 +54,10 @@ typedef enum {
 /* _mars_play_batch(): replay a batch of events.
 */
 static _mars_play_e
-_mars_play_batch(u3_mars* mar_u, c3_o mug_o, c3_w bat_w)
+_mars_play_batch(u3_mars* mar_u, c3_o mug_o, c3_c bat_c)
 {
   u3_disk*      log_u = mar_u->log_u;
-  u3_disk_walk* wok_u = u3_disk_walk_init(log_u, mar_u->dun_d + 1, bat_w);
+  u3_disk_walk* wok_u = u3_disk_walk_init(log_u, mar_u->dun_d + 1, bat_c);
   u3_fact       tac_u;
   u3_noun         dud;
 

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -54,10 +54,10 @@ typedef enum {
 /* _mars_play_batch(): replay a batch of events.
 */
 static _mars_play_e
-_mars_play_batch(u3_mars* mar_u, c3_o mug_o, c3_c bat_c)
+_mars_play_batch(u3_mars* mar_u, c3_o mug_o, c3_c* bat_c)
 {
   u3_disk*      log_u = mar_u->log_u;
-  u3_disk_walk* wok_u = u3_disk_walk_init(log_u, mar_u->dun_d + 1, bat_c);
+  u3_disk_walk* wok_u = u3_disk_walk_init(log_u, mar_u->dun_d + 1, *bat_c);
   u3_fact       tac_u;
   u3_noun         dud;
 

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -216,7 +216,7 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d)
 
       //  XX get batch from args
       //
-      switch ( _mars_play_batch(mar_u, c3y, 1024) ) {
+      switch ( _mars_play_batch(mar_u, c3y, mar_u->bat_c) ) {
         case _play_yes_e: {
           u3l_log("play (%" PRIu64 "): done\r\n", mar_u->dun_d);
           u3m_reclaim();

--- a/pkg/vere/mars.h
+++ b/pkg/vere/mars.h
@@ -1,0 +1,22 @@
+#ifndef U3_VERE_MARS_H
+#define U3_VERE_MARS_H
+
+  /** Data types.
+  **/
+    /* u3_mars: the urbit state machine.
+    */
+      typedef struct _u3_mars {
+        c3_d     key_d[4];                  //  disk key
+        u3_disk* log_u;                     //  event log
+        c3_c*    dir_c;                     //  execution directory (pier)
+        c3_d     sen_d;                     //  last event requested
+        c3_d     dun_d;                     //  last event processed
+        c3_l     mug_l;                     //  hash of state
+      } u3_mars;
+
+    /* u3_mars_play(): replay logged events up to [eve_d].
+    */
+      void
+      u3_mars_play(u3_mars* mar_u, c3_d eve_d);
+
+#endif /* ifndef U3_VERE_MARS_H */

--- a/pkg/vere/mars.h
+++ b/pkg/vere/mars.h
@@ -11,6 +11,7 @@
         c3_c*    dir_c;                     //  execution directory (pier)
         c3_d     sen_d;                     //  last event requested
         c3_d     dun_d;                     //  last event processed
+        c3_c*    bat_c;                    //  batch size
         c3_l     mug_l;                     //  hash of state
       } u3_mars;
 

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -200,7 +200,7 @@ _serf_grab(u3_noun sac)
       c3_c* wen_c = u3r_string(wen);
 
       c3_c nam_c[2048];
-      snprintf(nam_c, 2048, "%s/.urb/put/mass", u3C.dir_c);
+      snprintf(nam_c, 2048, "%s/.urb/put/mass", u3P.dir_c);
 
       struct stat st;
       if ( -1 == stat(nam_c, &st) ) {
@@ -839,7 +839,7 @@ _serf_writ_live_exit(u3_serf* sef_u, c3_w cod_w)
       c3_c* wen_c = u3r_string(wen);
 
       c3_c nam_c[2048];
-      snprintf(nam_c, 2048, "%s/.urb/put/profile", u3C.dir_c);
+      snprintf(nam_c, 2048, "%s/.urb/put/profile", u3P.dir_c);
 
       struct stat st;
       if ( -1 == stat(nam_c, &st) ) {
@@ -883,7 +883,7 @@ _serf_writ_live_save(u3_serf* sef_u, c3_d eve_d)
     exit(1);
   }
 
-  u3m_save();
+  u3e_save();
 }
 
 /* u3_serf_live(): apply %live command [com], producing *ret on c3y.
@@ -954,7 +954,7 @@ u3_serf_live(u3_serf* sef_u, u3_noun com, u3_noun* ret)
         return c3n;
       }
 
-      u3m_save();
+      u3e_save();
       u3_serf_grab();
 
       *ret = u3nc(c3__live, u3_nul);
@@ -981,7 +981,7 @@ u3_serf_live(u3_serf* sef_u, u3_noun com, u3_noun* ret)
       }
       else {
         u3z(com);
-        u3u_meld();
+        u3a_print_memory(stderr, "serf: meld: gained", u3u_meld());
         *ret = u3nc(c3__live, u3_nul);
         return c3y;
       }

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -551,6 +551,10 @@
           u3_info          put_u;               //  write queue
         } u3_disk;
 
+      /* u3_disk_walk: opaque event log iterator.
+      */
+        typedef struct _u3_disk_walk u3_disk_walk;
+
       /* u3_psat: pier state.
       */
         typedef enum {
@@ -930,6 +934,23 @@
         u3_disk*
         u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u);
 
+      /* u3_disk_etch(): serialize an event for persistence. RETAIN [eve]
+      */
+        size_t
+        u3_disk_etch(u3_disk* log_u,
+                     u3_noun    eve,
+                     c3_l     mug_l,
+                     c3_y**   out_y);
+
+      /* u3_disk_sift(): parse a persisted event buffer.
+      */
+        c3_o
+        u3_disk_sift(u3_disk* log_u,
+                     size_t   len_i,
+                     c3_y*    dat_y,
+                     c3_l*    mug_l,
+                     u3_noun*   job);
+
       /* u3_disk_info(): status info as $mass.
       */
         u3_noun
@@ -948,7 +969,7 @@
       /* u3_disk_read_meta(): read metadata.
       */
         c3_o
-        u3_disk_read_meta(MDB_env* mdb_u,
+        u3_disk_read_meta(u3_disk* log_u,
                           c3_d*    who_d,
                           c3_o*    fak_o,
                           c3_w*    lif_w);
@@ -956,7 +977,7 @@
       /* u3_disk_save_meta(): save metadata.
       */
         c3_o
-        u3_disk_save_meta(MDB_env* mdb_u,
+        u3_disk_save_meta(u3_disk* log_u,
                           c3_d     who_d[2],
                           c3_o     fak_o,
                           c3_w     lif_w);
@@ -980,6 +1001,33 @@
       */
         void
         u3_disk_plan(u3_disk* log_u, u3_fact* tac_u);
+
+      /* u3_disk_read_list(): synchronously read a cons list of events.
+      */
+        u3_weak
+        u3_disk_read_list(u3_disk* log_u, c3_d eve_d, c3_d len_d, c3_l* mug_l);
+
+      /* u3_disk_walk_init(): init iterator.
+      */
+        u3_disk_walk*
+        u3_disk_walk_init(u3_disk* log_u,
+                          c3_d     eve_d,
+                          c3_d     len_d);
+
+      /* u3_disk_walk_live(): check if live.
+      */
+        c3_o
+        u3_disk_walk_live(u3_disk_walk* wok_u);
+
+      /* u3_disk_walk_live(): get next fact.
+      */
+        c3_o
+        u3_disk_walk_step(u3_disk_walk* wok_u, u3_fact* tac_u);
+
+      /* u3_disk_walk_done(): close iterator.
+      */
+        void
+        u3_disk_walk_done(u3_disk_walk* wok_u);
 
       /* u3_lord_init(): start serf.
       */


### PR DESCRIPTION
Updated #210. A few things still need to be unclobbered and I haven't tested the pill issue discussed in #157, but the `play` subcommand now works with custom batch sizes and loom (which was missing in  #192)  Needed this to speed up ~littel-wolfur's replay, and I'm running it on a copy now. 