### PR TITLE
ci: `chown /usr/local` on our `linux-aarch64` runner

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: chown /usr/local
-        if: ${{ matrix.target == 'linux-x86_64' }}
+        if: ${{ matrix.target == 'linux-x86_64' || matrix.target == 'linux-aarch64'}}
         run: |
           # See https://github.com/actions/cache/issues/845. Note we don't run
           # this on linux-aarch64 because we run on a self-hosted GitHub Actions


### PR DESCRIPTION
Resolves #424.
