### PR TITLE
factor release/debug dispatch logic out of .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,16 +20,7 @@ build --@io_bazel_rules_docker//transitions:enable=false
 build --flag_alias=clang_version=//:clang_version
 build --flag_alias=gcc_version=//:gcc_version
 
-# Don't include source level debug info on macOS. See
-# https://github.com/urbit/urbit/issues/5561 and
-# https://github.com/urbit/vere/issues/131.
-build:linux --per_file_copt='pkg/.*@-g'
-build:linux --host_copt='-g'
 build --strip=never
-
-# Use -O3 as the default optimization level.
-build --per_file_copt='pkg/.*@-O3'
-build --host_copt='-O3'
 
 # Turn on CPU and memory debug for exec config, which we only use to run the
 # fake ship tests.  Also turn on extra snapshot validation.
@@ -44,13 +35,6 @@ build --host_copt='-DU3_SNAPSHOT_VALIDATION'
 build:mem_dbg --per_file_copt='pkg/.*@-DU3_MEMORY_DEBUG'
 build:cpu_dbg --per_file_copt='pkg/.*@-DU3_CPU_DEBUG'
 build:snp_dbg --per_file_copt='pkg/.*@-DU3_SNAPSHOT_VALIDATION'
-
-# Enable maximum debug info and disable optimizations for debug config. It's
-# important that these lines come after setting the default debug and
-# optimization level flags above.
-build:dbg --per_file_copt='pkg/.*@-O0'
-build:dbg --per_file_copt='pkg/.*@-g3'
-build:dbg --per_file_copt='pkg/.*@-DC3DBG'
 
 # Any personal configuration should go in .user.bazelrc.
 try-import %workspace%/.user.bazelrc

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -178,5 +178,10 @@ genrule(
 
 alias(
     name = "urbit",
-    actual = "//pkg/vere:urbit",
+    actual = "//pkg/vere:urbit-rel",
+)
+
+alias(
+    name = "urbit-dbg",
+    actual = "//pkg/vere:urbit-dbg",
 )

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -12,7 +12,7 @@ refresh_compile_commands(
         "//pkg/noun",
         "//pkg/ur",
         "//pkg/urcrypt",
-        "//pkg/vere:urbit",
+        "//pkg/vere:urbit-rel",
     ],
     # No need to add flags already in .bazelrc. They're automatically picked up.
     # If you don't need flags, a list of targets is also okay, as is a single target string.

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -47,7 +47,7 @@ container_image(
         ":get-urbit-code",
         ":reset-urbit-code",
         ":start-urbit",
-        "//pkg/vere:urbit",
+        "//pkg/vere:urbit-rel",
     ],
     layers = [":install_pkgs"],
     ports = [

--- a/pkg/vere/BUILD.bazel
+++ b/pkg/vere/BUILD.bazel
@@ -139,7 +139,7 @@ cc_library(
 #
 
 cc_binary(
-    name = "urbit",
+    name = "urbit-rel",
     srcs = [
         "main.c",
         ":ca_bundle",
@@ -164,6 +164,48 @@ cc_binary(
         "@sigsegv",
         "@whereami",
     ],
+    copts = [ "-O3" ]
+    # Don't include source level debug info on macOS. See
+    # https://github.com/urbit/urbit/issues/5561 and
+    # https://github.com/urbit/vere/issues/131.
+    + select({
+        "@platforms//os:macos": [],
+        "@platforms//os:linux": ["-g"],
+    }),
+)
+
+cc_binary(
+    name = "urbit-dbg",
+    srcs = [
+        "main.c",
+        ":ca_bundle",
+        ":ivory",
+        "//:pace_hdr",
+        "//:version_hdr",
+    ],
+    features = select({
+        "@platforms//os:linux": ["fully_static_link"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/c3",
+        "//pkg/noun",
+        "//pkg/ur",
+        ":vere",
+        # TODO: remove dependency (only used to report version).
+        "@h2o",
+        "@openssl",
+        # TODO: remove dependency (only used to report version).
+        "@sigsegv",
+        "@whereami",
+    ],
+    copts = ["-O0", "-g3"]
+    + select({
+        "@platforms//os:macos": [],
+        "@platforms//os:linux": [],
+    }),
+    defines = ["C3DBG"]
 )
 
 #
@@ -264,7 +306,7 @@ genrule(
     tar xfz $(execpath @urbit//file) -C ./urbit --strip-components=1
     cp -RL ./urbit/tests ./urbit/pkg/arvo/tests
 
-    $(execpath :urbit) --lite-boot --daemon --fake bus \
+    $(execpath :urbit-rel) --lite-boot --daemon --fake bus \
       --bootstrap $(execpath @solid_pill//file)        \
       --arvo ./urbit/pkg/arvo                          \
       --pier ./pier
@@ -316,7 +358,7 @@ genrule(
     ls -a ./pier
     zip -q -r $@ ./pier
     """,
-    tools = [":urbit"],
+    tools = [":urbit-rel"],
     visibility = ["//visibility:public"],
 )
 
@@ -334,7 +376,7 @@ genrule(
 
     set -x
 
-    $(execpath :urbit) --lite-boot --daemon --gc ./pier 2> urbit-output
+    $(execpath :urbit-rel) --lite-boot --daemon --gc ./pier 2> urbit-output
 
     port=$$(grep loopback ./pier/.http.ports | awk -F ' ' '{print $$1}')
 
@@ -494,6 +536,6 @@ genrule(
 
     exit "$$fail"
     """,
-    tools = [":urbit"],
+    tools = [":urbit-rel"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
move release/dbg dispatch logic out of .bazelrc and into separate cc_binary targets

Resolves #472 

Draft for now. Still need to:
[] update docs

[] confirm no changes to macos/linux release+debug builds

[] Fake ship tests are running about 3x slower due to removal of `build
--host_copt='-O3'` from .bazelrc. Unclear why as all third party dependencies
specify an optimization level in their cc_library targets and vere now specifies
it for both vere-rel and vere-dbg. -- Oh duh, probably specifying a copt in
bazel with `--copt`/`--host_copt` takes precedence over a `copts` "rule". Should
we just be building every dependency at -O3 then??? -- Answer: the other
cc_library targets in vere should also specify copts of -O3 for rel and -O0 for
dbg... which complicates things. By providing these in .bazelrc, it's easy to
send them to all targets in pkg/...

... may also try getting this stuff out of the .bazelrc file:

```
build:mem_dbg --per_file_copt='pkg/.*@-DU3_MEMORY_DEBUG'
build:cpu_dbg --per_file_copt='pkg/.*@-DU3_CPU_DEBUG'
build:snp_dbg --per_file_copt='pkg/.*@-DU3_SNAPSHOT_VALIDATION'
```

This sort of thing in other builds systems is just done by defining an env var
like:

```
MEM= CPU= bazel build :urbit
```

But I don't think this is possible in bazel. What we have now _may_ be the
simplest solution