### PR TITLE
bazel: bump zlib

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -354,10 +354,10 @@ versioned_http_archive(
 versioned_http_archive(
     name = "zlib",
     build_file = "//bazel/third_party/zlib:zlib.BUILD",
-    sha256 = "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e",
+    sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
     strip_prefix = "zlib-{version}",
     url = "https://www.zlib.net/zlib-{version}.tar.gz",
-    version = "1.3",
+    version = "1.3.1",
 )
 
 #


### PR DESCRIPTION
Looks https://zlib.net immediately stops distributing the old version the very instant a minor version bump happens. This broke our CI.