### PR TITLE
u3: removes free-list ream from v3 migration

### DIFF
--- a/pkg/noun/v3/allocate.h
+++ b/pkg/noun/v3/allocate.h
@@ -11,7 +11,6 @@
 #     define u3R_v3              u3a_Road
 #     define u3a_v3_balign       u3a_balign
 #     define u3a_v3_road         u3a_road
-#     define u3a_v3_ream         u3a_ream
 #     define u3a_v3_walign       u3a_walign
 #     define u3a_v3_walloc       u3a_walloc
 

--- a/pkg/noun/v3/manage.c
+++ b/pkg/noun/v3/manage.c
@@ -100,9 +100,6 @@ u3m_v3_migrate()
   u3R_v3 = &u3H_v3->rod_u;
   u3H_v3->ver_w = U3V_VER3;
 
-  //  recalculate free lists
-  u3a_v3_ream();
-
   //  initialize persistent cache
   u3R_v3->cax.per_p = u3h_v3_new_cache(u3C.per_w);
 


### PR DESCRIPTION
The last minute migration change to #539 was just wrong. #551 is a functional workaround, but the change to the v3 migration itself also needs to be removed. We regret the error. (This can be fixed for real in v4 migration.)