### PR TITLE
u3: inline cell deconstruction

### DIFF
--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -9,6 +9,35 @@
 #include "trace.h"
 #include "xtract.h"
 
+
+//  declarations of inline functions
+//
+c3_o
+u3r_cell(u3_noun a, u3_noun* b, u3_noun* c);
+c3_o
+u3r_trel(u3_noun a, u3_noun* b, u3_noun* c, u3_noun* d);
+c3_o
+u3r_qual(u3_noun  a,
+         u3_noun* b,
+         u3_noun* c,
+         u3_noun* d,
+         u3_noun* e);
+c3_o
+u3r_quil(u3_noun  a,
+         u3_noun* b,
+         u3_noun* c,
+         u3_noun* d,
+         u3_noun* e,
+         u3_noun* f);
+c3_o
+u3r_hext(u3_noun  a,
+         u3_noun* b,
+         u3_noun* c,
+         u3_noun* d,
+         u3_noun* e,
+         u3_noun* f,
+         u3_noun* g);
+
 /* _frag_word(): fast fragment/branch prediction for top word.
 */
 static u3_weak
@@ -833,27 +862,6 @@ u3r_bite(u3_noun bite, u3_atom* bloq, u3_atom *step)
   }
 }
 
-/* u3r_cell():
-**
-**   Factor (a) as a cell (b c).
-*/
-c3_o
-u3r_cell(u3_noun  a,
-           u3_noun* b,
-           u3_noun* c)
-{
-  u3_assert(u3_none != a);
-
-  if ( _(u3a_is_atom(a)) ) {
-    return c3n;
-  }
-  else {
-    if ( b ) *b = u3a_h(a);
-    if ( c ) *c = u3a_t(a);
-    return c3y;
-  }
-}
-
 /* u3r_p():
 **
 **   & [0] if [a] is of the form [b *c].
@@ -932,90 +940,6 @@ u3r_pqrs(u3_noun  a,
   if ( (c3y == u3r_p(a, b, &nux)) &&
        (c3y == u3r_qual(nux, c, d, e, f)) )
   {
-    return c3y;
-  }
-  else return c3n;
-}
-
-/* u3r_trel():
-**
-**   Factor (a) as a trel (b c d).
-*/
-c3_o
-u3r_trel(u3_noun a,
-           u3_noun *b,
-           u3_noun *c,
-           u3_noun *d)
-{
-  u3_noun guf;
-
-  if ( (c3y == u3r_cell(a, b, &guf)) &&
-       (c3y == u3r_cell(guf, c, d)) ) {
-    return c3y;
-  }
-  else {
-    return c3n;
-  }
-}
-
-/* u3r_qual():
-**
-**   Factor (a) as a qual (b c d e).
-*/
-c3_o
-u3r_qual(u3_noun  a,
-           u3_noun* b,
-           u3_noun* c,
-           u3_noun* d,
-           u3_noun* e)
-{
-  u3_noun guf;
-
-  if ( (c3y == u3r_cell(a, b, &guf)) &&
-       (c3y == u3r_trel(guf, c, d, e)) ) {
-    return c3y;
-  }
-  else return c3n;
-}
-
-/* u3r_quil():
-**
-**   Factor (a) as a quil (b c d e f).
-*/
-c3_o
-u3r_quil(u3_noun  a,
-           u3_noun* b,
-           u3_noun* c,
-           u3_noun* d,
-           u3_noun* e,
-           u3_noun* f)
-{
-  u3_noun guf;
-
-  if ( (c3y == u3r_cell(a, b, &guf)) &&
-       (c3y == u3r_qual(guf, c, d, e, f)) ) {
-    return c3y;
-  }
-  else return c3n;
-}
-
-/* u3r_hext():
-**
-**   Factor (a) as a hext (b c d e f g)
-*/
-c3_o
-u3r_hext(u3_noun  a,
-           u3_noun* b,
-           u3_noun* c,
-           u3_noun* d,
-           u3_noun* e,
-           u3_noun* f,
-           u3_noun* g)
-{
-  u3_noun guf;
-
-  if ( (c3y == u3r_cell(a, b, &guf)) &&
-       (c3y == u3r_quil(guf, c, d, e, f, g)) ) {
     return c3y;
   }
   else return c3n;

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -4,11 +4,104 @@
 #define U3_RETRIEVE_H
 
 #include "c3.h"
+#include "allocate.h"
+#include "error.h"
 #include "gmp.h"
 #include "types.h"
 
     /** u3r_*: read without ever crashing.
     **/
+
+      /* u3r_cell(): factor (a) as a cell (b c).
+      */
+        inline c3_o
+        u3r_cell(u3_noun a, u3_noun* b, u3_noun* c)
+        {
+          u3_assert(u3_none != a);
+
+          if ( c3y == u3a_is_cell(a) ) {
+            if ( b ) *b = u3a_h(a); // XX use unchecked
+            if ( c ) *c = u3a_t(a);
+            return c3y;
+          }
+          else {
+            return c3n;
+          }
+        }
+
+      /* u3r_trel(): factor (a) as a trel (b c d).
+      */
+        inline c3_o
+        u3r_trel(u3_noun a, u3_noun *b, u3_noun *c, u3_noun *d)
+        {
+          u3_noun guf;
+
+          if ( (c3y == u3r_cell(a, b, &guf)) &&
+               (c3y == u3r_cell(guf, c, d)) ) {
+            return c3y;
+          }
+          else {
+            return c3n;
+          }
+        }
+
+      /* u3r_qual(): factor (a) as a qual (b c d e).
+      */
+        inline c3_o
+        u3r_qual(u3_noun  a,
+                 u3_noun* b,
+                 u3_noun* c,
+                 u3_noun* d,
+                 u3_noun* e)
+        {
+          u3_noun guf;
+
+          if ( (c3y == u3r_cell(a, b, &guf)) &&
+               (c3y == u3r_trel(guf, c, d, e)) ) {
+            return c3y;
+          }
+          else return c3n;
+        }
+
+      /* u3r_quil(): factor (a) as a quil (b c d e f).
+      */
+        inline c3_o
+        u3r_quil(u3_noun  a,
+                 u3_noun* b,
+                 u3_noun* c,
+                 u3_noun* d,
+                 u3_noun* e,
+                 u3_noun* f)
+        {
+          u3_noun guf;
+
+          if ( (c3y == u3r_cell(a, b, &guf)) &&
+               (c3y == u3r_qual(guf, c, d, e, f)) ) {
+            return c3y;
+          }
+          else return c3n;
+        }
+
+      /* u3r_hext(): factor (a) as a hext (b c d e f g)
+      */
+        inline c3_o
+        u3r_hext(u3_noun  a,
+                 u3_noun* b,
+                 u3_noun* c,
+                 u3_noun* d,
+                 u3_noun* e,
+                 u3_noun* f,
+                 u3_noun* g)
+        {
+          u3_noun guf;
+
+          if ( (c3y == u3r_cell(a, b, &guf)) &&
+               (c3y == u3r_quil(guf, c, d, e, f, g)) ) {
+            return c3y;
+          }
+          else return c3n;
+        }
+
       /* u3r_at(): fragment `a` of `b`, or u3_none.
       */
         u3_weak
@@ -182,61 +275,6 @@
       */
         c3_o
         u3r_bite(u3_noun bite, u3_atom* bloq, u3_atom *step);
-
-      /* u3r_cell():
-      **
-      **   Divide `a` as a cell `[b c]`.
-      */
-        c3_o
-        u3r_cell(u3_noun  a,
-                 u3_noun* b,
-                 u3_noun* c);
-
-      /* u3r_trel():
-      **
-      **   Divide `a` as a trel `[b c d]`.
-      */
-        c3_o
-        u3r_trel(u3_noun  a,
-                 u3_noun* b,
-                 u3_noun* c,
-                 u3_noun* d);
-
-      /* u3r_qual():
-      **
-      **   Divide (a) as a qual [b c d e].
-      */
-        c3_o
-        u3r_qual(u3_noun  a,
-                 u3_noun* b,
-                 u3_noun* c,
-                 u3_noun* d,
-                 u3_noun* e);
-
-      /* u3r_quil():
-      **
-      **   Divide (a) as a quil [b c d e f].
-      */
-        c3_o
-        u3r_quil(u3_noun  a,
-                 u3_noun* b,
-                 u3_noun* c,
-                 u3_noun* d,
-                 u3_noun* e,
-                 u3_noun* f);
-
-      /* u3r_hext():
-      **
-      **   Divide (a) as a hext [b c d e f g].
-      */
-        c3_o
-        u3r_hext(u3_noun  a,
-                 u3_noun* b,
-                 u3_noun* c,
-                 u3_noun* d,
-                 u3_noun* e,
-                 u3_noun* f,
-                 u3_noun* g);
 
       /* u3r_p():
       **

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -17,11 +17,14 @@
         inline c3_o
         u3r_cell(u3_noun a, u3_noun* b, u3_noun* c)
         {
+          u3a_cell* cel_u;
+
           u3_assert(u3_none != a);
 
           if ( c3y == u3a_is_cell(a) ) {
-            if ( b ) *b = u3a_h(a); // XX use unchecked
-            if ( c ) *c = u3a_t(a);
+            cel_u = u3a_to_ptr(a);
+            if ( b ) *b = cel_u->hed;
+            if ( c ) *c = cel_u->tel;
             return c3y;
           }
           else {

--- a/pkg/noun/xtract.c
+++ b/pkg/noun/xtract.c
@@ -5,21 +5,8 @@
 #include "manage.h"
 #include "retrieve.h"
 
-/* u3x_good(): test for u3_none.
-*/
 u3_noun
-u3x_good(u3_weak som)
-{
-  return ( u3_none == som ) ? u3m_bail(c3__exit) : som;
-}
-
-/* u3x_at (u3at): fragment.
-*/
-u3_noun
-u3x_at(u3_noun axe, u3_noun som)
-{
-  return u3x_good(u3r_at(axe, som));
-}
+u3x_good(u3_weak som);
 
 /* u3x_mean():
 **
@@ -40,94 +27,3 @@ u3x_mean(u3_noun som, ...)
     u3m_bail(c3__exit);
   }
 }
-
-/* u3x_bite(): xtract/default $bloq and $step from $bite.
-*/
-void
-u3x_bite(u3_noun bite, u3_atom* bloq, u3_atom *step)
-{
-  if ( c3n == u3r_bite(bite, bloq, step) ) {
-    u3m_bail(c3__exit);
-  }
-}
-
-/* u3x_cell():
-**
-**   Divide `a` as a cell `[b c]`.
-*/
-void
-u3x_cell(u3_noun  a,
-         u3_noun* b,
-         u3_noun* c)
-{
-  if ( c3n == u3r_cell(a, b, c) ) {
-    u3m_bail(c3__exit);
-  }
-}
-
-/* u3x_trel():
-**
-**   Divide `a` as a trel `[b c d]`, or bail.
-*/
-void
-u3x_trel(u3_noun  a,
-         u3_noun* b,
-         u3_noun* c,
-         u3_noun* d)
-{
-  if ( c3n == u3r_trel(a, b, c, d) ) {
-    u3m_bail(c3__exit);
-  }
-}
-
-/* u3x_qual():
-**
-**   Divide `a` as a quadruple `[b c d e]`.
-*/
-void
-u3x_qual(u3_noun  a,
-         u3_noun* b,
-         u3_noun* c,
-         u3_noun* d,
-         u3_noun* e)
-{
-  if ( c3n == u3r_qual(a, b, c, d, e) ) {
-    u3m_bail(c3__exit);
-  }
-}
-
-/* u3x_quil():
-**
-**   Divide `a` as a quintuple `[b c d e f]`.
-*/
-void
-u3x_quil(u3_noun  a,
-         u3_noun* b,
-         u3_noun* c,
-         u3_noun* d,
-         u3_noun* e,
-         u3_noun* f)
-{
-  if ( c3n == u3r_quil(a, b, c, d, e, f) ) {
-    u3m_bail(c3__exit);
-  }
-}
-
-/* u3x_hext():
-**
-**   Divide `a` as a hextuple `[b c d e f g]`.
-*/
-void
-u3x_hext(u3_noun  a,
-         u3_noun* b,
-         u3_noun* c,
-         u3_noun* d,
-         u3_noun* e,
-         u3_noun* f,
-         u3_noun* g)
-{
-  if ( c3n == u3r_hext(a, b, c, d, e, f, g) ) {
-    u3m_bail(c3__exit);
-  }
-}
-

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -5,6 +5,8 @@
 
 #include "c3.h"
 #include "types.h"
+#include "allocate.h"
+#include "manage.h"
 
   /**  Constants.
   **/
@@ -40,6 +42,21 @@
   **/
     /* Word axis macros.  For 31-bit axes only.
     */
+
+      /* u3x_at (u3at): fragment.
+      */
+#       define u3x_at(a, b)   u3x_good(u3r_at(a, b))
+#       define u3at(a, b)     u3x_at(a, b)
+
+      /* u3x_bite(): xtract/default $bloq and $step from $bite.
+      */
+#       define u3x_bite(a, b, c)                      \
+          do {                                        \
+            if ( c3n == u3r_bite(a, b, c) ) {         \
+              u3m_bail(c3__exit);                     \
+            }                                         \
+          } while (0)
+
       /* u3x_dep(): number of axis bits.
       */
 #       define u3x_dep(a_w)   (c3_bits_word(a_w) - 1)
@@ -61,25 +78,70 @@
 #       define u3x_peg(a_w, b_w) \
           ( (a_w << u3x_dep(b_w)) | (b_w &~ (1 << u3x_dep(b_w))) )
 
-      /* u3x_atom(): atom or exit.
+      /* u3x_cell(): divide `a` as a cell `[b c]`.
       */
-#       define u3x_atom(a)                            \
-          ( (c3y == u3a_is_cell(a)) ? u3m_bail(c3__exit) : a )
+#       define u3x_cell(a, b, c)                      \
+          do {                                        \
+            if ( c3n == u3r_cell(a, b, c) ) {         \
+              u3m_bail(c3__exit);                     \
+            }                                         \
+          } while (0)
+
+      /* u3x_trel(): divide `a` as a trel `[b c d]`, or bail.
+      */
+#       define u3x_trel(a, b, c, d)                   \
+          do {                                        \
+            if ( c3n == u3r_trel(a, b, c, d) ) {      \
+              u3m_bail(c3__exit);                     \
+            }                                         \
+          } while (0)
+
+      /* u3x_qual(): divide `a` as a quadruple `[b c d e]`.
+      */
+#       define u3x_qual(a, b, c, d, e)                \
+          do {                                        \
+            if ( c3n == u3r_qual(a, b, c, d, e) ) {   \
+              u3m_bail(c3__exit);                     \
+            }                                         \
+          } while (0)
+
+      /* u3x_quil(): divide `a` as a quintuple `[b c d e f]`.
+      */
+#       define u3x_quil(a, b, c, d, e, f)                  \
+          do {                                             \
+            if ( c3n == u3r_quil(a, b, c, d, e, f) ) {     \
+              u3m_bail(c3__exit);                          \
+            }                                              \
+          } while (0)
+
+      /* u3x_hext(): divide `a` as a hextuple `[b c d e f g]`.
+      */
+#       define u3x_hext(a, b, c, d, e, f, g)               \
+          do {                                             \
+            if ( c3n == u3r_hext(a, b, c, d, e, f, g) ) {  \
+              u3m_bail(c3__exit);                          \
+            }                                              \
+          } while (0)
 
   /**  Functions.
   **/
     /** u3x_*: read, but bail with c3__exit on a crash.
     **/
+      /* u3x_atom(): atom or exit.
+      */
+        inline u3_atom
+        u3x_atom(u3_noun a)
+        {
+          return ( c3y == u3a_is_cell(a) ) ? u3m_bail(c3__exit) : a;
+        }
+
       /* u3x_good(): test for u3_none.
       */
-        u3_noun
-        u3x_good(u3_weak som);
-
-      /* u3x_at (u3at): fragment.
-      */
-        u3_noun
-        u3x_at(u3_noun axe, u3_noun som);
-#       define u3at(axe, som) u3x_at(axe, som)
+        inline u3_noun
+        u3x_good(u3_weak som)
+        {
+          return ( u3_none == som ) ? u3m_bail(c3__exit) : som;
+        }
 
       /* u3x_mean():
       **
@@ -88,65 +150,5 @@
       */
         void
         u3x_mean(u3_noun a, ...);
-
-      /* u3x_bite(): xtract/default $bloq and $step from $bite.
-      */
-        void
-        u3x_bite(u3_noun bite, u3_atom* bloq, u3_atom *step);
-
-      /* u3x_cell():
-      **
-      **   Divide `a` as a cell `[b c]`.
-      */
-        void
-        u3x_cell(u3_noun  a,
-                   u3_noun* b,
-                   u3_noun* c);
-
-      /* u3x_trel():
-      **
-      **   Divide `a` as a trel `[b c d]`, or bail.
-      */
-        void
-        u3x_trel(u3_noun  a,
-                   u3_noun* b,
-                   u3_noun* c,
-                   u3_noun* d);
-
-      /* u3x_qual():
-      **
-      **   Divide `a` as a quadruple `[b c d e]`.
-      */
-        void
-        u3x_qual(u3_noun  a,
-                   u3_noun* b,
-                   u3_noun* c,
-                   u3_noun* d,
-                   u3_noun* e);
-
-      /* u3x_quil():
-      **
-      **   Divide `a` as a quintuple `[b c d e f]`.
-      */
-        void
-        u3x_quil(u3_noun  a,
-                   u3_noun* b,
-                   u3_noun* c,
-                   u3_noun* d,
-                   u3_noun* e,
-                   u3_noun* f);
-
-      /* u3x_hext():
-      **
-      **   Divide `a` as a hextuple `[b c d e f g]`.
-      */
-        void
-        u3x_hext(u3_noun  a,
-                   u3_noun* b,
-                   u3_noun* c,
-                   u3_noun* d,
-                   u3_noun* e,
-                   u3_noun* f,
-                   u3_noun* g);
 
 #endif /* ifndef U3_XTRACT_H */


### PR DESCRIPTION
This PR converts `u3r_cell()`/trel/&c inline functions and `u3x_cell()`/trel/&c to macros. This is mostly just a straightforward optimization of frequently used deconstructors, as prelude to optimizing all the jet-interface (`u3w*`) functions.

In the case of `u3x_atom()` the previously-defined macro repeated its argument, which is a bad pattern as that "argument" is often a call to another function. It has now been switched to an inline function.