### PR TITLE
Fixed next/kelvin workflow to not upload to docker

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -20,7 +20,3 @@ jobs:
       upload: true
       next: ${{ github.ref_name }}
     secrets: inherit
-
-  docker:
-    uses: ./.github/workflows/docker-shared.yml
-    secrets: inherit


### PR DESCRIPTION
The next/kelvin workflow uploads to docker edge. This shouldn't happen as it messes up edge testing if the next/kelvin branch isn't in sync with develop