### PR TITLE
conn: fchdir, non-fatal error

### DIFF
--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -725,6 +725,7 @@ _conn_init_sock(u3_shan* san_u)
     u3l_log("conn: uv_listen: %s", uv_strerror(err_i));
     goto _conn_sock_err_unlink;
   }
+  u3l_log("conn: listening on %s/%s", u3_Host.dir_c, URB_SOCK_PATH);
   if ( -1 == fid_i || 0 != fchdir(fid_i) ) {
     if ( -1 != fid_i ) {
       u3l_log("conn: fchdir: %s", strerror(errno));
@@ -732,7 +733,6 @@ _conn_init_sock(u3_shan* san_u)
     }
     u3l_log("conn: cd to old cwd failed\r\n      new cwd: %s", u3_Host.dir_c);
   }
-  u3l_log("conn: listening on %s/%s", u3_Host.dir_c, URB_SOCK_PATH);
   return;
 
 _conn_sock_err_unlink:

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -702,14 +702,14 @@ _conn_init_sock(u3_shan* san_u)
 
   fid_i = open(".", O_EXEC);
   if ( -1 == fid_i ) {
-    u3l_log("conn: open (non-fatal): %s", uv_strerror(errno));
+    u3l_log("conn: open (non-fatal): %s", strerror(errno));
   }
   if ( 0 != chdir(u3_Host.dir_c) ) {
-    u3l_log("conn: chdir: %s", uv_strerror(errno));
+    u3l_log("conn: chdir: %s", strerror(errno));
     goto _conn_sock_err_close;
   }
   if ( 0 != unlink(URB_SOCK_PATH) && errno != ENOENT ) {
-    u3l_log("conn: unlink: %s", uv_strerror(errno));
+    u3l_log("conn: unlink: %s", strerror(errno));
     goto _conn_sock_err_fchdir;
   }
   if ( 0 != (err_i = uv_pipe_init(u3L, &san_u->pyp_u, 0)) ) {
@@ -727,7 +727,7 @@ _conn_init_sock(u3_shan* san_u)
   }
   if ( -1 != fid_i ) {
     if ( 0 != fchdir(fid_i) ) {
-      u3l_log("conn: fchdir (non-fatal): %s", uv_strerror(errno));
+      u3l_log("conn: fchdir (non-fatal): %s", strerror(errno));
     }
     close(fid_i);
   }
@@ -736,11 +736,11 @@ _conn_init_sock(u3_shan* san_u)
 
 _conn_sock_err_unlink:
   if ( 0 != unlink(URB_SOCK_PATH) ) {
-    u3l_log("conn: unlink: %s", uv_strerror(errno));
+    u3l_log("conn: unlink: %s", strerror(errno));
   }
 _conn_sock_err_fchdir:
   if ( -1 != fid_i && 0 != fchdir(fid_i) ) {
-    u3l_log("conn: fchdir: %s", uv_strerror(errno));
+    u3l_log("conn: fchdir: %s", strerror(errno));
   }
 _conn_sock_err_close:
   if ( -1 != fid_i ) {

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -702,7 +702,7 @@ _conn_init_sock(u3_shan* san_u)
 
   fid_i = open(".", O_EXEC);
   if ( -1 == fid_i ) {
-    u3l_log("conn: open (non-fatal): %s", strerror(errno));
+    u3l_log("conn: open \".\": %s", strerror(errno));
   }
   if ( 0 != chdir(u3_Host.dir_c) ) {
     u3l_log("conn: chdir: %s", strerror(errno));
@@ -725,11 +725,12 @@ _conn_init_sock(u3_shan* san_u)
     u3l_log("conn: uv_listen: %s", uv_strerror(err_i));
     goto _conn_sock_err_unlink;
   }
-  if ( -1 != fid_i ) {
-    if ( 0 != fchdir(fid_i) ) {
-      u3l_log("conn: fchdir (non-fatal): %s", strerror(errno));
+  if ( -1 == fid_i || 0 != fchdir(fid_i) ) {
+    if ( -1 != fid_i ) {
+      u3l_log("conn: fchdir: %s", strerror(errno));
+      close(fid_i);
     }
-    close(fid_i);
+    u3l_log("conn: cd to old cwd failed\n      new cwd: %s", u3_Host.dir_c);
   }
   u3l_log("conn: listening on %s/%s", u3_Host.dir_c, URB_SOCK_PATH);
   return;

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -730,7 +730,7 @@ _conn_init_sock(u3_shan* san_u)
       u3l_log("conn: fchdir: %s", strerror(errno));
       close(fid_i);
     }
-    u3l_log("conn: cd to old cwd failed\n      new cwd: %s", u3_Host.dir_c);
+    u3l_log("conn: cd to old cwd failed\r\n      new cwd: %s", u3_Host.dir_c);
   }
   u3l_log("conn: listening on %s/%s", u3_Host.dir_c, URB_SOCK_PATH);
   return;


### PR DESCRIPTION
- Uses `open` / `fchdir` instead of `getcwd` / `chdir` to return to the
  old cwd after setting up the socket.

- If we can't `fchdir` back (either because we couldn't open `.`
  `O_EXEC` or because `fchdir` itself failed), we don't kill the
  process; we just keep going with cwd at the pier directory.

This fixes an issue where if urbit is started with `sudo -u pier` from a
directory that the pier user doesn't have access to (e.g. a different
user's home directory that is chmod 0750), the process would die. It is
also more robust in the face of unusual or changing paths.