### PR TITLE
build: use `#include "urcrypt/urcrypt.h"` to avoid looking in `/usr/local/include`

### DIFF
--- a/pkg/noun/jets/e/aes_cbc.c
+++ b/pkg/noun/jets/e/aes_cbc.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 /* All of the CBC hoon truncates its key and prv inputs by passing them to
  * the ECB functions, which truncate them, hence the raw u3r_bytes unpacking.

--- a/pkg/noun/jets/e/aes_ecb.c
+++ b/pkg/noun/jets/e/aes_ecb.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 typedef int (*urcrypt_ecb)(c3_y*, c3_y[16], c3_y[16]);
 

--- a/pkg/noun/jets/e/aes_siv.c
+++ b/pkg/noun/jets/e/aes_siv.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 typedef int (*urcrypt_siv)(c3_y*, size_t,
                            urcrypt_aes_siv_data*, size_t,

--- a/pkg/noun/jets/e/argon2.c
+++ b/pkg/noun/jets/e/argon2.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 /* helpers
 */

--- a/pkg/noun/jets/e/blake.c
+++ b/pkg/noun/jets/e/blake.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 
   static u3_atom

--- a/pkg/noun/jets/e/ed_add_double_scalarmult.c
+++ b/pkg/noun/jets/e/ed_add_double_scalarmult.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_add_double_scalarmult(u3_atom a,

--- a/pkg/noun/jets/e/ed_add_scalarmult_scalarmult_base.c
+++ b/pkg/noun/jets/e/ed_add_scalarmult_scalarmult_base.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_add_scalarmult_scalarmult_base(u3_atom a,

--- a/pkg/noun/jets/e/ed_point_add.c
+++ b/pkg/noun/jets/e/ed_point_add.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 
   static u3_atom

--- a/pkg/noun/jets/e/ed_puck.c
+++ b/pkg/noun/jets/e/ed_puck.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_puck(u3_atom sed)

--- a/pkg/noun/jets/e/ed_scalarmult.c
+++ b/pkg/noun/jets/e/ed_scalarmult.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_scalarmult(u3_atom a,

--- a/pkg/noun/jets/e/ed_scalarmult_base.c
+++ b/pkg/noun/jets/e/ed_scalarmult_base.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_scalarmult_base(u3_atom a)

--- a/pkg/noun/jets/e/ed_shar.c
+++ b/pkg/noun/jets/e/ed_shar.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_shar(u3_atom pub, u3_atom sek)

--- a/pkg/noun/jets/e/ed_sign.c
+++ b/pkg/noun/jets/e/ed_sign.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_sign(u3_noun a,

--- a/pkg/noun/jets/e/ed_veri.c
+++ b/pkg/noun/jets/e/ed_veri.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqee_veri(u3_noun s,

--- a/pkg/noun/jets/e/keccak.c
+++ b/pkg/noun/jets/e/keccak.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 #define defw(bits,byts) \
   u3_atom \

--- a/pkg/noun/jets/e/ripe.c
+++ b/pkg/noun/jets/e/ripe.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_atom
   _cqe_ripe(u3_atom wid, u3_atom dat)

--- a/pkg/noun/jets/e/scr.c
+++ b/pkg/noun/jets/e/scr.c
@@ -5,7 +5,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_weak
   _cqes_hs(u3_atom p, c3_w pwd_w,

--- a/pkg/noun/jets/e/secp.c
+++ b/pkg/noun/jets/e/secp.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include <ent.h>
 
 static urcrypt_secp_context* sec_u;

--- a/pkg/noun/jets/e/sha1.c
+++ b/pkg/noun/jets/e/sha1.c
@@ -4,7 +4,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
   static u3_noun
   _cqe_sha1(u3_atom wid, u3_atom dat)

--- a/pkg/noun/jets/e/shax.c
+++ b/pkg/noun/jets/e/shax.c
@@ -5,7 +5,7 @@
 #include "jets/w.h"
 
 #include "noun.h"
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 
   static u3_atom

--- a/pkg/urcrypt/aes_cbc.c
+++ b/pkg/urcrypt/aes_cbc.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include <string.h>
 #include <openssl/aes.h>

--- a/pkg/urcrypt/aes_ecb.c
+++ b/pkg/urcrypt/aes_ecb.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include <openssl/aes.h>
 

--- a/pkg/urcrypt/aes_siv.c
+++ b/pkg/urcrypt/aes_siv.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include "aes_siv.h"
 

--- a/pkg/urcrypt/argon.c
+++ b/pkg/urcrypt/argon.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include <argon2.h>
 #include <blake2.h>

--- a/pkg/urcrypt/ed25519.c
+++ b/pkg/urcrypt/ed25519.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include <string.h>
 #include <ed25519.h>
 

--- a/pkg/urcrypt/ge_additions.c
+++ b/pkg/urcrypt/ge_additions.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include <ge-additions.h>
 
 int

--- a/pkg/urcrypt/keccak.c
+++ b/pkg/urcrypt/keccak.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include <keccak-tiny.h>
 

--- a/pkg/urcrypt/ripemd.c
+++ b/pkg/urcrypt/ripemd.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include <openssl/ripemd.h>
 

--- a/pkg/urcrypt/scrypt.c
+++ b/pkg/urcrypt/scrypt.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include <libscrypt.h>
 #include <sha256.h>
 

--- a/pkg/urcrypt/secp256k1.c
+++ b/pkg/urcrypt/secp256k1.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include <string.h>
 #include <secp256k1.h>

--- a/pkg/urcrypt/sha.c
+++ b/pkg/urcrypt/sha.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 #include "util.h"
 #include <openssl/sha.h>
 

--- a/pkg/urcrypt/util.c
+++ b/pkg/urcrypt/util.c
@@ -1,4 +1,4 @@
-#include "urcrypt.h"
+#include "urcrypt/urcrypt.h"
 
 void
 urcrypt__reverse(size_t size, uint8_t *ptr) {


### PR DESCRIPTION
We could do this with all our dependencies that sometimes "clash" with system include directory headers.