### PR TITLE
ames: clean up libuv timers

### DIFF
--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -3026,6 +3026,8 @@ _ames_io_exit(u3_auto* car_u)
 {
   u3_ames* sam_u = (u3_ames*)car_u;
   uv_close(&sam_u->had_u, _ames_exit_cb);
+  uv_close((uv_handle_t*)&sam_u->sun_u.dns_u, 0);
+  uv_close((uv_handle_t*)&sam_u->sun_u.tim_u, 0);
 }
 
 /* _ames_io_info(): produce status info.


### PR DESCRIPTION
CI on urbit/urbit next/kelvin/411 was broken, presumably because of this.