### PR TITLE
jet `+mate` arm

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -358,10 +358,10 @@ versioned_http_archive(
 versioned_http_archive(
     name = "zlib",
     build_file = "//bazel/third_party/zlib:zlib.BUILD",
-    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+    sha256 = "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e",
     strip_prefix = "zlib-{version}",
     url = "https://www.zlib.net/zlib-{version}.tar.gz",
-    version = "1.2.13",
+    version = "1.3",
 )
 
 #

--- a/pkg/noun/jets/b/mate.c
+++ b/pkg/noun/jets/b/mate.c
@@ -14,10 +14,10 @@
       return u3k(a);
     } else if ( u3_nul == a ) {
       return u3k(b);
-    } else if ( c3y == u3r_sing(a, b) ) {
+    } else if ( c3y == u3r_sing(u3t(a), u3t(b)) ) {
       return u3k(a);
     } else {
-      return u3m_bail(c3__fail);
+      return u3m_error("mate");
     }
   }
   u3_noun

--- a/pkg/noun/jets/b/mate.c
+++ b/pkg/noun/jets/b/mate.c
@@ -1,0 +1,30 @@
+/// @file
+
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+
+  u3_noun
+  u3qb_mate(u3_noun a,
+            u3_noun b)
+  {
+    if ( u3_nul == b ) {
+      return u3k(a);
+    } else if ( u3_nul == a ) {
+      return u3k(b);
+    } else if ( c3y == u3r_sing(a, b) ) {
+      return u3k(a);
+    } else {
+      return u3m_bail(c3__fail);
+    }
+  }
+  u3_noun
+  u3wb_mate(u3_noun cor)
+  {
+    u3_noun a, b;
+    u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0);
+    return u3qb_mate(a, b);
+  }
+

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -32,6 +32,7 @@
     u3_noun u3qb_lien(u3_noun, u3_noun);
     u3_noun u3qb_murn(u3_noun, u3_noun);
     u3_noun u3qb_need(u3_noun);
+    u3_noun u3qb_mate(u3_noun, u3_noun);
     u3_noun u3qb_reap(u3_atom, u3_noun);
     u3_noun u3qb_reel(u3_noun, u3_noun);
     u3_noun u3qb_roll(u3_noun, u3_noun);
@@ -254,3 +255,4 @@
     void u3qf_test(const c3_c*, u3_noun);
 
 #endif /* ifndef U3_JETS_Q_H */
+

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2139,6 +2139,7 @@ static c3_c* _k140_ha[] = {
 
 /* new jets
 */
+  static u3j_harm _139_two_mate_a[] = {{".2", u3wb_mate, c3y}, {}};
   static u3j_harm _139_hex_json_de_a[] = {{".2", u3we_json_de}, {}};
   static u3j_harm _139_hex_json_en_a[] = {{".2", u3we_json_en}, {}};
 static u3j_core _139_hex_json_d[] =
@@ -2282,6 +2283,7 @@ static u3j_core _139_two_d[] =
   { "lien", 7, _140_two_lien_a, 0, no_hashes },
   { "murn", 7, _140_two_murn_a, 0, no_hashes },
   { "need", 7, _140_two_need_a, 0, no_hashes },
+  { "mate", 7, _139_two_mate_a, 0, no_hashes },
   { "reap", 7, _140_two_reap_a, 0, no_hashes },
   { "reel", 7, _140_two_reel_a, 0, no_hashes },
   { "roll", 7, _140_two_roll_a, 0, no_hashes },
@@ -2438,3 +2440,4 @@ u3j_Dash = {
   0,
   0
 };
+

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2139,7 +2139,6 @@ static c3_c* _k140_ha[] = {
 
 /* new jets
 */
-  static u3j_harm _139_two_mate_a[] = {{".2", u3wb_mate, c3y}, {}};
   static u3j_harm _139_hex_json_de_a[] = {{".2", u3we_json_de}, {}};
   static u3j_harm _139_hex_json_en_a[] = {{".2", u3we_json_en}, {}};
 static u3j_core _139_hex_json_d[] =
@@ -2272,6 +2271,8 @@ static u3j_core _139_two__in_d[] =
     { "wyt", 3, _140_two__in_wyt_a, 0, no_hashes },
     {}
   };
+
+static u3j_harm _139_two_mate_a[] = {{".2", u3wb_mate, c3y}, {}};
 
 static u3j_core _139_two_d[] =
 { { "tri", 3, 0, _139_tri_d, no_hashes, _140_tri_ho },

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -32,6 +32,7 @@
     u3_noun u3wb_lien(u3_noun);
     u3_noun u3wb_murn(u3_noun);
     u3_noun u3wb_need(u3_noun);
+    u3_noun u3wb_mate(u3_noun);
     u3_noun u3wb_reap(u3_noun);
     u3_noun u3wb_reel(u3_noun);
     u3_noun u3wb_roll(u3_noun);
@@ -332,3 +333,4 @@
     u3_noun u3wfu_rest(u3_noun);
 
 #endif /* ifndef U3_JETS_W_H */
+


### PR DESCRIPTION
These changes introduce a jet for the [`+mate` arm](https://developers.urbit.org/reference/hoon/stdlib/2a#mate), and were tested with the following commands:

```
> (mate ~ ~)
~
> (mate ~ `1)
[~ u=1]
> (mate `2 ~)
[~ u=2]
> (mate `3 `3)
[~ u=3]
> (mate `4 `5)
(error)
took ms/2.118
> ~>  %bout  (roll (gulf 1 1.000) |=([n=@ a=(unit @)] (mate (mate `n ~) (mate ~ `n))))
[~ 1.000]
> =hoon-mate |*([a=(unit) b=(unit)] ?~(b a ?~(a b ?.(=(u.a u.b) ~>(%mean.'mate' !!) a))))
took ms/4.603
> ~>  %bout  (roll (gulf 1 1.000) |=([n=@ a=(unit @)] (hoon-mate (hoon-mate `n ~) (hoon-mate ~ `n))))
[~ 1.000]
```

The `+mate` error text (`bail: fail` followed by stack trace) looks different from the `+need` error text (`dojo: hoon expression failed`) despite using the same jet error routine (i.e. `u3m_bail(c3__fail)`). Feedback on this would be appreciated!