### PR TITLE
lick: Shut bug

### DIFF
--- a/pkg/vere/io/lick.c
+++ b/pkg/vere/io/lick.c
@@ -29,6 +29,7 @@ typedef struct _u3_shan {
 typedef struct _u3_port {
   c3_c*              nam_c;           //  name of port
   c3_o               con_o;
+  c3_o               liv_o;
   struct _u3_shan*   san_u;           //  server reference
   struct _u3_lick*   lic_u;           //  device backpointer
   struct _u3_port*   nex_u;           //  next pointer
@@ -181,12 +182,16 @@ _lick_moor_poke(void* ptr_v, c3_d len_d, c3_y* byt_y)
     return;
   }
 
-  wir = u3nc(c3__lick, u3_nul);
-  dev = _lick_string_to_path(gen_u->nam_c+1);
-  cad = u3nt(c3__soak, dev, put);
-  u3_auto_peer(
-    u3_auto_plan(&lic_u->car_u, u3_ovum_init(0, c3__l, wir, cad)),
-    0, 0, 0);
+  if ( c3y == gen_u->liv_o ) {
+    wir = u3nc(c3__lick, u3_nul);
+    dev = _lick_string_to_path(gen_u->nam_c+1);
+    cad = u3nt(c3__soak, dev, put);
+    u3_auto_peer(
+      u3_auto_plan(&lic_u->car_u, u3_ovum_init(0, c3__l, wir, cad)),
+      0, 0, 0);
+  } else {
+    u3z(put);
+  }
 }
 
 /* _lick_close_chan(): close given channel, freeing.
@@ -214,7 +219,7 @@ _lick_close_chan(u3_chan* can_u)
   }
   can_u->mor_u.nex_u = NULL;
 
-  if ( NULL == san_u->can_u ) {
+  if ( NULL == san_u->can_u && c3y == gen_u->liv_o ) {
     //  send a close event to arvo and stop reading.
     //
     u3_noun wir, cad, dev, dat, mar;
@@ -423,6 +428,7 @@ _lick_ef_shut(u3_lick* lic_u, u3_noun nam)
 
   while ( NULL != cur_u ) {
     if ( 0 == strcmp(cur_u->nam_c, nam_c) ) {
+      cur_u->liv_o = c3n;
       _lick_close_sock(cur_u->san_u);
       if( las_u == NULL ) {
         lic_u->gen_u = cur_u->nex_u;
@@ -462,6 +468,7 @@ _lick_ef_spin(u3_lick* lic_u, u3_noun nam)
   gen_u->san_u->gen_u = gen_u;
   gen_u->nam_c        = nam_c;
   gen_u->con_o        = c3n;
+  gen_u->liv_o        = c3y;
 
   _lick_init_sock(gen_u->san_u);
   if ( NULL == las_u) {

--- a/pkg/vere/io/lick.c
+++ b/pkg/vere/io/lick.c
@@ -303,7 +303,7 @@ _lick_close_sock(u3_shan* san_u)
 {
   u3_lick*  lic_u = san_u->gen_u->lic_u;
 
-  if ( NULL != can_u ) {
+  if ( NULL != san_u->can_u ) {
     _lick_close_chan(san_u->can_u);
   }
 

--- a/pkg/vere/io/lick.c
+++ b/pkg/vere/io/lick.c
@@ -302,7 +302,6 @@ static void
 _lick_close_sock(u3_shan* san_u)
 {
   u3_lick*  lic_u = san_u->gen_u->lic_u;
-  u3_chan*  can_u = san_u->can_u;
 
   if ( NULL != can_u ) {
     _lick_close_chan(san_u->can_u);

--- a/pkg/vere/io/lick.c
+++ b/pkg/vere/io/lick.c
@@ -182,16 +182,12 @@ _lick_moor_poke(void* ptr_v, c3_d len_d, c3_y* byt_y)
     return;
   }
 
-  if ( c3y == gen_u->liv_o ) {
-    wir = u3nc(c3__lick, u3_nul);
-    dev = _lick_string_to_path(gen_u->nam_c+1);
-    cad = u3nt(c3__soak, dev, put);
-    u3_auto_peer(
-      u3_auto_plan(&lic_u->car_u, u3_ovum_init(0, c3__l, wir, cad)),
-      0, 0, 0);
-  } else {
-    u3z(put);
-  }
+  wir = u3nc(c3__lick, u3_nul);
+  dev = _lick_string_to_path(gen_u->nam_c+1);
+  cad = u3nt(c3__soak, dev, put);
+  u3_auto_peer(
+    u3_auto_plan(&lic_u->car_u, u3_ovum_init(0, c3__l, wir, cad)),
+    0, 0, 0);
 }
 
 /* _lick_close_chan(): close given channel, freeing.
@@ -306,6 +302,12 @@ static void
 _lick_close_sock(u3_shan* san_u)
 {
   u3_lick*  lic_u = san_u->gen_u->lic_u;
+  u3_chan*  can_u = san_u->can_u;
+
+  if ( NULL != can_u ) {
+    _lick_close_chan(san_u->can_u);
+  }
+
   c3_w len_w = strlen(lic_u->fod_c) + strlen(san_u->gen_u->nam_c) + 2;
   c3_c* paf_c = c3_malloc(len_w);
   c3_i  wit_i;


### PR DESCRIPTION
There is a bug in lick where if a port still has a connection and lick gets a %shut task the port can still send %soaks to arvo. Arvo poops when this happens. This bug also shows up when the port is disconnected and a %disconnect %soak is sent. This PR fixes both of these bugs