### PR TITLE
fix epoch migration bug

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -522,10 +522,10 @@ _ce_patch_verify(u3_ce_patch* pat_u)
   c3_zs ret_zs;
   c3_o  sou_o = c3n;  // south seen
 
-  if ( U3E_VERLAT != pat_u->con_u->ver_w ) {
+  if ( U3P_VERLAT != pat_u->con_u->ver_w ) {
     fprintf(stderr, "loom: patch version mismatch: have %"PRIc3_w", need %u\r\n",
                     pat_u->con_u->ver_w,
-                    U3E_VERLAT);
+                    U3P_VERLAT);
     return c3n;
   }
 
@@ -737,7 +737,7 @@ _ce_patch_compose(c3_w nor_w, c3_w sou_w)
 
     _ce_patch_create(pat_u);
     pat_u->con_u = c3_malloc(sizeof(u3e_control) + (pgs_w * sizeof(u3e_line)));
-    pat_u->con_u->ver_w = U3E_VERLAT;
+    pat_u->con_u->ver_w = U3P_VERLAT;
     pgc_w = 0;
 
     for ( i_w = 0; i_w < nor_w; i_w++ ) {

--- a/pkg/noun/version.h
+++ b/pkg/noun/version.h
@@ -24,7 +24,7 @@ typedef c3_w       u3e_version;
  * synchronized between:
  * - u3_disk->ver_w
  * - log/<0iN>/epoc.txt
- * - version field in META table of data.mdb files
+ * - version key in META table of data.mdb files
  */
 
 #define U3D_VER1   1         // <= vere-v2

--- a/pkg/noun/version.h
+++ b/pkg/noun/version.h
@@ -20,9 +20,16 @@ typedef c3_w       u3e_version;
 #define U3E_VERLAT U3E_VER1
 
 /* DISK FORMAT
+ *
+ * synchronized between:
+ * - u3_disk->ver_w
+ * - log/<0iN>/epoc.txt
+ * - version field in META table of data.mdb files
  */
 
-#define U3D_VER1   1
-#define U3D_VERLAT U3L_VER1
+#define U3D_VER1   1         // <= vere-v2
+#define U3D_VER2   2         // migrating to >= vere-v3
+#define U3D_VER3   3         // >= vere-v3
+#define U3D_VERLAT U3D_VER3
 
 #endif /* ifndef U3_VERSION_H */

--- a/pkg/noun/version.h
+++ b/pkg/noun/version.h
@@ -23,7 +23,6 @@ typedef c3_w       u3e_version;
  *
  * synchronized between:
  * - u3_disk->ver_w
- * - log/<0iN>/epoc.txt
  * - version key in META table of data.mdb files
  */
 
@@ -33,10 +32,9 @@ typedef c3_w       u3e_version;
 #define U3D_VERLAT U3D_VER3
 
 /* EPOCH SYSTEM
- * XX use this instead of U3D_VER for epoc.txt files
 */
 
 #define U3E_VER1   1
-#define U3E_VERLAT U3E_VER3
+#define U3E_VERLAT U3E_VER1
 
 #endif /* ifndef U3_VERSION_H */

--- a/pkg/noun/version.h
+++ b/pkg/noun/version.h
@@ -11,13 +11,13 @@ typedef c3_w       u3v_version;
 #define U3V_VER3   3
 #define U3V_VERLAT U3V_VER3
 
-/* EVENTS
+/* PATCHES
  */
 
 typedef c3_w       u3e_version;
 
-#define U3E_VER1   1
-#define U3E_VERLAT U3E_VER1
+#define U3P_VER1   1
+#define U3P_VERLAT U3P_VER1
 
 /* DISK FORMAT
  *
@@ -31,5 +31,12 @@ typedef c3_w       u3e_version;
 #define U3D_VER2   2         // migrating to >= vere-v3
 #define U3D_VER3   3         // >= vere-v3
 #define U3D_VERLAT U3D_VER3
+
+/* EPOCH SYSTEM
+ * XX use this instead of U3D_VER for epoc.txt files
+*/
+
+#define U3E_VER1   1
+#define U3E_VERLAT U3E_VER3
 
 #endif /* ifndef U3_VERSION_H */

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1435,12 +1435,12 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
   snprintf(dat_c, sizeof(dat_c), "%s/data.mdb", epo_c);
   snprintf(lok_c, sizeof(lok_c), "%s/lock.mdb", epo_c);
 
-  if ( c3_link(dut_c, dat_c) ) {
+  if ( c3_link(dut_c, dat_c) && (EEXIST != errno) ) {
     fprintf(stderr, "disk: failed to create data.mdb hard link\r\n");
     return c3n;
   }
   if ( c3y == luk_o ) {  //  only link lock.mdb if it exists
-    if ( c3_link(luk_c, lok_c) ) {
+    if ( c3_link(luk_c, lok_c) && (EEXIST != errno) ) {
       fprintf(stderr, "disk: failed to create lock.mdb hard link\r\n");
       return c3n;
     }

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1135,7 +1135,7 @@ fail1:
   return c3n;
 }
 
-/* u3_disk_epoc_init: create new epoch.
+/* u3_disk_epoc_roll: epoch rollover.
 */
 c3_o
 u3_disk_epoc_roll(u3_disk* log_u, c3_d epo_d)

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1749,19 +1749,31 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
       //  ensure old data.mdb file does not exist
       if ( c3y == exs_o ) {
         fprintf(stderr, "disk: old data.mdb file exists\r\n");
+        c3_free(log_u);
         return 0;
       }
+
       //  initialize first epoch "0i0"
       if ( c3n == u3_disk_epoc_zero(log_u) ) {
         fprintf(stderr, "disk: failed to initialize first epoch\r\n");
-        return log_u;  //  XX
+        c3_free(log_u);
+        return 0;
       }
+
+      if ( 0 == (log_u->mdb_u = u3_lmdb_init(log_c, siz_i)) ) {
+        fprintf(stderr, "disk: failed to initialize lmdb\r\n");
+        c3_free(log_u);
+        return 0;
+      }
+
+      return log_u;
     }
 
     if ( c3n == exs_o ) {
       c3_d lat_d;
       if ( c3n == u3_disk_epoc_last(log_u, &lat_d) ) {
         fprintf(stderr, "disk: no event log anywhere\r\n");
+        c3_free(log_u);
         return 0;
       }
       //  presume pre-release migrated pier

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1760,7 +1760,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
         return 0;
       }
 
-      if ( 0 == (log_u->mdb_u = u3_lmdb_init(log_c, siz_i)) ) {
+      if ( _epoc_good != _disk_epoc_load(log_u, 0) ) {
         fprintf(stderr, "disk: failed to initialize lmdb\r\n");
         c3_free(log_u);
         return 0;

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1743,13 +1743,6 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
       exs_o = c3y;
     }
 
-    //  check if epochs exist
-    c3_o epx_o = c3n;
-    c3_d lax_d;
-    if ( c3y == u3_disk_epoc_last(log_u, &lax_d) ) {
-      epx_o = c3y;
-    }
-
     //  if fresh boot, initialize disk U3D_VERLAT
     //
     if ( c3y == u3_Host.ops_u.nuu ) {
@@ -1847,7 +1840,7 @@ try_init:
           u3t_trace_open(pax_c);
 #endif
 
-          if ( c3n == exs_o && c3y == epx_o ) {
+          if ( c3n == exs_o ) {
             fprintf(stderr, "disk: repairing pre-release pier metadata\r\n");
 
             //  read metadata from epoch's log

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -663,6 +663,33 @@ u3_disk_save_meta(MDB_env* mdb_u,
   return c3y;
 }
 
+
+/* u3_disk_save_meta_meta(): save meta metadata.
+*/
+c3_o
+u3_disk_save_meta_meta(c3_c* log_c,
+                       c3_d  who_d[2],
+                       c3_o  fak_o,
+                       c3_w  lif_w)
+{
+  MDB_env* dbm_u;
+
+  if ( 0 == (dbm_u = u3_lmdb_init(log_c, siz_i)) ) {
+    fprintf(stderr, "disk: failed to initialize meta-lmdb\r\n");
+    return c3n;
+  }
+
+  if ( c3n == u3_disk_save_meta(dbm_u, U3D_VERLAT, who_d, fak_o, lif_w) ) {
+    fprintf(stderr, "disk: failed to save metadata\r\n");
+    return c3n;
+  }
+
+  u3_lmdb_exit(dbm_u);
+
+  return c3y;
+}
+
+
 typedef struct {
   ssize_t hav_i;
   c3_y    buf_y[16];
@@ -1866,20 +1893,11 @@ try_init:
               return 0;
             }
 
-            MDB_env* dbm_u;
-            if ( 0 == (dbm_u = u3_lmdb_init(log_c, siz_i)) ) {
-              fprintf(stderr, "disk: failed to initialize lmdb\r\n");
+            if ( c3n == u3_disk_save_meta_meta(log_c, who_d, fak_o, lif_w) ) {
+              fprintf(stderr, "disk: failed to save top-level metadata\r\n");
               c3_free(log_u);
               return 0;
             }
-
-            if ( c3n == u3_disk_save_meta(dbm_u, U3D_VERLAT, who_d, fak_o, lif_w) ) {
-              fprintf(stderr, "disk: failed to read metadata\r\n");
-              c3_free(log_u);
-              return 0;
-            }
-
-            u3_lmdb_exit(dbm_u);
           }
 
           return log_u;

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1102,7 +1102,7 @@ u3_disk_epoc_zero(u3_disk* log_u)
   c3_c epv_c[8193];
   snprintf(epv_c, sizeof(epv_c), "%s/epoc.txt", epo_c);
   FILE* epv_f = fopen(epv_c, "w");  // XX errors
-  fprintf(epv_f, "%d", U3D_VER3);
+  fprintf(epv_f, "%d", U3E_VERLAT);
   fclose(epv_f);
 
   //  create binary version file, overwriting any existing file
@@ -1120,7 +1120,7 @@ u3_disk_epoc_zero(u3_disk* log_u)
 
   //  load new epoch directory and set it in log_u
   log_u->epo_d = 0;
-  log_u->ver_w = U3D_VER3;
+  log_u->ver_w = U3D_VERLAT;
 
   //  success
   return c3y;
@@ -1184,7 +1184,7 @@ u3_disk_epoc_roll(u3_disk* log_u, c3_d epo_d)
   c3_c epv_c[8193];
   snprintf(epv_c, sizeof(epv_c), "%s/epoc.txt", epo_c);
   FILE* epv_f = fopen(epv_c, "w");  // XX errors
-  fprintf(epv_f, "%d", U3D_VER3);
+  fprintf(epv_f, "%d", U3E_VERLAT);
   fclose(epv_f);
 
   //  create binary version file, overwriting any existing file
@@ -1214,7 +1214,7 @@ u3_disk_epoc_roll(u3_disk* log_u, c3_d epo_d)
   }
 
   // write the metadata to the database
-  if ( c3n == u3_disk_save_meta(log_u->mdb_u, U3D_VER3, who_d, fak_o, lif_w) ) {
+  if ( c3n == u3_disk_save_meta(log_u->mdb_u, U3D_VERLAT, who_d, fak_o, lif_w) ) {
     fprintf(stderr, "disk: failed to save metadata\r\n");
     goto fail3;
   }
@@ -1229,7 +1229,7 @@ u3_disk_epoc_roll(u3_disk* log_u, c3_d epo_d)
 
   //  load new epoch directory and set it in log_u
   log_u->epo_d = epo_d;
-  log_u->ver_w = U3D_VER3;
+  log_u->ver_w = U3D_VERLAT;
 
   //  success
   return c3y;
@@ -1314,7 +1314,9 @@ u3_disk_epoc_list(u3_disk* log_u, c3_d* sot_d)
   c3_z     len_z = 0;
 
   while ( den_u ) {  //  count epochs
-    len_z++;
+    if ( 1 == sscanf(den_u->nam_c, "0i%" PRIc3_d, (sot_d + len_z)) ) {
+      len_z++;
+    }
     den_u = den_u->nex_u;
   }
 
@@ -1411,7 +1413,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
     luk_o = c3y;
   }
 
-  fprintf(stderr, "disk: migrating disk to v%d format\r\n", U3D_VER3);
+  fprintf(stderr, "disk: migrating disk to v%d format\r\n", U3D_VERLAT);
 
   // ensure there's a current snapshot
   if ( eve_d != las_d ) {
@@ -1481,7 +1483,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
     return c3n;
   }
   //  u3_disk_save_meta with v3
-  if ( c3n == u3_disk_save_meta(log_u->mdb_u, U3D_VER3, who_d, fak_o, lif_w) ) {
+  if ( c3n == u3_disk_save_meta(log_u->mdb_u, U3D_VERLAT, who_d, fak_o, lif_w) ) {
     fprintf(stderr, "disk: failed to save metadata\r\n");
     return c3n;
   }
@@ -1518,7 +1520,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
   //  XX: maybe rollover
 
   //  success
-  fprintf(stderr, "disk: migrated disk to v%d format\r\n", U3D_VER3);
+  fprintf(stderr, "disk: migrated disk to v%d format\r\n", U3D_VERLAT);
 
   return c3y;
 }
@@ -1614,13 +1616,11 @@ _disk_epoc_load(u3_disk* log_u, c3_d lat_d)
       return _epoc_fail;
     }
 
-    if ( U3D_VER3 != ver_w ) {
+    if ( U3E_VERLAT != ver_w ) {
       fprintf(stderr, "disk: unknown epoch version: '%s', expected '%d'\r\n",
-                      ver_c, U3D_VER3);
+                      ver_c, U3E_VERLAT);
       return _epoc_late;
     }
-
-    log_u->ver_w = ver_w;  //  XX conflicts with data.mdb version
   }
 
   //  set path to latest epoch
@@ -1741,7 +1741,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
       exs_o = c3y;
     }
 
-    //  if fresh boot, initialize disk U3D_VER3
+    //  if fresh boot, initialize disk U3D_VERLAT
     //
     if ( c3y == u3_Host.ops_u.nuu ) {
       //  ensure old data.mdb file does not exist
@@ -1763,7 +1763,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
         return 0;
       }
       //  presume pre-release migrated pier
-      log_u->ver_w = U3D_VER3;
+      log_u->ver_w = U3D_VERLAT;
     }
     else {
       //  load the old data.mdb file
@@ -1797,7 +1797,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
         return log_u;
       }
 
-      case U3D_VER3: break;
+      case U3D_VERLAT: break;
 
       default: {
         fprintf(stderr, "disk: unknown log version: %d\r\n", log_u->ver_w);
@@ -1859,7 +1859,7 @@ try_init:
               return 0;
             }
 
-            if ( c3n == u3_disk_save_meta(dbm_u, U3D_VER3, who_d, fak_o, lif_w) ) {
+            if ( c3n == u3_disk_save_meta(dbm_u, U3D_VERLAT, who_d, fak_o, lif_w) ) {
               fprintf(stderr, "disk: failed to read metadata\r\n");
               c3_free(log_u);
               return 0;

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1743,6 +1743,13 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
       exs_o = c3y;
     }
 
+    //  check if epochs exist
+    c3_o epx_o = c3n;
+    c3_d lax_d;
+    if ( c3y == u3_disk_epoc_last(log_u, &lax_d) ) {
+      epx_o = c3y;
+    }
+
     //  if fresh boot, initialize disk U3D_VERLAT
     //
     if ( c3y == u3_Host.ops_u.nuu ) {
@@ -1840,7 +1847,7 @@ try_init:
           u3t_trace_open(pax_c);
 #endif
 
-          if ( c3n == exs_o ) {
+          if ( c3n == exs_o && c3y == epx_o ) {
             fprintf(stderr, "disk: repairing pre-release pier metadata\r\n");
 
             //  read metadata from epoch's log

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1897,13 +1897,6 @@ try_init:
                           "falling back to previous at 0i%" PRIc3_d "\r\n",
                           lat_d, sot_d[1]);
 
-          fprintf(stderr, "kindly: len_z: %ld\r\n", len_z);
-          for ( c3_z i_z = 0; i_z < len_z; i_z++ ) {
-            fprintf(stderr, "kindly: sot_d[%ld]: %" PRIc3_d "\r\n",
-                            i_z, sot_d[i_z]);
-          }
-          return 0;
-
           u3_disk_epoc_kill(log_u, lat_d);
 
           lat_d = sot_d[1];

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2484,7 +2484,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   }
 
   //  create new epoch if latest isn't empty
-  if ( (fir_d != las_d) && (c3n == u3_disk_epoc_init(log_u, las_d)) ) {
+  if ( (fir_d != las_d) && (c3n == u3_disk_epoc_roll(log_u, las_d)) ) {
     fprintf(stderr, "chop: failed to create new epoch\r\n");
     exit(1);
   }
@@ -2576,7 +2576,7 @@ _cw_roll(c3_i argc, c3_c* argv[])
   u3_disk_kindly(log_u, u3_Host.eve_d);
 
   // check if there's a *current* snapshot
-  if ( log_u->dun_d != u3A->eve_d ) {
+  if ( log_u->dun_d != u3_Host.eve_d ) {
     fprintf(stderr, "roll: error: snapshot is out of date, please "
                     "start/shutdown your pier gracefully first\r\n");
     fprintf(stderr, "roll: eve_d: %" PRIc3_d ", dun_d: %" PRIc3_d "\r\n", \
@@ -2595,7 +2595,7 @@ _cw_roll(c3_i argc, c3_c* argv[])
     fprintf(stderr, "roll: latest epoch already empty\r\n");
     exit(0);
   }
-  else if ( c3n == u3_disk_epoc_init(log_u, las_d) ) {
+  else if ( c3n == u3_disk_epoc_roll(log_u, las_d) ) {
     fprintf(stderr, "roll: failed to create new epoch\r\n");
     exit(1);
   }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2222,6 +2222,7 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
   }
 
   u3_disk_exit(log_u);
+  //  NB: loom migrations without replay are not saved
   u3m_stop();
 
   return pay_d;

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -248,7 +248,7 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d)
   if ( !mar_u->dun_d ) {
     c3_w lif_w;
 
-    if ( c3n == u3_disk_read_meta(log_u->mdb_u, 0, 0, &lif_w) ) {
+    if ( c3n == u3_disk_read_meta(log_u->mdb_u, 0, 0, 0, &lif_w) ) {
       fprintf(stderr, "mars: disk read meta fail\r\n");
       //  XX exit code, cb
       //

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1905,6 +1905,13 @@ _pier_boot_plan(u3_pier* pir_u,
     return c3n;
   }
 
+  if ( c3n == u3_disk_save_meta_meta(pir_u->log_u->com_u->pax_c,
+                                     pir_u->who_d, pir_u->fak_o, pir_u->lif_w) )
+  {
+    fprintf(stderr, "disk: failed to save top-level metadata\r\n");
+    return c3n;
+  }
+
   //  insert boot sequence directly
   //
   //    Note that these are not ovum or (pair @da ovum) events,

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1644,7 +1644,7 @@ _pier_init(c3_w wag_w, c3_c* pax_c)
       return 0;
     }
 
-    u3_assert( U3D_VER1 == pir_u->log_u->ver_w );
+    u3_assert( U3D_VER3 == pir_u->log_u->ver_w );
   }
 
   //  initialize compute
@@ -1698,7 +1698,8 @@ u3_pier_stay(c3_w wag_w, u3_noun pax)
     return 0;
   }
 
-  if ( c3n == u3_disk_read_meta(pir_u->log_u->mdb_u,  pir_u->who_d,
+  if ( c3n == u3_disk_read_meta(pir_u->log_u->mdb_u,
+                               &pir_u->log_u->ver_w,  pir_u->who_d,
                                &pir_u->fak_o,        &pir_u->lif_w) )
   {
     fprintf(stderr, "pier: disk read meta fail\r\n");
@@ -1895,7 +1896,8 @@ _pier_boot_plan(u3_pier* pir_u,
     pir_u->lif_w = u3qb_lent(bot_u.bot);
   }
 
-  if ( c3n == u3_disk_save_meta(pir_u->log_u->mdb_u, pir_u->who_d,
+  if ( c3n == u3_disk_save_meta(pir_u->log_u->mdb_u,
+                                pir_u->log_u->ver_w, pir_u->who_d,
                                 pir_u->fak_o,        pir_u->lif_w) )
   {
     //  XX dispose bot_u

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1644,7 +1644,7 @@ _pier_init(c3_w wag_w, c3_c* pax_c)
       return 0;
     }
 
-    u3_assert( U3D_VER3 == pir_u->log_u->ver_w );
+    u3_assert( U3D_VERLAT == pir_u->log_u->ver_w );
   }
 
   //  initialize compute

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -542,7 +542,7 @@
           u3_dire*         urb_u;               //  urbit system data
           u3_dire*         com_u;               //  log directory
           c3_o             liv_o;               //  live
-          c3_w             ver_w;               //  pier version
+          c3_w             ver_w;               //  version (see version.h)
           void*            mdb_u;               //  lmdb env of current epoch
           c3_d             sen_d;               //  commit requested
           c3_d             dun_d;               //  committed
@@ -976,6 +976,7 @@
       */
         c3_o
         u3_disk_read_meta(MDB_env* mdb_u,
+                          c3_w*    ver_w,
                           c3_d*    who_d,
                           c3_o*    fak_o,
                           c3_w*    lif_w);
@@ -984,6 +985,7 @@
       */
         c3_o
         u3_disk_save_meta(MDB_env* mdb_u,
+                          c3_w     ver_w,
                           c3_d     who_d[2],
                           c3_o     fak_o,
                           c3_w     lif_w);

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -1013,7 +1013,7 @@
       /* u3_disk_epoc_init(): create new epoch.
        */
         c3_o
-        u3_disk_epoc_init(u3_disk* log_u, c3_d epo_d);
+        u3_disk_epoc_roll(u3_disk* log_u, c3_d epo_d);
 
       /* u3_disk_epoc_kill(): delete an epoch.
        */

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -990,6 +990,14 @@
                           c3_o     fak_o,
                           c3_w     lif_w);
 
+      /* u3_disk_save_meta_meta(): save meta metadata.
+      */
+        c3_o
+        u3_disk_save_meta_meta(c3_c* log_c,
+                               c3_d  who_d[2],
+                               c3_o  fak_o,
+                               c3_w  lif_w);
+
       /* u3_disk_read(): read [len_d] events starting at [eve_d].
       */
         void


### PR DESCRIPTION
Refactors the epoch system migration to prevent downgrade shenanigans and jankery when pilots booted 3 -> 2 -> 3, or other similar permutations. We use the version number in the `META` database of `log/data.mdb` as our migration indicator now instead of the (non-)existence of `log/data.mdb`.