### PR TITLE
conn: do not chdir for conn.sock

### DIFF
--- a/pkg/c3/portable.h
+++ b/pkg/c3/portable.h
@@ -37,6 +37,8 @@
 #     include <sys/resource.h>
 #     include <sys/mman.h>
 #     include <sys/sendfile.h>
+#     include <sys/socket.h>
+#     include <sys/un.h>
 
 #   elif defined(U3_OS_osx)
 #     include <ctype.h>
@@ -57,6 +59,8 @@
 #     include <sys/syslimits.h>
 #     include <sys/mman.h>
 #     include <sys/clonefile.h>
+#     include <sys/types.h>
+#     include <sys/un.h>
 #     include <copyfile.h>
 
 #   elif defined(U3_OS_bsd)
@@ -75,6 +79,8 @@
 #     include <sys/time.h>
 #     include <sys/resource.h>
 #     include <sys/mman.h>
+#     include <sys/types.h>
+#     include <sys/un.h>
 
 #   else
       #error "port: headers"
@@ -111,6 +117,7 @@
 
 
 #   define U3_BIN_ALIAS ".run"
+#   define U3_SOCK_MAX sizeof(((struct sockaddr_un *)0)->sun_path)
 
   /** Address space layout.
   ***

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -693,55 +693,63 @@ _conn_init_sock(u3_shan* san_u)
   u3l_log("conn: listening on %s", pip_c);
 
 #else   //  _WIN32
-  //  the full socket path is limited to about 108 characters,
-  //  and we want it to be relative to the pier. save our current
-  //  path, chdir to the pier, open the socket at the desired
-  //  path, then chdir back. hopefully there aren't any threads.
-  //
-  c3_c pax_c[2048];
-  c3_i err_i;
+  c3_c tad_c[104];
+  c3_i err_i, fid_i;
+  c3_c *ven_c;
 
-  if ( NULL == getcwd(pax_c, sizeof(pax_c)) ) {
-    u3l_log("conn: getcwd: %s", uv_strerror(errno));
+  if ( (ven_c = getenv("TMPDIR")) ) {
+    if ( strlen(ven_c) >= 80 ) {
+      u3l_log("conn: TMPDIR too long");
+      ven_c = 0;
+    }
+  }
+  if ( !ven_c ) {
+    ven_c = "/tmp";
+  }
+  snprintf(tad_c, sizeof(tad_c), "%s/urbit-XXXXXX", ven_c);
+  if ( !mkdtemp(tad_c) ) {
+    u3l_log("conn: mkdtemp: %s", strerror(errno));
     u3_king_bail();
   }
-  if ( 0 != chdir(u3_Host.dir_c) ) {
-    u3l_log("conn: chdir: %s", uv_strerror(errno));
-    u3_king_bail();
-  }
-  if ( 0 != unlink(URB_SOCK_PATH) && errno != ENOENT ) {
-    u3l_log("conn: unlink: %s", uv_strerror(errno));
-    goto _conn_sock_err_chdir;
-  }
+  strncat(tad_c, "/conn.sock", sizeof(tad_c) - strlen(tad_c) - 1);
   if ( 0 != (err_i = uv_pipe_init(u3L, &san_u->pyp_u, 0)) ) {
     u3l_log("conn: uv_pipe_init: %s", uv_strerror(err_i));
-    goto _conn_sock_err_chdir;
+    u3_king_bail();
   }
-  if ( 0 != (err_i = uv_pipe_bind(&san_u->pyp_u, URB_SOCK_PATH)) ) {
+  if ( 0 != (err_i = uv_pipe_bind(&san_u->pyp_u, tad_c)) ) {
     u3l_log("conn: uv_pipe_bind: %s", uv_strerror(err_i));
-    goto _conn_sock_err_chdir;
+    u3_king_bail();
   }
   if ( 0 != (err_i = uv_listen((uv_stream_t*)&san_u->pyp_u, 0,
                                _conn_sock_cb)) ) {
     u3l_log("conn: uv_listen: %s", uv_strerror(err_i));
     goto _conn_sock_err_unlink;
   }
-  if ( 0 != chdir(pax_c) ) {
-    u3l_log("conn: chdir: %s", uv_strerror(errno));
+  if ( -1 == (fid_i = open(u3_Host.dir_c, O_DIRECTORY)) ) {
+    u3l_log("conn: open: %s", strerror(errno));
+    goto _conn_sock_err_unlink;
+  }
+  if ( 0 != unlinkat(fid_i, URB_SOCK_PATH, 0) && errno != ENOENT ) {
+    u3l_log("conn: unlinkat: %s", strerror(errno));
     goto _conn_sock_err_close;
   }
-  u3l_log("conn: listening on %s/%s", u3_Host.dir_c, URB_SOCK_PATH);
+  if ( 0 != symlinkat(tad_c, fid_i, URB_SOCK_PATH) ) {
+    u3l_log("conn: symlinkat: %s", strerror(errno));
+    goto _conn_sock_err_close;
+  }
+  if ( 0 != close(fid_i) ) {
+    u3l_log("conn: close: %s", strerror(errno));
+  }
+  u3l_log("conn: listening on %s/%s (%s)", u3_Host.dir_c, URB_SOCK_PATH, tad_c);
   return;
 
 _conn_sock_err_close:
-  uv_close((uv_handle_t*)&san_u->pyp_u, _conn_close_cb);
-_conn_sock_err_unlink:
-  if ( 0 != unlink(URB_SOCK_PATH) ) {
-    u3l_log("conn: unlink: %s", uv_strerror(errno));
+  if ( 0 != close(fid_i) ) {
+    u3l_log("conn: close: %s", strerror(errno));
   }
-_conn_sock_err_chdir:
-  if ( 0 != chdir(pax_c) ) {
-    u3l_log("conn: chdir: %s", uv_strerror(errno));
+_conn_sock_err_unlink:
+  if ( 0 != unlink(tad_c) ) {
+    u3l_log("conn: unlink: %s", strerror(errno));
   }
   u3_king_bail();
 #endif  //  _WIN32
@@ -855,24 +863,40 @@ static void
 _conn_io_exit(u3_auto* car_u)
 {
   u3_conn*          con_u = (u3_conn*)car_u;
-  c3_c*             pax_c = u3_Host.dir_c;
-  c3_w              len_w = strlen(pax_c) + 1 + sizeof(URB_SOCK_PATH);
-  c3_c*             paf_c = c3_malloc(len_w);
-  c3_i              wit_i;
+  c3_c*             fas_c;
+  c3_c              tad_c[104];
+  c3_i              fid_i, got_i;
 
-  wit_i = snprintf(paf_c, len_w, "%s/%s", pax_c, URB_SOCK_PATH);
-  u3_assert(wit_i > 0);
-  u3_assert(len_w == (c3_w)wit_i + 1);
-
-  if ( 0 != unlink(paf_c) ) {
-    if ( ENOENT != errno ) {
-      u3l_log("conn: failed to unlink socket: %s", uv_strerror(errno));
+  if ( -1 == (fid_i = open(u3_Host.dir_c, O_DIRECTORY)) ) {
+    u3l_log("conn: open: %s", strerror(errno));
+  } else if ( -1 == (got_i = readlinkat(fid_i, URB_SOCK_PATH, tad_c,
+                                        sizeof(tad_c) - 1)) ) {
+    u3l_log("conn: readlinkat: %s", strerror(errno));
+  } else {
+    tad_c[got_i] = 0;
+    if ( 0 != unlinkat(fid_i, URB_SOCK_PATH, 0) ) {
+      if ( ENOENT != errno ) {
+        u3l_log("unlinkat: %s", strerror(errno));
+      }
+    }
+    if ( 0 != unlink(tad_c) ) {
+      if ( ENOENT != errno ) {
+        u3l_log("conn: unlink: %s", strerror(errno));
+      }
+    } else if ( !(fas_c = strrchr(tad_c, '/')) ) {
+      u3l_log("conn: strange conn.sock: %s", tad_c);
+    } else {
+      *fas_c = 0;
+      if ( 0 != rmdir(tad_c) ) {
+        if ( ENOENT != errno ) {
+          u3l_log("conn: rmdir: %s", strerror(errno));
+        }
+      }
     }
   }
-  else {
-    // u3l_log("conn: unlinked %s", paf_c);
+  if ( -1 == fid_i && 0 != close(fid_i) ) {
+    u3l_log("conn: close: %s", strerror(errno));
   }
-  c3_free(paf_c);
 
   {
     u3_shan*        san_u = con_u->san_u;

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -742,7 +742,7 @@ _conn_init_sock(u3_shan* san_u)
   if ( 0 != close(fid_i) ) {
     u3l_log("conn: close: %s", strerror(errno));
   }
-  u3l_log("conn: listening on %s/%s (%s)", u3_Host.dir_c, URB_SOCK_PATH, tad_c);
+  u3l_log("conn: listening on %s", tad_c);
   return;
 
 _conn_sock_err_close:

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -877,9 +877,6 @@ _conn_io_exit(u3_auto* car_u)
     if ( 0 != unlinkat(fid_i, URB_SOCK_PATH, 0) && ENOENT != errno ) {
       u3l_log("conn: unlinkat: %s", strerror(errno));
     }
-    if ( 0 != close(fid_i) ) {
-      u3l_log("conn: close: %s", strerror(errno));
-    }
     if ( 0 != unlink(tad_c) && ENOENT != errno ) {
       u3l_log("conn: unlink: %s", strerror(errno));
     } else if ( !(fas_c = strrchr(tad_c, '/')) ) {
@@ -890,6 +887,9 @@ _conn_io_exit(u3_auto* car_u)
         u3l_log("conn: rmdir: %s", strerror(errno));
       }
     }
+  }
+  if ( -1 != fid_i && 0 != close(fid_i) ) {
+    u3l_log("conn: close: %s", strerror(errno));
   }
 
   {

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -729,7 +729,7 @@ _conn_init_sock(u3_shan* san_u)
     u3l_log("conn: open: %s", strerror(errno));
     goto _conn_sock_err_unlink;
   }
-  if ( 0 != unlinkat(fid_i, URB_SOCK_PATH, 0) && errno != ENOENT ) {
+  if ( 0 != unlinkat(fid_i, URB_SOCK_PATH, 0) && ENOENT != errno ) {
     u3l_log("conn: unlinkat: %s", strerror(errno));
     goto _conn_sock_err_close;
   }
@@ -874,28 +874,22 @@ _conn_io_exit(u3_auto* car_u)
     u3l_log("conn: readlinkat: %s", strerror(errno));
   } else {
     tad_c[got_i] = 0;
-    if ( 0 != unlinkat(fid_i, URB_SOCK_PATH, 0) ) {
-      if ( ENOENT != errno ) {
-        u3l_log("unlinkat: %s", strerror(errno));
-      }
+    if ( 0 != unlinkat(fid_i, URB_SOCK_PATH, 0) && ENOENT != errno ) {
+      u3l_log("conn: unlinkat: %s", strerror(errno));
     }
-    if ( 0 != unlink(tad_c) ) {
-      if ( ENOENT != errno ) {
-        u3l_log("conn: unlink: %s", strerror(errno));
-      }
+    if ( 0 != close(fid_i) ) {
+      u3l_log("conn: close: %s", strerror(errno));
+    }
+    if ( 0 != unlink(tad_c) && ENOENT != errno ) {
+      u3l_log("conn: unlink: %s", strerror(errno));
     } else if ( !(fas_c = strrchr(tad_c, '/')) ) {
       u3l_log("conn: strange conn.sock: %s", tad_c);
     } else {
       *fas_c = 0;
-      if ( 0 != rmdir(tad_c) ) {
-        if ( ENOENT != errno ) {
-          u3l_log("conn: rmdir: %s", strerror(errno));
-        }
+      if ( 0 != rmdir(tad_c) && ENOENT != errno ) {
+        u3l_log("conn: rmdir: %s", strerror(errno));
       }
     }
-  }
-  if ( -1 == fid_i && 0 != close(fid_i) ) {
-    u3l_log("conn: close: %s", strerror(errno));
   }
 
   {

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -693,10 +693,10 @@ _conn_init_sock(u3_shan* san_u)
   u3l_log("conn: listening on %s", pip_c);
 
 #else   //  _WIN32
-  c3_c tad_c[U3_SOCK_MAX];
-  c3_w len_w;
-  c3_i err_i, fid_i;
-  c3_c *ven_c;
+  c3_c  tad_c[U3_SOCK_MAX];
+  c3_w  len_w;
+  c3_i  err_i, fid_i;
+  c3_c* ven_c;
 
   if ( (ven_c = getenv("TMPDIR")) ) {
     if ( !(len_w = strlen(ven_c)) ) {

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -100,6 +100,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <sys/stat.h>
+#include <sys/un.h>
 
 #include "noun.h"
 #include "uv.h"
@@ -143,6 +144,7 @@
   } u3_conn;
 
 static const c3_c URB_SOCK_PATH[] = ".urb/conn.sock";
+#define SOCK_PATH_MAX sizeof(((struct sockaddr_un *)0)->sun_path)
 
 /* _conn_close_cb(): socket close callback.
 */
@@ -693,12 +695,12 @@ _conn_init_sock(u3_shan* san_u)
   u3l_log("conn: listening on %s", pip_c);
 
 #else   //  _WIN32
-  c3_c tad_c[104];
+  c3_c tad_c[SOCK_PATH_MAX];
   c3_i err_i, fid_i;
   c3_c *ven_c;
 
   if ( (ven_c = getenv("TMPDIR")) ) {
-    if ( strlen(ven_c) >= 80 ) {
+    if ( strlen(ven_c) >= SOCK_PATH_MAX - sizeof("/urbit-XXXXXX/conn.sock") ) {
       u3l_log("conn: TMPDIR too long");
       ven_c = 0;
     }
@@ -869,7 +871,7 @@ _conn_io_exit(u3_auto* car_u)
 {
   u3_conn*          con_u = (u3_conn*)car_u;
   c3_c*             fas_c;
-  c3_c              tad_c[104];
+  c3_c              tad_c[SOCK_PATH_MAX];
   c3_i              fid_i, got_i;
 
   if ( -1 == (fid_i = open(u3_Host.dir_c, O_DIRECTORY)) ) {

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -722,11 +722,6 @@ _conn_init_sock(u3_shan* san_u)
     u3l_log("conn: uv_pipe_bind: %s", uv_strerror(err_i));
     goto _conn_sock_err_rmdir;
   }
-  if ( 0 != (err_i = uv_listen((uv_stream_t*)&san_u->pyp_u, 0,
-                               _conn_sock_cb)) ) {
-    u3l_log("conn: uv_listen: %s", uv_strerror(err_i));
-    goto _conn_sock_err_unlink;
-  }
   if ( -1 == (fid_i = open(u3_Host.dir_c, O_DIRECTORY)) ) {
     u3l_log("conn: open: %s", strerror(errno));
     goto _conn_sock_err_unlink;
@@ -741,6 +736,11 @@ _conn_init_sock(u3_shan* san_u)
   }
   if ( 0 != close(fid_i) ) {
     u3l_log("conn: close: %s", strerror(errno));
+  }
+  if ( 0 != (err_i = uv_listen((uv_stream_t*)&san_u->pyp_u, 0,
+                               _conn_sock_cb)) ) {
+    u3l_log("conn: uv_listen: %s", uv_strerror(err_i));
+    goto _conn_sock_err_unlink;
   }
   u3l_log("conn: listening on %s", tad_c);
   return;

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -714,11 +714,11 @@ _conn_init_sock(u3_shan* san_u)
   strncat(tad_c, "/conn.sock", sizeof(tad_c) - strlen(tad_c) - 1);
   if ( 0 != (err_i = uv_pipe_init(u3L, &san_u->pyp_u, 0)) ) {
     u3l_log("conn: uv_pipe_init: %s", uv_strerror(err_i));
-    u3_king_bail();
+    goto _conn_sock_err_rmdir;
   }
   if ( 0 != (err_i = uv_pipe_bind(&san_u->pyp_u, tad_c)) ) {
     u3l_log("conn: uv_pipe_bind: %s", uv_strerror(err_i));
-    u3_king_bail();
+    goto _conn_sock_err_rmdir;
   }
   if ( 0 != (err_i = uv_listen((uv_stream_t*)&san_u->pyp_u, 0,
                                _conn_sock_cb)) ) {
@@ -750,6 +750,11 @@ _conn_sock_err_close:
 _conn_sock_err_unlink:
   if ( 0 != unlink(tad_c) ) {
     u3l_log("conn: unlink: %s", strerror(errno));
+  }
+_conn_sock_err_rmdir:
+  *strrchr(tad_c, '/') = 0;
+  if ( 0 != rmdir(tad_c) ) {
+    u3l_log("conn: rmdir: %s", strerror(errno));
   }
   u3_king_bail();
 #endif  //  _WIN32

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -100,7 +100,6 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <sys/stat.h>
-#include <sys/un.h>
 
 #include "noun.h"
 #include "uv.h"
@@ -144,7 +143,6 @@
   } u3_conn;
 
 static const c3_c URB_SOCK_PATH[] = ".urb/conn.sock";
-#define SOCK_PATH_MAX sizeof(((struct sockaddr_un *)0)->sun_path)
 
 /* _conn_close_cb(): socket close callback.
 */
@@ -695,7 +693,7 @@ _conn_init_sock(u3_shan* san_u)
   u3l_log("conn: listening on %s", pip_c);
 
 #else   //  _WIN32
-  c3_c tad_c[SOCK_PATH_MAX];
+  c3_c tad_c[U3_SOCK_MAX];
   c3_w len_w;
   c3_i err_i, fid_i;
   c3_c *ven_c;
@@ -707,7 +705,7 @@ _conn_init_sock(u3_shan* san_u)
       if ( ven_c[len_w - 1] == '/' ) {
         --len_w;
       }
-      if ( len_w >= SOCK_PATH_MAX - sizeof("/urbit-XXXXXX/conn.sock") ) {
+      if ( len_w >= U3_SOCK_MAX - sizeof("/urbit-XXXXXX/conn.sock") ) {
         u3l_log("conn: TMPDIR too long");
         ven_c = 0;
       }
@@ -882,7 +880,7 @@ _conn_io_exit(u3_auto* car_u)
 {
   u3_conn*          con_u = (u3_conn*)car_u;
   c3_c*             fas_c;
-  c3_c              tad_c[SOCK_PATH_MAX];
+  c3_c              tad_c[U3_SOCK_MAX];
   c3_i              fid_i, got_i;
 
   if ( -1 == (fid_i = open(u3_Host.dir_c, O_DIRECTORY)) ) {


### PR DESCRIPTION
Instead, we create the socket in a temporary directory - `TMPDIR` if it is not too long, or else `/tmp`. The directory is made via `mkdtemp` with the template `urbit-XXXXXX`. The socket is located there (getting around the length limit) and `$pier/.urb/conn.sock` is symlinked to it.

This fixes an issue where if urbit is started with `sudo -u pieruser` from a directory that the pier user doesn't have access to (e.g. a different user's home directory that is chmod 0750), the process would die trying to `chdir` back to the old directory.

It also gives clients more flexibility; previously, they would have had to `chdir` to the pier directory to connect to the socket without risking overrunning the length limit. They can still do that (and use `".urb/conn.sock"` as their `sun_path`), but they now also have the option of using `readlink` and connecting to the full absolute path of the socket without changing directories.

Replaces calls to `uv_strerror` with `strerror` for system calls; the former does not print system call errors properly.

Supersedes #580.