### PR TITLE
build: bump openssl dep

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -253,10 +253,10 @@ versioned_http_archive(
 versioned_http_archive(
     name = "openssl",
     build_file = "//bazel/third_party/openssl:openssl.BUILD",
-    sha256 = "8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b",
+    sha256 = "cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8",
     strip_prefix = "openssl-{version}",
     url = "https://www.openssl.org/source/openssl-{version}.tar.gz",
-    version = "1.1.1t",
+    version = "1.1.1w",
 )
 
 versioned_http_archive(


### PR DESCRIPTION
1.1.1t is 404ing on openssl.org.

Resolves #
