### PR TITLE
u3: declares %139 jets for +scot and +scow

### DIFF
--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2224,11 +2224,8 @@ static u3j_core _139_qua_d[] =
   { "mole", 7, _140_qua_mole_a, 0, no_hashes },
   { "mule", 7, _140_qua_mule_a, 0, no_hashes },
 
-  //  XX disabled, implicated in memory corruption
-  //  write tests and re-enable
-  //
-  // { "scot", 7, _140_qua_scot_a, 0, no_hashes },
-  // { "scow", 7, _140_qua_scow_a, 0, no_hashes },
+  { "scot", 7, _140_qua_scot_a, 0, no_hashes },
+  { "scow", 7, _140_qua_scow_a, 0, no_hashes },
   { "slaw", 7, _140_qua_slaw_a, 0, no_hashes },
   {}
 };


### PR DESCRIPTION
This PR corrects a mistake from #291, introduced in porting from urbit/urbit#6008. Those new jets were declared for %140, but that PR was merged on top of the release of %139, and the declarations were not duplicated as they should've been. 