### PR TITLE
build: upgrade `zlib` to v1.3

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -358,10 +358,10 @@ versioned_http_archive(
 versioned_http_archive(
     name = "zlib",
     build_file = "//bazel/third_party/zlib:zlib.BUILD",
-    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+    sha256 = "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e",
     strip_prefix = "zlib-{version}",
     url = "https://www.zlib.net/zlib-{version}.tar.gz",
-    version = "1.2.13",
+    version = "1.3",
 )
 
 #


### PR DESCRIPTION
`zlib` 1.3 was [released on August 18, 2023](http://zlib.net/). Fixes recent CI failures as well.