### PR TITLE
Jb/epoc cleanup

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1671,6 +1671,9 @@ u3e_stop(void)
     close(u3P.eph_i);
     unlink(u3C.eph_c);
   }
+
+  close(u3P.sou_u.fid_i);
+  close(u3P.sou_u.fid_i);
 }
 
 /* u3e_yolo(): disable dirty page tracking, read/write whole loom.
@@ -1709,6 +1712,8 @@ void
 u3e_init(void)
 {
   u3P.pag_w = u3C.wor_i >> u3a_page;
+
+  u3P.nor_u.fid_i = u3P.sou_u.fid_i = -1;
 
   u3e_foul();
 

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -299,7 +299,7 @@ u3t_flee(void)
 /*  u3t_trace_open(): opens a trace file and writes the preamble.
 */
 void
-u3t_trace_open(c3_c* dir_c)
+u3t_trace_open(const c3_c* dir_c)
 {
   c3_c fil_c[2048];
 

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -103,7 +103,7 @@
     /* u3t_trace_open(): opens the path for writing tracing information.
     */
       void
-      u3t_trace_open(c3_c *dir_c);
+      u3t_trace_open(const c3_c *dir_c);
 
     /* u3t_trace_close(): closes the trace file. optional.
     */

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1150,10 +1150,12 @@ u3_disk_epoc_kill(u3_disk* log_u, c3_d epo_d)
 c3_o
 u3_disk_epoc_last(u3_disk* log_u, c3_d* lat_d)
 {
-  c3_o ret_o = c3n;  //  return c3n if no epoch directories exist
-  *lat_d = 0;        //  initialize lat_d to 0
   u3_dire* die_u = u3_foil_folder(log_u->com_u->pax_c);
   u3_dent* den_u = die_u->dil_u;
+  c3_o     ret_o = c3n;
+
+  *lat_d = 0;
+
   while ( den_u ) {
     c3_d epo_d = 0;
     if ( 1 == sscanf(den_u->nam_c, "0i%" PRIc3_d, &epo_d) ) {
@@ -1283,24 +1285,29 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
   snprintf(bhk_c, sizeof(bhk_c), "%s/.urb/bhk", u3_Host.dir_c);
   snprintf(nop_c, sizeof(nop_c), "%s/north.bin", bhk_c);
   snprintf(sop_c, sizeof(sop_c), "%s/south.bin", bhk_c);
-  if ( c3n == c3_unlink(nop_c) ) {
-    fprintf(stderr, "disk: failed to delete bhk/north.bin\r\n");
+  if ( c3_unlink(nop_c) ) {
+    fprintf(stderr, "disk: failed to delete bhk/north.bin: %s\r\n",
+                    strerror(errno));
   }
-  else if ( c3n == c3_unlink(sop_c) ) {
-    fprintf(stderr, "disk: failed to delete bhk/south.bin\r\n");
+  else if ( c3_unlink(sop_c) ) {
+    fprintf(stderr, "disk: failed to delete bhk/south.bin: %s\r\n",
+                    strerror(errno));
   }
   else {
-    if ( c3n == c3_rmdir(bhk_c) ) {
-      fprintf(stderr, "disk: failed to delete bhk/\r\n");
+    if ( c3_rmdir(bhk_c) ) {
+      fprintf(stderr, "disk: failed to delete bhk/: %s\r\n",
+                      strerror(errno));
     }
   }
 
   //  delete old lock.mdb and data.mdb files
-  if ( 0 != c3_unlink(luk_c) ) {
-    fprintf(stderr, "disk: failed to unlink lock.mdb\r\n");
+  if ( c3_unlink(luk_c) ) {
+    fprintf(stderr, "disk: failed to unlink lock.mdb: %s\r\n",
+                    strerror(errno));
   }
-  if ( 0 != c3_unlink(dut_c) ) {
-    fprintf(stderr, "disk: failed to unlink data.mdb\r\n");
+  if ( c3_unlink(dut_c) ) {
+    fprintf(stderr, "disk: failed to unlink data.mdb: %s\r\n",
+                    strerror(errno));
     return c3n;  //  migration succeeds only if we can unlink data.mdb
   }
 

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1043,7 +1043,18 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u, c3_o mig_o)
       return 0;
     }
 
-    if ( c3y == u3_disk_need_migrate(log_u) ) {
+
+
+    //  if fresh boot, initialize disk v1
+    //
+    if ( c3y == u3_Host.ops_u.nuu ) {
+      //  initialize first epoch "0i0"
+      if ( c3n == u3_disk_epoc_init(log_u, 0) ) {
+        fprintf(stderr, "disk: failed to initialize first epoch\r\n");
+        return 0;
+      }
+    }
+    else if ( c3y == u3_disk_need_migrate(log_u) ) {
       if ( (c3y == mig_o) && (c3n == u3_disk_migrate(log_u)) ) {
         fprintf(stderr, "disk: failed to migrate log\r\n");
         c3_free(log_u);
@@ -1341,8 +1352,6 @@ u3_disk_migrate(u3_disk* log_u)
    *  5. delete old data.mdb and lock.mdb files (c3_unlink() calls)
    */
 
-  fprintf(stderr, "disk: migrating disk to v%d format\r\n", U3D_VER1);
-
   //  check if lock.mdb is readable in log directory
   c3_o luk_o = c3n;
   c3_c luk_c[8193];
@@ -1351,16 +1360,7 @@ u3_disk_migrate(u3_disk* log_u)
     luk_o = c3y;
   }
 
-  //  if fresh boot, initialize disk v1
-  if ( c3y == u3_Host.ops_u.nuu ) {
-    //  initialize first epoch "0i0"
-    if ( c3n == u3_disk_epoc_init(log_u, 0) ) {
-      fprintf(stderr, "disk: failed to initialize first epoch\r\n");
-      return c3n;
-    }
-
-    return c3y;
-  }
+  fprintf(stderr, "disk: migrating disk to v%d format\r\n", U3D_VER1);
 
   //  migrate existing pier which has either:
   //  - not started the migration, or

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1194,7 +1194,7 @@ static u3_disk*
 _cw_disk_init(c3_c* dir_c)
 {
   u3_disk_cb cb_u = {0};
-  u3_disk*  log_u = u3_disk_init(dir_c, cb_u, c3y);
+  u3_disk*  log_u = u3_disk_init(dir_c, cb_u);
 
   if ( !log_u ) {
     fprintf(stderr, "unable to open event log\n");
@@ -2157,11 +2157,7 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
 
   //  XX handle SIGTSTP so that the lockfile is not orphaned?
   //
-  u3_disk* log_u;
-  if ( 0 == (log_u = u3_disk_init(u3_Host.dir_c, (u3_disk_cb){0}, c3n)) ) {
-    fprintf(stderr, "mars: failed to load event log\r\n");
-    exit(1);
-  }
+  u3_disk* log_u = _cw_disk_init(u3_Host.dir_c);
 
   //  Handle SIGTSTP as if it was SIGINT.
   //

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2457,6 +2457,8 @@ _cw_chop(c3_i argc, c3_c* argv[])
   u3_Host.eve_d = u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
   u3_disk* log_u = _cw_disk_init(u3_Host.dir_c);
 
+  u3_disk_kindly(log_u, u3_Host.eve_d);
+
   //  get latest epoch number prior to creating a new one
   c3_d pre_d;
   if ( c3n == u3_disk_epoc_last(log_u, &pre_d) ) {
@@ -2590,6 +2592,8 @@ _cw_roll(c3_i argc, c3_c* argv[])
   // gracefully shutdown the pier if it's running
   u3_Host.eve_d = u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
   u3_disk* log_u = _cw_disk_init(u3_Host.dir_c);
+
+  u3_disk_kindly(log_u, u3_Host.eve_d);
 
   // check if there's a *current* snapshot
   if ( log_u->dun_d != u3A->eve_d ) {

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2199,15 +2199,9 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
     pay_d = u3_mars_play(&mar_u, eve_d, sap_d);
     u3_Host.eve_d = mar_u.dun_d;
 
-    if ( c3y == u3_disk_need_migrate(log_u) ) {
-      u3_disk_migrate(log_u);
-    }
-    else if ( c3y == u3_disk_vere_diff(log_u) ) {
-      if ( c3n == u3_disk_epoc_init(log_u, log_u->dun_d) ) {
-        fprintf(stderr, "disk: failed to initialize epoch\r\n");
-        exit(1);
-      }
-    }
+    //  migrate or rollover as needed
+    //
+    u3_disk_kindly(log_u, u3_Host.eve_d);
   }
 
   u3_disk_exit(log_u);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2150,9 +2150,11 @@ _cw_play_exit(c3_i int_i)
 
 /* _cw_play_impl(): replay events, but better.
 */
-static void
+static c3_d
 _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
 {
+  c3_d pay_d;
+
   //  XX handle SIGTSTP so that the lockfile is not orphaned?
   //
   u3_disk* log_u;
@@ -2195,7 +2197,7 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
       .dun_d = u3A->eve_d,
     };
 
-    u3_mars_play(&mar_u, eve_d, sap_d);
+    pay_d = u3_mars_play(&mar_u, eve_d, sap_d);
 
     //  migrate after replay, if necessary
     u3_Host.eve_d = mar_u.dun_d;
@@ -2206,6 +2208,8 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
 
   u3_disk_exit(log_u);
   u3m_stop();
+
+  return pay_d;
 }
 
 /* _cw_play(): replay events, but better.
@@ -2300,7 +2304,9 @@ _cw_play(c3_i argc, c3_c* argv[])
     exit(1);
   }
 
-  _cw_play_impl(eve_d, sap_d, mel_o, sof_o, ful_o);
+  if ( !_cw_play_impl(eve_d, sap_d, mel_o, sof_o, ful_o) ) {
+    fprintf(stderr, "mars: nothing to do!");
+  }
 }
 
 /* _cw_prep(): prepare for upgrade

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2185,6 +2185,9 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
     _cw_play_snap(log_u);
   }
 
+  //  XX this should check that snapshot is within epoc,
+  //  and load from the epoc / reboot if it is not
+  //
   u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
 
   u3C.slog_f = _cw_play_slog;
@@ -2198,11 +2201,16 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
     };
 
     pay_d = u3_mars_play(&mar_u, eve_d, sap_d);
-
-    //  migrate after replay, if necessary
     u3_Host.eve_d = mar_u.dun_d;
+
     if ( c3y == u3_disk_need_migrate(log_u) ) {
       u3_disk_migrate(log_u);
+    }
+    else if ( c3y == u3_disk_vere_diff(log_u) ) {
+      if ( c3n == u3_disk_epoc_init(log_u, log_u->dun_d) ) {
+        fprintf(stderr, "disk: failed to initialize epoch\r\n");
+        exit(1);
+      }
     }
   }
 

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -195,10 +195,11 @@ _mars_do_boot(u3_disk* log_u, c3_d eve_d)
 
 /* u3_mars_play(): replay up to [eve_d], snapshot every [sap_d].
 */
-void
+c3_d
 u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d)
 {
   u3_disk* log_u = mar_u->log_u;
+  c3_d     pay_d = 0;
 
   if ( !eve_d ) {
     eve_d = log_u->dun_d;
@@ -207,16 +208,17 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d)
     u3l_log("mars: already computed %" PRIu64 "", eve_d);
     u3l_log("      state=%" PRIu64 ", log=%" PRIu64 "",
             mar_u->dun_d, log_u->dun_d);
-    return;
+    return pay_d;
   }
   else {
     eve_d = c3_min(eve_d, log_u->dun_d);
   }
 
   if ( mar_u->dun_d == log_u->dun_d ) {
-    u3l_log("mars: nothing to do!");
-    return;
+    return pay_d;
   }
+
+  pay_d = eve_d - mar_u->dun_d;
 
   if ( !mar_u->dun_d ) {
     c3_w lif_w;
@@ -351,4 +353,6 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d)
 
   u3l_log("---------------- playback complete ----------------");
   u3m_save();
+
+  return pay_d;
 }

--- a/pkg/vere/mars.h
+++ b/pkg/vere/mars.h
@@ -15,7 +15,7 @@
 
     /* u3_mars_play(): replay up to [eve_d], snapshot every [sap_d].
     */
-      void
+      c3_d
       u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d);
 
 #endif /* ifndef U3_VERE_MARS_H */

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -827,14 +827,6 @@ _pier_wyrd_card(u3_pier* pir_u)
 static void
 _pier_wyrd_init(u3_pier* pir_u)
 {
-  //  create a new epoch if current version mismatches the latest epoch's
-  if ( c3y == u3_disk_vere_diff(pir_u->log_u) ) {
-    if ( c3n == u3_disk_epoc_init(pir_u->log_u, pir_u->log_u->dun_d) ) {
-      fprintf(stderr, "disk: failed to initialize epoch\r\n");
-      exit(1);
-    }
-  }
-
   u3_noun cad = _pier_wyrd_card(pir_u);
   u3_noun wir = u3nc(c3__arvo, u3_nul);
 

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1639,10 +1639,12 @@ _pier_init(c3_w wag_w, c3_c* pax_c)
       .write_bail_f = _pier_on_disk_write_bail
     };
 
-    if ( !(pir_u->log_u = u3_disk_init(pax_c, cb_u, c3y)) ) {
+    if ( !(pir_u->log_u = u3_disk_init(pax_c, cb_u)) ) {
       c3_free(pir_u);
       return 0;
     }
+
+    u3_assert( U3D_VER1 == pir_u->log_u->ver_w );
   }
 
   //  initialize compute

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -1022,20 +1022,11 @@
        c3_o
        u3_disk_epoc_last(u3_disk* log_u, c3_d* lat_d);
 
-      /* u3_disk_vere_diff(): checks if vere version mismatches latest epoch's.
-       */
-       c3_o
-       u3_disk_vere_diff(u3_disk* log_u);
-
-      /* u3_disk_need_migrate(): does the disk need migration?
+      /* u3_disk_kindly(): do the needful.
       */
-        c3_o
-        u3_disk_need_migrate(u3_disk* log_u);
+        void
+        u3_disk_kindly(u3_disk* log_u, c3_d eve_d);
 
-      /* u3_disk_migrate(): migrates disk format.
-       */
-        c3_o
-        u3_disk_migrate(u3_disk* log_u);
       /* u3_disk_read_list(): synchronously read a cons list of events.
       */
         u3_weak

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -541,6 +541,7 @@
           u3_dire*         urb_u;               //  urbit system data
           u3_dire*         com_u;               //  log directory
           c3_o             liv_o;               //  live
+          c3_w             ver_w;               //  pier version
           void*            mdb_u;               //  lmdb env of current epoch
           c3_d             sen_d;               //  commit requested
           c3_d             dun_d;               //  committed
@@ -936,7 +937,7 @@
       /* u3_disk_init(): load or create pier directories and event log.
       */
         u3_disk*
-        u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u, c3_o mig_o);
+        u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u);
 
       /* u3_disk_etch(): serialize an event for persistence. RETAIN [eve]
       */

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -1021,11 +1021,6 @@
        c3_o
        u3_disk_epoc_last(u3_disk* log_u, c3_d* lat_d);
 
-      /* u3_disk_epoc_vere(): get binary version from epoch.
-       */
-       c3_o
-       u3_disk_epoc_vere(u3_disk* log_u, c3_d epo_d, c3_c* ver_w);
-
       /* u3_disk_vere_diff(): checks if vere version mismatches latest epoch's.
        */
        c3_o


### PR DESCRIPTION
This PR cleans up the new epoch system from #459, fixing some small bugs, plugging leaks, and simplifying the interface to it.

It still needs a final round of crash recovery testing (killing the process at every stage of the intialization/migration, confirming that subsequent restarts proceed as they should). And #530 still needs to be reproduced/addressed.