### PR TITLE
mdns: distinguish fake ships in the mdns namespace

### DIFF
--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2762,9 +2762,14 @@ _mdns_dear_bail(u3_ovum* egg_u, u3_noun lud)
 /* _ames_put_dear(): send lane to arvo after hearing mdns response
 */
 static void
-_ames_put_dear(c3_c* ship, c3_w s_addr, c3_s port, void* context)
+_ames_put_dear(c3_c* ship, bool fake, c3_w s_addr, c3_s port, void* context)
 {
   u3_ames* sam_u = (u3_ames*)context;
+
+  // one is loobean one is boolean
+  if (fake == sam_u->pir_u->fak_o) {
+    return;
+  }
 
   u3_lane lan;
   lan.pip_w = ntohl(s_addr);
@@ -2866,7 +2871,7 @@ _ames_io_start(u3_ames* sam_u)
     char* our_s = u3r_string(our);
     u3z(our);
 
-    mdns_init(por_s, our_s, _ames_put_dear, (void *)sam_u);
+    mdns_init(por_s, !sam_u->pir_u->fak_o, our_s, _ames_put_dear, (void *)sam_u);
     c3_free(our_s);
   }
 

--- a/pkg/vere/mdns.c
+++ b/pkg/vere/mdns.c
@@ -182,7 +182,15 @@ void mdns_init(uint16_t port, char* our, mdns_cb* cb, void* context)
                            NULL, NULL, htons(port), 0, NULL, register_cb, (void*)register_payload);
 
   if (err != kDNSServiceErr_NoError) {
-    u3l_log("mdns: service register error %i", err);
+    if (err == kDNSServiceErr_Unknown) {
+      #if defined(U3_OS_linux)
+      u3l_log("mdns: init failed, install avahi on this system for mdns support");
+      #else
+      u3l_log("mdns: service register error %i", err);
+      #   endif
+    } else {
+      u3l_log("mdns: service register error %i", err);
+    }
     DNSServiceRefDeallocate(sref);
     return;
   }

--- a/pkg/vere/mdns.h
+++ b/pkg/vere/mdns.h
@@ -1,5 +1,6 @@
 #include "noun.h"
+#include <stdbool.h>
 
-typedef void mdns_cb(c3_c* ship, c3_w s_addr, c3_s port, void* context);
+typedef void mdns_cb(c3_c* ship, bool fake, c3_w s_addr, c3_s port, void* context);
 
-void mdns_init(uint16_t port, char* our, mdns_cb* cb, void* context);
+void mdns_init(uint16_t port, bool fake, char* our, mdns_cb* cb, void* context);


### PR DESCRIPTION
Also print a better error message for linux users if avahi is not installed.

I'm targeting this wonky branch to get this into 3.0.