### PR TITLE
leer: fix jet mismatch

### DIFF
--- a/pkg/noun/jets/e/leer.c
+++ b/pkg/noun/jets/e/leer.c
@@ -94,7 +94,7 @@ u3qe_leer(u3_atom txt)
     u3_noun* hed;
     u3_noun* tel;
 
-    while ( i_w < len_w ) {
+    while ( i_w <= len_w ) {
       //  scan till end or newline
       //
       for ( pos_w = i_w; i_w < len_w; ++i_w ) {


### PR DESCRIPTION
With old jet:
```
> `(list @tas)`(to-wain:format 'hello\0a\0a')
~[%hello %$]

>`(list @tas)`(to-wain:format 'hello\0a')
~[%hello]
```

Without old jet:
```
> `(list @tas)`(to-wain:format 'hello\0a\0a')
~[%hello %$ %$]

>`(list @tas)`(to-wain:format 'hello\0a')
~[%hello %$]
```

The unjetted behavior certainly seems more reasonable to me so this PR fixes the jet to match the hoon. Here's a generator to test stuff out with:
``` hoon
=>
|%
  ++  to-wain                                           ::  cord to line list
    ::  ~%  %leer  ..part  ~
    |=  txt=cord
    ^-  wain
    =/  len=@  (met 3 txt)
    =/  cut  =+(cut -(a 3, c 1, d txt))
    =/  sub  sub
    =|  [i=@ out=wain]
    |-  ^+  out
    =+  |-  ^-  j=@
        ?:  ?|  =(i len)
                =(10 (cut(b i)))
            ==
          i
        $(i +(i))
    =.  out  :_  out
      (cut(b i, c (sub j i)))
    ~&  `(list @tas)`out
    ?:  =(j len)
      (flop out)
    $(i +(j))
--
:-  %say
|=  [^ [arg=@t ~] ~]
:-  %noun
(to-wain arg)

```