### PR TITLE
events.h: fix u3t_trace_open() prototype to remove build warning

### DIFF
--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -103,7 +103,7 @@
     /* u3t_trace_open(): opens the path for writing tracing information.
     */
       void
-      u3t_trace_open();
+      u3t_trace_open(c3_c *dir_c);
 
     /* u3t_trace_close(): closes the trace file. optional.
     */


### PR DESCRIPTION
Before this, the prototype for `u3t_trace_open()` had the wrong type.  Now Vere now builds cleanly without warnings.