### PR TITLE
disk: check for null pointer when writing through fak_o

### DIFF
--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -758,7 +758,9 @@ u3_disk_read_meta(MDB_env* mdb_u,
     }
   }
   else if ( (1 == val_u.hav_i) || !((*val_u.buf_y) >> 1) ) {
-    *fak_o = (*val_u.buf_y) & 1;
+    if ( fak_o ) {
+      *fak_o = (*val_u.buf_y) & 1;
+    }
   }
   else {
     fprintf(stderr, "disk: read meta: invalid fake bit %u %zd\r\n",


### PR DESCRIPTION
#547 was not quite enough to get `~binnec-dozzod-marzod` back online. This one is. Thanks to @mopfel-winrux for the solution.