### PR TITLE
serf: stay in an inner road between events

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -2088,6 +2088,7 @@ u3m_stop()
 {
   u3e_stop();
   u3je_secp_stop();
+  c3_free(u3D.ray_u);
 }
 
 /* u3m_boot(): start the u3 system. return next event, starting from 1.

--- a/pkg/noun/serial.c
+++ b/pkg/noun/serial.c
@@ -620,7 +620,7 @@ u3s_cue_xeno_init_with(c3_d pre_d, c3_d siz_d)
 {
   u3_cue_xeno* sil_u;
 
-  u3_assert( &(u3H->rod_u) == u3R );
+  // u3_assert( &(u3H->rod_u) == u3R );
 
   sil_u = c3_calloc(sizeof(*sil_u));
   ur_dict32_grow((ur_root_t*)0, &sil_u->dic_u, pre_d, siz_d);
@@ -645,7 +645,7 @@ u3s_cue_xeno_with(u3_cue_xeno* sil_u,
 {
   u3_weak som;
 
-  u3_assert( &(u3H->rod_u) == u3R );
+  // u3_assert( &(u3H->rod_u) == u3R );
 
   som = _cs_cue_xeno(sil_u, len_d, byt_y);
   ur_dict32_wipe(&sil_u->dic_u);

--- a/pkg/noun/vortex.c
+++ b/pkg/noun/vortex.c
@@ -255,6 +255,16 @@ u3v_lily(u3_noun fot, u3_noun txt, c3_l* tid_l)
   }
 }
 
+/* u3v_peek_raw2(): raw +peek
+*/
+u3_noun
+u3v_peek_raw2(u3_noun roc, u3_noun sam)
+{
+  u3_noun fol = u3k(u3x_at(_CVX_PEEK, roc));
+  u3_noun fun = u3n_nock_on(roc, fol);
+  return u3n_slam_on(fun, sam);
+}
+
 /* u3v_peek(): query the reck namespace (protected).
 */
 u3_noun
@@ -304,6 +314,30 @@ u3_noun
 u3v_poke_raw(u3_noun sam)
 {
   u3_noun fun = u3n_nock_on(u3k(u3A->roc), u3k(u3x_at(_CVX_POKE, u3A->roc)));
+  u3_noun pro;
+
+  {
+# ifdef  U3_MEMORY_DEBUG
+    c3_w cod_w = u3a_lush(u3h(u3t(u3t(sam))));
+# endif
+
+    pro = u3n_slam_on(fun, sam);
+
+# ifdef  U3_MEMORY_DEBUG
+    u3a_lop(cod_w);
+# endif
+  }
+
+  return pro;
+}
+
+/* u3v_poke_raw2(): raw +poke
+*/
+u3_noun
+u3v_poke_raw2(u3_noun roc, u3_noun sam)
+{
+  u3_noun fol = u3k(u3x_at(_CVX_POKE, roc));
+  u3_noun fun = u3n_nock_on(roc, fol);
   u3_noun pro;
 
   {

--- a/pkg/noun/vortex.h
+++ b/pkg/noun/vortex.h
@@ -86,6 +86,11 @@
       c3_o
       u3v_lily(u3_noun fot, u3_noun txt, c3_l* tid_l);
 
+    /* u3v_peek_raw2(): raw +peek
+    */
+      u3_noun
+      u3v_peek_raw2(u3_noun roc, u3_noun sam);
+
     /* u3v_peek(): query the reck namespace.
     */
       u3_noun
@@ -95,6 +100,11 @@
     */
       u3_noun
       u3v_soft_peek(c3_w mil_w, u3_noun sam);
+
+    /* u3v_poke_raw2(): raw +poke
+    */
+      u3_noun
+      u3v_poke_raw2(u3_noun roc, u3_noun sam);
 
     /* u3v_poke(): insert and apply an input ovum (protected).
     */

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -959,6 +959,10 @@ _cw_serf_writ(void* vod_p, c3_d len_d, c3_y* byt_y)
   u3t_event_trace("serf ipc cue", 'B');
 #endif
 
+  // u3_assert( &(u3H->rod_u) == u3R );
+  u3m_hate(1 << 18);
+  // u3_assert( &(u3H->rod_u) != u3R );
+
   jar = u3s_cue_xeno_with(sil_u, len_d, byt_y);
 
 #ifdef SERF_TRACE_CUE

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -959,9 +959,12 @@ _cw_serf_writ(void* vod_p, c3_d len_d, c3_y* byt_y)
   u3t_event_trace("serf ipc cue", 'B');
 #endif
 
-  // u3_assert( &(u3H->rod_u) == u3R );
-  u3m_hate(1 << 18);
-  // u3_assert( &(u3H->rod_u) != u3R );
+  if ( !(u3V.fag_e & u3_serf_inn_e) ) {
+    // u3_assert( &(u3H->rod_u) == u3R );
+    u3m_hate(1 << 18);
+    u3V.fag_e |= u3_serf_inn_e;
+    // u3_assert( &(u3H->rod_u) != u3R );
+  }
 
   jar = u3s_cue_xeno_with(sil_u, len_d, byt_y);
 

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1645,7 +1645,7 @@ _cw_grab(c3_i argc, c3_c* argv[])
 
   u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
   u3C.wag_w |= u3o_hashless;
-  u3_serf_grab();
+  u3_serf_grab(0);
   u3m_stop();
 }
 

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -179,6 +179,9 @@ void
 u3_serf_post(u3_serf* sef_u)
 {
   // if ( sef_u->fag_e & u3_serf_mut_e )
+
+  if (  (sef_u->fag_e & u3_serf_inn_e)
+     && (sef_u->fag_e & ~(u3_serf_mut_e|u3_serf_inn_e)) )
   {
     // u3_assert( &(u3H->rod_u) != u3R );
     sef_u->roc    = u3m_love(sef_u->roc);
@@ -187,10 +190,12 @@ u3_serf_post(u3_serf* sef_u)
     u3z(u3A->roc);  // XX really groace
     u3A->roc      = u3k(sef_u->roc);
     u3A->eve_d    = sef_u->dun_d;
-    sef_u->fag_e &= ~u3_serf_mut_e;
+    sef_u->fag_e &= ~u3_serf_inn_e;
   }
   // XX wat do?
   // else if u3_serf_inn_e ?
+
+  sef_u->fag_e &= ~u3_serf_mut_e;
 
   if ( sef_u->fag_e & u3_serf_rec_e ) {
     u3m_reclaim();

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -184,6 +184,7 @@ u3_serf_post(u3_serf* sef_u)
      && (sef_u->fag_e & ~(u3_serf_mut_e|u3_serf_inn_e)) )
   {
     // u3_assert( &(u3H->rod_u) != u3R );
+    u3r_sing(u3A->roc, sef_u->roc); // try to unify
     sef_u->roc    = u3m_love(sef_u->roc);
     // u3_assert( &(u3H->rod_u) == u3R );
     u3z(u3A->roc);

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -172,23 +172,23 @@ u3_serf_grab(void)
 void
 u3_serf_post(u3_serf* sef_u)
 {
-  if ( c3y == sef_u->rec_o ) {
+  if ( sef_u->fag_e & u3_serf_rec_e ) {
     u3m_reclaim();
-    sef_u->rec_o = c3n;
+    sef_u->fag_e &= ~u3_serf_rec_e;
   }
 
   //  XX this runs on replay too, |mass s/b elsewhere
   //
-  if ( c3y == sef_u->mut_o ) {
+  if ( sef_u->fag_e & u3_serf_mut_e ) {
     _serf_grab(sef_u->sac);
-    sef_u->sac   = u3_nul;
-    sef_u->mut_o = c3n;
+    sef_u->sac    = u3_nul;
+    sef_u->fag_e &= ~u3_serf_mut_e;
   }
 
-  if ( c3y == sef_u->pac_o ) {
+  if ( sef_u->fag_e & u3_serf_pac_e ) {
     u3a_print_memory(stderr, "serf: pack: gained", u3m_pack());
     u3l_log("");
-    sef_u->pac_o = c3n;
+    sef_u->fag_e &= ~u3_serf_pac_e;
   }
 
   if ( u3C.wag_w & u3o_toss ) {
@@ -201,9 +201,6 @@ u3_serf_post(u3_serf* sef_u)
 static u3_noun
 _serf_sure_feck(u3_serf* sef_u, c3_w pre_w, u3_noun vir)
 {
-  c3_o rec_o = c3n;
-  c3_o pac_o = c3n;
-
   //  intercept |mass, observe |reset
   //
   {
@@ -234,7 +231,7 @@ _serf_sure_feck(u3_serf* sef_u, c3_w pre_w, u3_noun vir)
       //  reclaim memory from persistent caches on |reset
       //
       if ( c3__vega == u3h(fec) ) {
-        rec_o = c3y;
+        sef_u->fag_e |= u3_serf_rec_e;
       }
 
       riv = u3t(riv);
@@ -251,9 +248,9 @@ _serf_sure_feck(u3_serf* sef_u, c3_w pre_w, u3_noun vir)
   //    For future flexibility, the urgency of the notification is represented
   //    by a *decreasing* number: 0 is maximally urgent, 1 less so, &c.
   //
-  //    high-priority: 2^22 contiguous words remaining (~8 MB)
+  //    high-priority: 2^22 contiguous words remaining (~16 MB)
   //    low-priority:  2^27 contiguous words remaining (~536 MB)
-  //    XX maybe use 2^23 (~16 MB) and 2^26 (~268 MB?
+  //    XX maybe use 2^23 (~32 MB) and 2^26 (~268 MB)?
   //
   //    XX these thresholds should trigger notifications sent to the king
   //    instead of directly triggering these remedial actions.
@@ -267,13 +264,13 @@ _serf_sure_feck(u3_serf* sef_u, c3_w pre_w, u3_noun vir)
     if ( (pre_w > low_w) && !(pos_w > low_w) ) {
       //  XX set flag(s) in u3V so we don't repeat endlessly?
       //
-      pac_o = c3y;
-      rec_o = c3y;
+      sef_u->fag_e |= u3_serf_pac_e;
+      sef_u->fag_e |= u3_serf_rec_e;
       pri   = 1;
     }
     else if ( (pre_w > hig_w) && !(pos_w > hig_w) ) {
-      pac_o = c3y;
-      rec_o = c3y;
+      sef_u->fag_e |= u3_serf_pac_e;
+      sef_u->fag_e |= u3_serf_rec_e;
       pri   = 0;
     }
     //  reclaim memory from persistent caches periodically
@@ -283,7 +280,7 @@ _serf_sure_feck(u3_serf* sef_u, c3_w pre_w, u3_noun vir)
     //    - we don't make very effective use of our free lists
     //
     else if ( 0 == (sef_u->dun_d % 1000ULL) ) {
-      rec_o = c3y;
+      sef_u->fag_e |= u3_serf_rec_e;
     }
 
     //  notify daemon of memory pressure via "fake" effect
@@ -295,9 +292,6 @@ _serf_sure_feck(u3_serf* sef_u, c3_w pre_w, u3_noun vir)
     }
   }
 
-  sef_u->rec_o = c3o(sef_u->rec_o, rec_o);
-  sef_u->pac_o = c3o(sef_u->pac_o, pac_o);
-
   return vir;
 }
 
@@ -306,13 +300,13 @@ _serf_sure_feck(u3_serf* sef_u, c3_w pre_w, u3_noun vir)
 static void
 _serf_sure_core(u3_serf* sef_u, u3_noun cor)
 {
-  sef_u->dun_d = sef_u->sen_d;
+  sef_u->dun_d  = sef_u->sen_d;
 
   u3z(u3A->roc);
-  u3A->roc     = cor;
-  u3A->eve_d   = sef_u->dun_d;
-  sef_u->mug_l = u3r_mug(u3A->roc);
-  sef_u->mut_o = c3y;
+  u3A->roc      = cor;
+  u3A->eve_d    = sef_u->dun_d;
+  sef_u->mug_l  = u3r_mug(u3A->roc);
+  sef_u->fag_e |= u3_serf_mut_e;
 }
 
 /* _serf_sure(): event succeeded, save state and process effects.
@@ -950,9 +944,7 @@ u3_serf_init(u3_serf* sef_u)
   //   }
   // }
 
-  sef_u->pac_o = c3n;
-  sef_u->rec_o = c3n;
-  sef_u->mut_o = c3n;
+  sef_u->fag_e = 0;
   sef_u->sac   = u3_nul;
 
   return rip;

--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -178,13 +178,19 @@ u3_serf_grab(u3_serf* sef_u)
 void
 u3_serf_post(u3_serf* sef_u)
 {
-  if ( sef_u->fag_e & u3_serf_mut_e ) {
-    // sef_u->roc    = u3m_love(sef_u->roc);
+  // if ( sef_u->fag_e & u3_serf_mut_e )
+  {
+    // u3_assert( &(u3H->rod_u) != u3R );
+    sef_u->roc    = u3m_love(sef_u->roc);
+    // u3_assert( &(u3H->rod_u) == u3R );
     u3z(u3A->roc);
+    u3z(u3A->roc);  // XX really groace
     u3A->roc      = u3k(sef_u->roc);
     u3A->eve_d    = sef_u->dun_d;
     sef_u->fag_e &= ~u3_serf_mut_e;
   }
+  // XX wat do?
+  // else if u3_serf_inn_e ?
 
   if ( sef_u->fag_e & u3_serf_rec_e ) {
     u3m_reclaim();

--- a/pkg/vere/serf.h
+++ b/pkg/vere/serf.h
@@ -13,7 +13,8 @@
         u3_serf_mel_e = 1 <<  4,   //  meld requested
         u3_serf_ram_e = 1 <<  5,   //  cram requested
         u3_serf_gab_e = 1 <<  6,   //  grab requested
-        u3_serf_xit_e = 1 <<  7    //  exit requested
+        u3_serf_inn_e = 1 <<  7,   //  in an inner road
+        u3_serf_xit_e = 1 <<  8    //  exit requested
       } u3_serf_flag_e;
 
     /* u3_serf: worker-process state

--- a/pkg/vere/serf.h
+++ b/pkg/vere/serf.h
@@ -12,7 +12,8 @@
         u3_serf_sav_e = 1 <<  3,   //  snapshot requested
         u3_serf_mel_e = 1 <<  4,   //  meld requested
         u3_serf_ram_e = 1 <<  5,   //  cram requested
-        u3_serf_xit_e = 1 <<  6    //  exit requested
+        u3_serf_gab_e = 1 <<  6,   //  grab requested
+        u3_serf_xit_e = 1 <<  7    //  exit requested
       } u3_serf_flag_e;
 
     /* u3_serf: worker-process state
@@ -23,7 +24,6 @@
         c3_d    sen_d;             //  last event requested
         c3_d    dun_d;             //  last event processed
         c3_l    mug_l;             //  hash of state
-        u3_noun sac;               //  space measurementl
         u3_serf_flag_e fag_e;
         c3_y    xit_y;
         void  (*xit_f)(void);      //  exit callback

--- a/pkg/vere/serf.h
+++ b/pkg/vere/serf.h
@@ -19,14 +19,15 @@
     /* u3_serf: worker-process state
     */
       typedef struct _u3_serf {
-        c3_d    key_d[4];          //  disk key
-        c3_c*   dir_c;             //  execution directory (pier)
-        c3_d    sen_d;             //  last event requested
-        c3_d    dun_d;             //  last event processed
-        c3_l    mug_l;             //  hash of state
-        u3_serf_flag_e fag_e;
-        c3_y    xit_y;
-        void  (*xit_f)(void);      //  exit callback
+        c3_d           key_d[4];   //  disk key
+        c3_c*          dir_c;      //  execution directory (pier)
+        c3_d           sen_d;      //  last event requested
+        c3_d           dun_d;      //  last event processed
+        u3_noun          roc;      //  arvo kernel at [dun_d]
+        c3_l           mug_l;      //  hash of state
+        u3_serf_flag_e fag_e;      //  flags
+        c3_y           xit_y;      //  exit code
+        void         (*xit_f)(void);  //  exit callback
       } u3_serf;
 
   /** Functions.
@@ -69,6 +70,6 @@
     /* u3_serf_grab(): garbage collect.
     */
       void
-      u3_serf_grab(void);
+      u3_serf_grab(u3_serf* sef_u);
 
 #endif /* ifndef U3_VERE_SERF_H */

--- a/pkg/vere/serf.h
+++ b/pkg/vere/serf.h
@@ -8,7 +8,11 @@
       typedef enum {               //  execution flags
         u3_serf_mut_e = 1 <<  0,   //  state changed
         u3_serf_pac_e = 1 <<  1,   //  pack requested
-        u3_serf_rec_e = 1 <<  2    //  reclaim requested
+        u3_serf_rec_e = 1 <<  2,   //  reclaim requested
+        u3_serf_sav_e = 1 <<  3,   //  snapshot requested
+        u3_serf_mel_e = 1 <<  4,   //  meld requested
+        u3_serf_ram_e = 1 <<  5,   //  cram requested
+        u3_serf_xit_e = 1 <<  6    //  exit requested
       } u3_serf_flag_e;
 
     /* u3_serf: worker-process state
@@ -21,6 +25,7 @@
         c3_l    mug_l;             //  hash of state
         u3_noun sac;               //  space measurementl
         u3_serf_flag_e fag_e;
+        c3_y    xit_y;
         void  (*xit_f)(void);      //  exit callback
       } u3_serf;
 

--- a/pkg/vere/serf.h
+++ b/pkg/vere/serf.h
@@ -3,6 +3,14 @@
 
   /** Data types.
   **/
+    /* u3_serf_flag_e: process/system flags.
+    */
+      typedef enum {               //  execution flags
+        u3_serf_mut_e = 1 <<  0,   //  state changed
+        u3_serf_pac_e = 1 <<  1,   //  pack requested
+        u3_serf_rec_e = 1 <<  2    //  reclaim requested
+      } u3_serf_flag_e;
+
     /* u3_serf: worker-process state
     */
       typedef struct _u3_serf {
@@ -11,10 +19,8 @@
         c3_d    sen_d;             //  last event requested
         c3_d    dun_d;             //  last event processed
         c3_l    mug_l;             //  hash of state
-        c3_o    pac_o;             //  pack kernel
-        c3_o    rec_o;             //  reclaim cache
-        c3_o    mut_o;             //  mutated kerne
         u3_noun sac;               //  space measurementl
+        u3_serf_flag_e fag_e;
         void  (*xit_f)(void);      //  exit callback
       } u3_serf;
 


### PR DESCRIPTION
This PR runs the serf in an inner road, as long as possible. In practice, the serf will return to the home road to take a snapshot or for `|pack`, `|meld`, and `|mass`.

With this change, all allocations of events and effects no longer modify persistent state. Home-road unification (which we don't have) is somewhat deprioritized, as arvo lives on an inner road between snapshots. On the other hand, with the more efficient free-list utilization from #539, the many small (re)allocations involved in incremental arvo updates should help to defragment the home-road heap.

This PR is a draft because the changes are still somewhat messy, and the error-handling behavior after this change needs to be carefully tested.

This PR should help with urbit/urbit#6805