### PR TITLE
u3: redeclare inline u3x_atom for linkability

### DIFF
--- a/pkg/noun/xtract.c
+++ b/pkg/noun/xtract.c
@@ -5,6 +5,8 @@
 #include "manage.h"
 #include "retrieve.h"
 
+u3_atom
+u3x_atom(u3_noun a);
 u3_noun
 u3x_good(u3_weak som);
 


### PR DESCRIPTION
This PR fixes my mistake in #536. Thanks for @liam-fitzgerald for flagging that this broke debug builds.