### PR TITLE
Jet for jub:by

### DIFF
--- a/pkg/noun/jets/d/by_jib.c
+++ b/pkg/noun/jets/d/by_jib.c
@@ -1,0 +1,129 @@
+/* j/4/by_jib.c
+**
+*/
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+u3_noun
+u3qdb_jib(u3_noun a,
+          u3_noun key,
+          u3_noun fun)
+{
+  if ( u3_nul == a ) {
+    u3_noun value = u3n_kick_on(u3k(fun));
+
+    if ( u3_nul != val ) {
+      u3_noun b = u3nt(u3nc(u3k(key), u3k(u3t(val))), u3_nul, u3_nul);
+
+      u3z(val);
+      return b;
+    }
+    else {
+      return u3_nul;
+    }
+  }
+
+  else {
+    u3_noun n_a, lr_a;
+    u3_noun pn_a, qn_a;
+    u3x_cell(a, &n_a, &lr_a);
+    u3x_cell(n_a, &pn_a, &qn_a);
+
+    if ( c3y == u3r_sing(pn_a, key) ) {
+      u3_noun value = u3n_slam_on(u3k(fun), u3k(qn_a));
+
+      if ( u3_nul != val ) {
+        u3_noun u_val = u3t(val);
+
+        if ( c3y == u3r_sing(qn_a, u_val) ) {
+
+          u3z(val);
+          return u3k(a);
+        }
+        else {
+          u3_noun b = u3nc(u3nc(u3k(pn_a), u3k(u_val)), u3k(lr_a));
+
+          u3z(val);
+          return b;
+        }
+      }
+      else {
+        u3_noun b = u3qdb_del(a, key);
+
+        return b;
+      }
+    }
+    else {
+      u3_noun l_a, r_a;
+      u3x_cell(lr_a, &l_a, &r_a);
+      u3_noun d;
+
+      if ( c3y == u3qc_gor(key, pn_a) ) {
+        d = u3qdb_jib(l_a, key, fun);
+
+        if ( u3_nul == d ) {
+          return u3qdb_put(u3k(r_a), u3k(pn_a), u3k(qn_a));
+        }
+
+        if ( c3y == u3qc_mor(pn_a, u3h(u3h(d))) ) {
+          return u3nt(u3k(n_a),
+                      d,
+                      u3k(r_a));
+        }
+        else {
+          u3_noun n_d, l_d, r_d;
+
+          u3r_trel(d, &n_d, &l_d, &r_d);
+
+          u3_noun e = u3nt(u3k(n_d),
+                           u3k(l_d),
+                           u3nt(u3k(n_a),
+                                u3k(r_d),
+                                u3k(r_a)));
+
+          u3z(d);
+          return e;
+        }
+      }
+      else {
+        d = u3qdb_jib(r_a, key, fun);
+
+        if ( u3_nul == d ) {
+          return u3qdb_put(u3k(l_a), u3k(pn_a), u3k(qn_a));
+        }
+
+        if ( c3y == u3qc_mor(pn_a, u3h(u3h(d))) ) {
+          return u3nt(u3k(n_a),
+                      u3k(l_a),
+                      d);
+        }
+        else {
+          u3_noun n_d, l_d, r_d;
+          u3r_trel(d, &n_d, &l_d, &r_d);
+
+          u3_noun e = u3nt(u3k(n_d),
+                           u3nt(u3k(n_a),
+                                u3k(l_a),
+                                u3k(l_d)),
+                            u3k(r_d));
+
+          u3z(d);
+          return e;
+        }
+      }
+    }
+  }
+}
+
+u3_noun
+u3wdb_jib(u3_noun cor)
+{
+  u3_noun a, key, fun;
+  u3x_mean(cor, u3x_sam_2,   &key,
+                u3x_sam_3,   &fun,
+                u3x_con_sam, &a, 0);
+
+  return u3qdb_jib(a, key, fun);
+}

--- a/pkg/noun/jets/d/by_jub.c
+++ b/pkg/noun/jets/d/by_jub.c
@@ -1,0 +1,129 @@
+/* j/4/by_jub.c
+**
+*/
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+u3_noun
+u3qdb_jub(u3_noun a,
+          u3_noun key,
+          u3_noun fun)
+{
+  if ( u3_nul == a ) {
+    u3_noun val = u3n_slam_on(u3k(fun), u3_nul);
+
+    if ( u3_nul != val ) {
+      u3_noun b = u3nt(u3nc(u3k(key), u3k(u3t(val))), u3_nul, u3_nul);
+
+      u3z(val);
+      return b;
+    }
+    else {
+      return u3_nul;
+    }
+  }
+
+  else {
+    u3_noun n_a, lr_a;
+    u3_noun pn_a, qn_a;
+    u3x_cell(a, &n_a, &lr_a);
+    u3x_cell(n_a, &pn_a, &qn_a);
+
+    if ( c3y == u3r_sing(pn_a, key) ) {
+      u3_noun val = u3n_slam_on(u3k(fun), u3nc(u3_nul, u3k(qn_a)));
+
+      if ( u3_nul != val ) {
+        u3_noun u_val = u3t(val);
+
+        if ( c3y == u3r_sing(qn_a, u_val) ) {
+
+          u3z(val);
+          return u3k(a);
+        }
+        else {
+          u3_noun b = u3nc(u3nc(u3k(pn_a), u3k(u_val)), u3k(lr_a));
+
+          u3z(val);
+          return b;
+        }
+      }
+      else {
+        u3_noun b = u3qdb_del(a, key);
+
+        return b;
+      }
+    }
+    else {
+      u3_noun l_a, r_a;
+      u3x_cell(lr_a, &l_a, &r_a);
+      u3_noun d;
+
+      if ( c3y == u3qc_gor(key, pn_a) ) {
+        d = u3qdb_jub(l_a, key, fun);
+
+        if ( u3_nul == d ) {
+          return u3qdb_put(u3k(r_a), u3k(pn_a), u3k(qn_a));
+        }
+
+        if ( c3y == u3qc_mor(pn_a, u3h(u3h(d))) ) {
+          return u3nt(u3k(n_a),
+                      d,
+                      u3k(r_a));
+        }
+        else {
+          u3_noun n_d, l_d, r_d;
+
+          u3r_trel(d, &n_d, &l_d, &r_d);
+
+          u3_noun e = u3nt(u3k(n_d),
+                           u3k(l_d),
+                           u3nt(u3k(n_a),
+                                u3k(r_d),
+                                u3k(r_a)));
+
+          u3z(d);
+          return e;
+        }
+      }
+      else {
+        d = u3qdb_jub(r_a, key, fun);
+
+        if ( u3_nul == d ) {
+          return u3qdb_put(u3k(l_a), u3k(pn_a), u3k(qn_a));
+        }
+
+        if ( c3y == u3qc_mor(pn_a, u3h(u3h(d))) ) {
+          return u3nt(u3k(n_a),
+                      u3k(l_a),
+                      d);
+        }
+        else {
+          u3_noun n_d, l_d, r_d;
+          u3r_trel(d, &n_d, &l_d, &r_d);
+
+          u3_noun e = u3nt(u3k(n_d),
+                           u3nt(u3k(n_a),
+                                u3k(l_a),
+                                u3k(l_d)),
+                            u3k(r_d));
+
+          u3z(d);
+          return e;
+        }
+      }
+    }
+  }
+}
+
+u3_noun
+u3wdb_jub(u3_noun cor)
+{
+  u3_noun a, key, fun;
+  u3x_mean(cor, u3x_sam_2,   &key,
+                u3x_sam_3,   &fun,
+                u3x_con_sam, &a, 0);
+
+  return u3qdb_jub(a, key, fun);
+}

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -89,6 +89,7 @@
     u3_noun u3qdb_dif(u3_noun, u3_noun);
     u3_noun u3qdb_gas(u3_noun, u3_noun);
     u3_noun u3qdb_get(u3_noun, u3_noun);
+    u3_noun u3qdb_del(u3_noun, u3_noun);
     u3_noun u3qdb_has(u3_noun, u3_noun);
     u3_noun u3qdb_int(u3_noun, u3_noun);
     u3_noun u3qdb_key(u3_noun);

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -1905,6 +1905,7 @@ static c3_c* _140_two__in_ha[] = {
     "fac9248ebd1defade9df695cd81f94355bebb271f85b164ff34658a5f45c71a0",
     0
   };
+
 static u3j_core _140_two__by_d[] =
   { { "all", 7, _140_two__by_all_a, 0, _140_two__by_all_ha },
     { "any", 7, _140_two__by_any_a, 0, _140_two__by_any_ha },
@@ -2272,6 +2273,31 @@ static u3j_core _139_two__in_d[] =
     {}
   };
 
+static u3j_harm _139_two__by_jub_a[] = {{".2", u3wdb_jub, c3y}, {}};
+static u3j_core _139_two__by_d[] =
+  { { "all", 7, _140_two__by_all_a, 0, no_hashes },
+    { "any", 7, _140_two__by_any_a, 0, no_hashes },
+    { "apt", 7, _140_two__by_apt_a, 0, no_hashes },
+    { "bif", 7, _140_two__by_bif_a, 0, no_hashes },
+    { "del", 7, _140_two__by_del_a, 0, no_hashes },
+    { "dif", 7, _140_two__by_dif_a, 0, no_hashes },
+    { "gas", 7, _140_two__by_gas_a, 0, no_hashes },
+    { "get", 7, _140_two__by_get_a, 0, no_hashes },
+    { "has", 7, _140_two__by_has_a, 0, no_hashes },
+    { "int", 7, _140_two__by_int_a, 0, no_hashes },
+    { "jab", 7, _140_two__by_jab_a, 0, no_hashes },
+    { "key", 7, _140_two__by_key_a, 0, no_hashes },
+    { "put", 7, _140_two__by_put_a, 0, no_hashes },
+    { "rep", 7, _140_two__by_rep_a, 0, no_hashes },
+    { "run", 7, _140_two__by_run_a, 0, no_hashes },
+    { "tap", 7, _140_two__by_tap_a, 0, no_hashes },
+    { "uni", 7, _140_two__by_uni_a, 0, no_hashes },
+    { "urn", 7, _140_two__by_urn_a, 0, no_hashes },
+    { "wyt", 3, _140_two__by_wyt_a, 0, no_hashes },
+    { "jub", 7, _139_two__by_jub_a, 0, no_hashes },
+    {}
+  };
+
 static u3j_core _139_two_d[] =
 { { "tri", 3, 0, _139_tri_d, no_hashes, _140_tri_ho },
 
@@ -2326,7 +2352,7 @@ static u3j_core _139_two_d[] =
   { "sqt",  7, _140_two_sqt_a, 0, no_hashes },
   { "xeb",  7, _140_two_xeb_a, 0, no_hashes },
 
-  { "by", 7, 0, _140_two__by_d, no_hashes },
+  { "by", 7, 0, _139_two__by_d, no_hashes },
   { "in", 7, 0, _139_two__in_d, no_hashes },
   {}
 };

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -96,6 +96,7 @@
     u3_noun u3wdb_has(u3_noun);
     u3_noun u3wdb_int(u3_noun);
     u3_noun u3wdb_jab(u3_noun);
+    u3_noun u3wdb_jub(u3_noun);
     u3_noun u3wdb_key(u3_noun);
     u3_noun u3wdb_put(u3_noun);
 #   define u3wdb_tap u3wdi_tap

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -813,7 +813,7 @@ _pier_wyrd_card(u3_pier* pir_u)
   u3_noun kel = u3nl(u3nc(c3__zuse, VERE_ZUSE),  //  XX from both king and serf?
                      u3nc(c3__lull, VERE_LULL),  //  XX from both king and serf?
                      u3nc(c3__arvo, 238),        //  XX from both king and serf?
-                     u3nc(c3__hoon, 139),        //  god_u->hon_y
+                     u3nc(c3__hoon, 138),        //  god_u->hon_y
                      u3nc(c3__nock, 4),          //  god_u->noc_y
                      u3_none);
   u3_noun wir = u3nc(c3__arvo, u3_nul);

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -976,7 +976,7 @@ u3_serf_init(u3_serf* sef_u)
 
   {
     c3_w  pro_w = 1;
-    c3_y  hon_y = 139;
+    c3_y  hon_y = 138;
     c3_y  noc_y = 4;
     u3_noun ver = u3nt(pro_w, hon_y, noc_y);
 


### PR DESCRIPTION
jub:by is a variant of jab:by, which applies a gate to a value at a certain key. It crashes if it's not there, and also does not allow it to be deleted. This variant allows a create, update, or delete operation with one gate call and one tree traversal. The gate passed to jub takes a unit and returns a unit. The unit it is passed is ~ if the kv pair does not exist, and `val if it does. The unit returned causes a deletion if it is ~, and inserts otherwise.

https://github.com/urbit/urbit/pull/6782 is the corresponding PR with the hoon.

I added a jet for jib, referenced in the PR by amsden these pair of PR's would replace. I haven't written the hoon for it yet. Maybe we don't want to add it, as jub is exhaustive and would only be an ergonomic addition.