### PR TITLE
u3: specify madv_random for file-backed snapshot mapping

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -995,6 +995,11 @@ _ce_loom_mapf_north(c3_i fid_i, c3_w pgs_w, c3_w old_w)
                       pgs_w, strerror(errno));
       u3_assert(0);
     }
+
+    if ( -1 == madvise(_ce_ptr(0), _ce_len(pgs_w), MADV_RANDOM) ) {
+        fprintf(stderr, "loom: madv_random failed (%u pages): %s\r\n",
+                        pgs_w, strerror(errno));
+    }
   }
 
   if ( old_w > pgs_w ) {


### PR DESCRIPTION
Since #402 was released, there have been isolated reports of unusually high disk i/o, specifically reads. This is unexpected behavior -- our current, best guess is the kernel's readahead logic for file-backed mappings. This PR implements the standard solution to overeager readahead (MADV_RANDOM), as a draft since the diagnosis is not confirmed, and the advice may need to be behind a flag. 