### PR TITLE
build: recent macOS updates clang

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,8 +76,8 @@ config_setting(
 # Version flag for clang.
 string_flag(
     name = "clang_version",
-    # macOS uses `clang-14.0.3` by default.
-    build_setting_default = "14.0.3",
+    # macOS uses `clang-15.0.0` by default.
+    build_setting_default = "15.0.0",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Not sure what you want to do with this, but on Sonoma, clang 15.0.0 is what is installed.

I'm not currently able to build on my OSX machine, seemingly because I can't get bazel and my nix libtool package to cooperate.