### PR TITLE
u3: adds unconditional freelist migration as workaround

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -650,6 +650,10 @@ _find_home(void)
       fprintf(stderr, "loom: strange size north (%u, %u)\r\n",
                       nor_w, u3P.nor_u.pgs_w);
     }
+
+    //  XX move me
+    //
+    u3a_ream();
   }
 
   /* As a further guard against any sneaky loom corruption */


### PR DESCRIPTION
... early migration prerelease

In other words, my comment at https://github.com/urbit/vere/pull/539#issuecomment-1806060851 was wrong, the couple of ships that are affected cannot just meld because the loom-sane assertion runs too early.