### PR TITLE
vere: disable systemd and apparmor for the dbus dependency

### DIFF
--- a/bazel/third_party/dbus/dbus.BUILD
+++ b/bazel/third_party/dbus/dbus.BUILD
@@ -13,7 +13,7 @@ configure_make(
         "//conditions:default": ["--jobs=`nproc`"],
     }),
     copts = ["-O3"],
-    configure_options = ["--disable-selinux --without-x --disable-tests"],
+    configure_options = ["--disable-selinux --without-x --disable-tests --disable-systemd --disable-apparmor"],
     lib_source = ":all",
     configure_in_place = True,
     deps = ["@expat"],


### PR DESCRIPTION
Some people have been having problems building vere because of these.