### PR TITLE
ci: fix error check in version upload

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -241,6 +241,7 @@ jobs:
           # We don't use -n here because we want to overwrite the version
           # string.
           gsutil cp ./bazel-bin/version "$target"
+          exitcode=$?
 
           [ $exitcode -eq 0 ] &&
             echo "Upload to $target completed successfully." ||


### PR DESCRIPTION
It looks like this has been broken since the repository split. The version upload works, but the error check does not.