### PR TITLE
Ensure build works on macOS even with overlapping dependencies in `/usr/local/include`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,11 @@
+# Exclude all system include directories on macOS. 
+# TODO: Use {compiler_version} variable.
+build:macos --copt=-nostdinc
+build:macos --copt=-isystem/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+build:macos --copt=-isystem/Library/Developer/CommandLineTools/usr/lib/clang/14.0.3/include
+build:macos --copt=-isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+build:macos --copt=-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.3/include
+
 # Enable configurations specific to the host platform.
 common --enable_platform_specific_config
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -148,6 +148,8 @@ versioned_http_file(
 versioned_http_archive(
     name = "curl",
     build_file = "//bazel/third_party/curl:curl.BUILD",
+    patch_args = ["-p1"],
+    patches = ["//bazel/third_party/curl:{version}.patch"],
     sha256 = "78a06f918bd5fde3c4573ef4f9806f56372b32ec1829c9ec474799eeee641c27",
     strip_prefix = "curl-{version}",
     url = "https://curl.se/download/curl-{version}.tar.gz",

--- a/bazel/third_party/curl/7.85.0.patch
+++ b/bazel/third_party/curl/7.85.0.patch
@@ -1,13 +1,16 @@
 diff --git a/lib/easy_lock.h b/lib/easy_lock.h
-index d96e56b8d..313baf32f 100644
+index d96e56b8d..92e963240 100644
 --- a/lib/easy_lock.h
 +++ b/lib/easy_lock.h
-@@ -23,6 +23,8 @@
-  ***************************************************************************/
+@@ -24,6 +24,11 @@
  
  #include "curl_setup.h"
+ 
++#if defined(URBIT_RUNTIME_CPU_AARCH64) && defined(URBIT_RUNTIME_OS_DARWIN)
 +#undef HAVE_ATOMIC
 +#undef HAVE_STDATOMIC_H
- 
++#endif
++
  #define GLOBAL_INIT_IS_THREADSAFE
  
+ #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600

--- a/bazel/third_party/curl/7.85.0.patch
+++ b/bazel/third_party/curl/7.85.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/easy_lock.h b/lib/easy_lock.h
+index d96e56b8d..313baf32f 100644
+--- a/lib/easy_lock.h
++++ b/lib/easy_lock.h
+@@ -23,6 +23,8 @@
+  ***************************************************************************/
+ 
+ #include "curl_setup.h"
++#undef HAVE_ATOMIC
++#undef HAVE_STDATOMIC_H
+ 
+ #define GLOBAL_INIT_IS_THREADSAFE
+ 


### PR DESCRIPTION
Resolves #440. 

TODO:
- [ ] Ensure need for `curl` patch
  - [x] If yes, only patch on macOS
- [ ] Parameterize the `clang_version` used in `.bazelrc`