### PR TITLE
u3: move the guard page earlier when making roads

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1715,7 +1715,7 @@ u3e_ward(u3_post low_p, u3_post hig_p)
   c3_w sop_w = hig_p >> u3a_page;
   c3_w pag_w = u3P.gar_w;
 
-  if ( !((pag_w > nop_w) && (pag_w < hig_p)) ) {
+  if ( !((pag_w > nop_w) && (pag_w < sop_w)) ) {
     u3_assert( !_ce_ward_post(nop_w, sop_w) );
     u3_assert( !_ce_flaw_mprotect(pag_w) );
     u3_assert( u3P.dit_w[pag_w >> 5] & (1 << (pag_w & 31)) );

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -518,7 +518,7 @@ _pave_road(c3_w* rut_w, c3_w* mat_w, c3_w* cap_w, c3_w siz_w)
    len_w - size of your loom in words
 */
 static u3_road*
-_pave_north(c3_w* mem_w, c3_w siz_w, c3_w len_w)
+_pave_north(c3_w* mem_w, c3_w siz_w, c3_w len_w, c3_o kid_o)
 {
   //  in a north road, the heap is low and the stack is high
   //
@@ -532,6 +532,10 @@ _pave_north(c3_w* mem_w, c3_w siz_w, c3_w len_w)
   c3_w* mat_w = c3_align(mem_w + len_w - siz_w, u3C.balign_d, C3_ALGLO);
   c3_w* rut_w = c3_align(mem_w, u3C.balign_d, C3_ALGHI);
   c3_w* cap_w = mat_w;
+
+  if ( c3y == kid_o ) {
+    u3e_ward(u3of(c3_w, rut_w) - 1, u3of(c3_w, cap_w));
+  }
 
   return _pave_road(rut_w, mat_w, cap_w, siz_w);
 }
@@ -555,9 +559,12 @@ _pave_south(c3_w* mem_w, c3_w siz_w, c3_w len_w)
   //
   //    00~~~|M|+++|C|######|H|---|R|~~~FFF
   //         ^---u3R which _pave_road returns
+  //
   c3_w* mat_w = c3_align(mem_w, u3C.balign_d, C3_ALGHI);
   c3_w* rut_w = c3_align(mem_w + len_w, u3C.balign_d, C3_ALGLO);
   c3_w* cap_w = mat_w + siz_w;
+
+  u3e_ward(u3of(c3_w, cap_w) - 1, u3of(c3_w, rut_w));
 
   return _pave_road(rut_w, mat_w, cap_w, siz_w);
 }
@@ -574,7 +581,7 @@ _pave_home(void)
   c3_w  siz_w = c3_wiseof(u3v_home);
   c3_w  len_w = u3C.wor_i - u3C.walign_w;
 
-  u3H = (void *)_pave_north(mem_w, siz_w, len_w);
+  u3H = (void *)_pave_north(mem_w, siz_w, len_w, c3n);
   u3H->ver_w = U3V_VERLAT;
   u3R = &u3H->rod_u;
 
@@ -879,7 +886,7 @@ u3m_leap(c3_w pad_w)
     else {
       bot_p = u3R->cap_p;
 
-      rod_u = _pave_north(u3a_into(bot_p), c3_wiseof(u3a_road), len_w);
+      rod_u = _pave_north(u3a_into(bot_p), c3_wiseof(u3a_road), len_w, c3y);
 #if 0
       fprintf(stderr, "SPAR.hat_p: 0x%x %p, NKID.hat_p: 0x%x %p\r\n",
               u3R->hat_p, u3a_into(u3R->hat_p),
@@ -901,7 +908,6 @@ u3m_leap(c3_w pad_w)
   */
   {
     u3R = rod_u;
-    u3m_ward();
     _pave_parts();
   }
 #ifdef U3_MEMORY_DEBUG

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -845,6 +845,7 @@ u3m_leap(c3_w pad_w)
 {
   c3_w     len_w; /* the length of the new road (avail - (pad + wiseof(u3a_road))) */
   u3_road* rod_u;
+  const c3_w gar_w = u3P.gar_w;
 
   _rod_vaal(u3R);
 
@@ -894,6 +895,12 @@ u3m_leap(c3_w pad_w)
 
 #endif
     }
+  }
+
+  if (  ((u3a_outa(rod_u) >> u3a_page) == gar_w)
+     || ((u3a_outa(rod_u) + c3_wiseof(u3a_road) - 1) >> u3a_page) == gar_w )
+  {
+    fprintf(stderr, "loom: ward would've been bogus\r\n");
   }
 
   /* Attach the new road to its parents.

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -845,7 +845,6 @@ u3m_leap(c3_w pad_w)
 {
   c3_w     len_w; /* the length of the new road (avail - (pad + wiseof(u3a_road))) */
   u3_road* rod_u;
-  const c3_w gar_w = u3P.gar_w;
 
   _rod_vaal(u3R);
 
@@ -895,12 +894,6 @@ u3m_leap(c3_w pad_w)
 
 #endif
     }
-  }
-
-  if (  ((u3a_outa(rod_u) >> u3a_page) == gar_w)
-     || ((u3a_outa(rod_u) + c3_wiseof(u3a_road) - 1) >> u3a_page) == gar_w )
-  {
-    fprintf(stderr, "loom: ward would've been bogus\r\n");
   }
 
   /* Attach the new road to its parents.


### PR DESCRIPTION
... preventing spurious `loom: ward bogus` assertion failures. The guard page was being moved if necessary after initializing an inner road (accounting for road padding), but it could still be hit while initializing the road struct itself, in which case it would trigger an guard-page sanity assertion.