### PR TITLE
u3: "toss" ephemeral pages after every event

### DIFF
--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -89,6 +89,11 @@
       void
       u3e_save(u3_post low_p, u3_post hig_p);
 
+    /* u3e_toss(): discard ephemeral pages.
+    */
+      void
+      u3e_toss(u3_post low_p, u3_post hig_p);
+
     /* u3e_live(): start the persistence system.  Return c3y if no image.
     */
       c3_o

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1859,6 +1859,16 @@ u3m_save(void)
   return u3e_save(low_p, hig_p);
 }
 
+/* u3m_toss(): discard ephemeral memory.
+*/
+void
+u3m_toss(void)
+{
+  u3_post low_p, hig_p;
+  u3m_water(&low_p, &hig_p);
+  u3e_toss(low_p, hig_p);
+}
+
 /* u3m_ward(): tend the guardpage.
 */
 void

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1866,7 +1866,17 @@ u3m_toss(void)
 {
   u3_post low_p, hig_p;
   u3m_water(&low_p, &hig_p);
-  u3e_toss(low_p, hig_p);
+
+  if (  ((low_p + u3C.tos_w) < u3C.wor_i)
+     && (hig_p > u3C.tos_w) )
+  {
+    low_p += u3C.tos_w;
+    hig_p -= u3C.tos_w;
+
+    if ( low_p < hig_p ) {
+      u3e_toss(low_p, hig_p);
+    }
+  }
 }
 
 /* u3m_ward(): tend the guardpage.

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -60,6 +60,11 @@
         void
         u3m_save(void);
 
+      /* u3m_toss(): discard ephemeral memory.
+      */
+        void
+        u3m_toss(void);
+
       /* u3m_ward(): tend the guardpage.
       */
         void

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -24,6 +24,7 @@
         } migration_state;
 
         size_t  wor_i;                        //  loom word-length (<= u3a_words)
+        c3_w    tos_w;                        //  loom toss skip-length
         void (*stderr_log_f)(c3_c*);          //  errors from c code
         void (*slog_f)(u3_noun);              //  function pointer for slog
         void (*sign_hold_f)(void);            //  suspend system signal regime
@@ -48,7 +49,8 @@
         u3o_no_demand     = 1 <<  9,          //  disables demand paging
         u3o_auto_meld     = 1 << 10,          //  enables meld under pressure
         u3o_soft_mugs     = 1 << 11,          //  continue replay on mismatch
-        u3o_swap          = 1 << 12           //  enables ephemeral file
+        u3o_swap          = 1 << 12,          //  enables ephemeral file
+        u3o_toss          = 1 << 13           //  reclaim often
       };
 
   /** Globals.

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -1160,12 +1160,13 @@ u3_lord_init(c3_c* pax_c, c3_w wag_w, c3_d key_d[4], u3_lord_cb cb_u)
   //  spawn new process and connect to it
   //
   {
-    c3_c* arg_c[10];
+    c3_c* arg_c[11];
     c3_c  key_c[256];
     c3_c  wag_c[11];
     c3_c  hap_c[11];
     c3_c  cev_c[11];
     c3_c  lom_c[11];
+    c3_c  tos_c[11];
     c3_i  err_i;
 
     sprintf(key_c, "%" PRIx64 ":%" PRIx64 ":%" PRIx64 ":%" PRIx64,
@@ -1179,6 +1180,8 @@ u3_lord_init(c3_c* pax_c, c3_w wag_w, c3_d key_d[4], u3_lord_cb cb_u)
     sprintf(hap_c, "%u", u3_Host.ops_u.hap_w);
 
     sprintf(lom_c, "%u", u3_Host.ops_u.lom_y);
+
+    sprintf(tos_c, "%u", u3C.tos_w);
 
     arg_c[0] = god_u->bin_c;            //  executable
     arg_c[1] = "serf";                  //  protocol
@@ -1204,7 +1207,8 @@ u3_lord_init(c3_c* pax_c, c3_w wag_w, c3_d key_d[4], u3_lord_cb cb_u)
       arg_c[8] = strdup(u3C.eph_c);     //  ephemeral file
     }
 
-    arg_c[9] = NULL;
+    arg_c[9] = tos_c;
+    arg_c[10] = NULL;
 
     uv_pipe_init(u3L, &god_u->inn_u.pyp_u, 0);
     uv_timer_init(u3L, &god_u->out_u.tim_u);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -176,6 +176,7 @@ _main_init(void)
   u3_Host.ops_u.qui = c3n;
   u3_Host.ops_u.rep = c3n;
   u3_Host.ops_u.eph = c3n;
+  u3_Host.ops_u.tos = c3n;
   u3_Host.ops_u.tem = c3n;
   u3_Host.ops_u.tex = c3n;
   u3_Host.ops_u.tra = c3n;
@@ -189,6 +190,7 @@ _main_init(void)
   u3_Host.ops_u.lom_y = 31;
 
   u3C.eph_c = 0;
+  u3C.tos_w = 0;
 }
 
 /* _main_pier_run(): get pier from binary path (argv[0]), if appropriate
@@ -271,6 +273,7 @@ _main_getopt(c3_i argc, c3_c** argv)
     { "no-demand",           no_argument,       NULL, 6 },
     { "swap",                no_argument,       NULL, 7 },
     { "swap-to",             required_argument, NULL, 8 },
+    { "toss",                required_argument, NULL, 9 },
     //
     { NULL, 0, NULL, 0 },
   };
@@ -297,6 +300,13 @@ _main_getopt(c3_i argc, c3_c** argv)
       case 8: {  //  swap-to
         u3_Host.ops_u.eph = c3y;
         u3C.eph_c = strdup(optarg);
+        break;
+      }
+      case 9: {  //  toss
+        u3_Host.ops_u.tos = c3y;
+        if ( 1 != sscanf(optarg, "%" SCNu32, &u3C.tos_w) ) {
+          return c3n;
+        }
         break;
       }
       //  special args
@@ -1075,6 +1085,8 @@ _cw_serf_commence(c3_i argc, c3_c* argv[])
   c3_w       lom_w;
   c3_c*      eve_c = argv[7];
   c3_c*      eph_c = argv[8];
+  c3_c*      tos_c = argv[9];
+  c3_w       tos_w;
 
   _cw_init_io(lup_u);
 
@@ -1095,12 +1107,18 @@ _cw_serf_commence(c3_i argc, c3_c* argv[])
   //  load runtime config
   //
   {
+    //  XX check return
+    //
     sscanf(wag_c, "%" SCNu32, &u3C.wag_w);
     sscanf(hap_c, "%" SCNu32, &u3_Host.ops_u.hap_w);
     sscanf(lom_c, "%" SCNu32, &lom_w);
 
+    if ( 1 != sscanf(tos_c, "%" SCNu32, &u3C.tos_w) ) {
+      fprintf(stderr, "serf: toss: invalid number '%s'\r\n", tos_c);
+    }
+
     if ( 1 != sscanf(eve_c, "%" PRIu64, &eve_d) ) {
-      fprintf(stderr, "serf: rock: invalid number '%s'\r\n", argv[4]);
+      fprintf(stderr, "serf: rock: invalid number '%s'\r\n", eve_c);
     }
   }
 
@@ -2971,6 +2989,12 @@ main(c3_i   argc,
       */
       if ( _(u3_Host.ops_u.eph) ) {
         u3C.wag_w |= u3o_swap;
+      }
+
+      /*  Set toss flog
+      */
+      if ( _(u3_Host.ops_u.tos) ) {
+        u3C.wag_w |= u3o_toss;
       }
     }
 

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -190,6 +190,10 @@ u3_serf_post(u3_serf* sef_u)
     u3l_log("");
     sef_u->pac_o = c3n;
   }
+
+  if ( u3C.wag_w & u3o_toss ) {
+    u3m_toss();
+  }
 }
 
 /* _serf_sure_feck(): event succeeded, send effects.

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -305,6 +305,7 @@
         c3_o    nuu;                        //      new pier
         c3_o    map;                        //  --no-demand (reversed)
         c3_o    eph;                        //  --swap, use ephemeral file
+        c3_o    tos;                        //  --toss, discard ephemeral
       } u3_opts;
 
     /* u3_host: entire host.


### PR DESCRIPTION
Highly relevant to #410 (I think this behavior should be always-on in the presence of "swap"), but also likely useful as a standalone option for low-memory deployments. This is a draft PR as the behavior is hardcoded, not controlled by command-line arguments.