### PR TITLE
Revert "build: recent macOS updates clang"

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,8 +76,8 @@ config_setting(
 # Version flag for clang.
 string_flag(
     name = "clang_version",
-    # macOS uses `clang-15.0.0` by default.
-    build_setting_default = "15.0.0",
+    # macOS uses `clang-14.0.3` by default.
+    build_setting_default = "14.0.3",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Reverts urbit/vere#579

We have to revert this until @jalehman gets back and we can access macstadium. CI on develop is broken otherwise. No biggie, we'll just put this back after.