### PR TITLE
make U3_SNAPSHOT_VALIDATION a bazel build flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,16 +32,18 @@ build --per_file_copt='pkg/.*@-O3'
 build --host_copt='-O3'
 
 # Turn on CPU and memory debug for exec config, which we only use to run the
-# fake ship tests.
+# fake ship tests.  Also turn on extra snapshot validation.
 build --host_copt='-DU3_CPU_DEBUG'
 build --host_copt='-DU3_MEMORY_DEBUG'
 build --host_copt='-DC3DBG'
+build --host_copt='-DU3_SNAPSHOT_VALIDATION'
 
 # Set as per-file copts as a plain --copt gets passed to third party
 # dependencies which forces recompilation (slow) if you are switching between
 # including/excluding a symbol define.
 build:mem_dbg --per_file_copt='pkg/.*@-DU3_MEMORY_DEBUG'
 build:cpu_dbg --per_file_copt='pkg/.*@-DU3_CPU_DEBUG'
+build:snp_dbg --per_file_copt='pkg/.*@-DU3_SNAPSHOT_VALIDATION'
 
 # Enable maximum debug info and disable optimizations for debug config. It's
 # important that these lines come after setting the default debug and

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -103,8 +103,6 @@
 #include "retrieve.h"
 #include "types.h"
 
-#define U3_SNAPSHOT_VALIDATION
-
 /* _ce_len:       byte length of pages
 ** _ce_len_words: word length of pages
 ** _ce_page:      byte length of a single page


### PR DESCRIPTION
Resolves #427.

Disables snapshot validation by default, except for fake ship tests in CI.  To enable, run:
```
bazel build --config=snp_dbg :urbit
```
