### PR TITLE
ci: separate `chown` calls to fix buildjet jobs (`linux-aarch64`)

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -59,11 +59,7 @@ jobs:
       - name: chown /usr/local
         if: ${{ matrix.target == 'linux-x86_64' || matrix.target == 'linux-aarch64'}}
         run: |
-          # See https://github.com/actions/cache/issues/845. Note we don't run
-          # this on linux-aarch64 because we run on a self-hosted GitHub Actions
-          # runner for which `/usr/local` has already been `chown`d to the user
-          # running the GitHub Actions runner.
-          sudo chown $(whoami) /usr/local && (chown -R $USER /usr/local/*-musl || true)
+          sudo chown $(whoami) /usr/local
 
       - name: Set up build cache
         uses: actions/cache@v3
@@ -77,6 +73,11 @@ jobs:
             # Cache musl libc toolchains.
             /usr/local/*-musl
       
+      - name: chown /usr/local/*-musl
+        if: ${{ matrix.target == 'linux-x86_64' || matrix.target == 'linux-aarch64'}}
+        run: |
+          chown -R $USER /usr/local/*-musl || true
+
       - name: Install bazel
         if: ${{ matrix.target == 'linux-aarch64' }}
         run: |


### PR DESCRIPTION
Resolves #424.