### PR TITLE
vere: fix epoc lifecycle error handling, enforce invariants

### DIFF
--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -573,6 +573,11 @@ u3_disk_walk_init(u3_disk* log_u,
                                    eve_d,
                                    c3_min(max_d, log_u->dun_d));
 
+  if ( c3n == wok_u->liv_o ) {
+    c3_free(wok_u);
+    return 0;
+  }
+
   return wok_u;
 }
 

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1315,19 +1315,25 @@ u3_disk_epoc_last(u3_disk* log_u, c3_d* lat_d)
   u3_dire* die_u = u3_foil_folder(log_u->com_u->pax_c);
   u3_dent* den_u = die_u->dil_u;
   c3_o     ret_o = c3n;
-
-  *lat_d = 0;
+  c3_d     epo_d = 0;
+  c3_d     val_d;
+  c3_i     car_i;
 
   while ( den_u ) {
-    c3_d epo_d = 0;
-    if ( 1 == sscanf(den_u->nam_c, "0i%" PRIc3_d, &epo_d) ) {
+    if (  (1 == sscanf(den_u->nam_c, "0i%" SCNu64 "%n", &val_d, &car_i))
+       && (0 < car_i)
+       && ('\0' == *(den_u->nam_c + car_i)) )
+    {
       ret_o = c3y;   //  NB: returns yes if the directory merely exists
-      *lat_d = c3_max(epo_d, *lat_d);  //  update the latest epoch number
+      epo_d = c3_max(epo_d, val_d);
     }
+
     den_u = den_u->nex_u;
   }
 
   u3_dire_free(die_u);
+
+  *lat_d = epo_d;
 
   return ret_o;
 }
@@ -1340,12 +1346,17 @@ u3_disk_epoc_list(u3_disk* log_u, c3_d* sot_d)
   u3_dire* ned_u = u3_foil_folder(log_u->com_u->pax_c);
   u3_dent* den_u = ned_u->dil_u;
   c3_z     len_z = 0;
+  c3_i     car_i;
+  c3_d     val_d;
 
   while ( den_u ) {  //  count epochs
-    c3_d tmp_d;
-    if ( 1 == sscanf(den_u->nam_c, "0i%" PRIc3_d, &tmp_d) ) {
+    if (  (1 == sscanf(den_u->nam_c, "0i%" SCNu64 "%n", &val_d, &car_i))
+       && (0 < car_i)
+       && ('\0' == *(den_u->nam_c + car_i)) )
+    {
       len_z++;
     }
+
     den_u = den_u->nex_u;
   }
 
@@ -1358,9 +1369,13 @@ u3_disk_epoc_list(u3_disk* log_u, c3_d* sot_d)
   den_u = ned_u->dil_u;
 
   while ( den_u ) {
-    if ( 1 == sscanf(den_u->nam_c, "0i%" PRIc3_d, (sot_d + len_z)) ) {
-      len_z++;
+    if (  (1 == sscanf(den_u->nam_c, "0i%" SCNu64 "%n", &val_d, &car_i))
+       && (0 < car_i)
+       && ('\0' == *(den_u->nam_c + car_i)) )
+    {
+      sot_d[len_z++] = val_d;
     }
+
     den_u = den_u->nex_u;
   }
 
@@ -1636,6 +1651,8 @@ _disk_epoc_load(u3_disk* log_u, c3_d lat_d)
   {
     c3_c ver_c[8];
     c3_w ver_w;
+    c3_i car_i;
+
     if ( c3n == _disk_epoc_meta(log_u, lat_d, "epoc",
                                 sizeof(ver_c) - 1, ver_c) )
     {
@@ -1645,7 +1662,10 @@ _disk_epoc_load(u3_disk* log_u, c3_d lat_d)
       return _epoc_gone;
     }
 
-    if ( 1 != sscanf(ver_c, "%d", &ver_w) ) {
+    if (  (1 != sscanf(ver_c, "%" SCNu32 "%n", &ver_w, &car_i))
+       && (0 < car_i)
+       && ('\0' == *(ver_c + car_i)) )
+    {
       fprintf(stderr, "disk: failed to parse epoch version: '%s'\r\n", ver_c);
       return _epoc_fail;
     }

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1409,22 +1409,12 @@ static c3_o
 _disk_migrate(u3_disk* log_u, c3_d eve_d)
 {
   /*  migration steps:
-   *  0. detect whether we need to migrate or not
-   *     a. if it's a fresh boot via u3_Host.ops_u.nuu -> skip migration
-   *     b. if log/data.mdb is readable and is not v3 -> execute migration
-   *        if not -> skip migration (returns yes)
-   *  1. set log/data.mdb to version 2 (migration in progress)
-   *  2. initialize epoch 0i0
-   *     a. creates epoch directory
-   *     b. creates epoch version file
-   *     c. creates binary version file
-   *     d. creates hard links to data.mdb and lock.mdb in 0i0/
-   *     e. deletes backup snapshot
-   *  3. create hard links to data.mdb and lock.mdb in 0i0/
-   *  4. use scratch space to initialize new log/data.db in log/tmp
-   *  5. save old metadata to new db in scratch space
-   *  6. clobber old log/data.mdb with new log/tmp/data.mdb
-   *  7. open epoch lmdb and set it in log_u
+   *  1. initialize epoch 0i0 (see u3_disk_epoc_zero)
+   *  2. create hard links to data.mdb and lock.mdb in 0i0/
+   *  3. use scratch space to initialize new log/data.db in log/tmp
+   *  4. save old metadata to new db in scratch space
+   *  5. clobber old log/data.mdb with new log/tmp/data.mdb
+   *  6. open epoch lmdb and set it in log_u
    */
   
   //  NB: requires that log_u->mdb_u is initialized to log/data.mdb

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2215,10 +2215,17 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
     _cw_play_snap(log_u);
   }
 
-  //  XX this should check that snapshot is within epoc,
-  //  and load from the epoc / reboot if it is not
+  u3_Host.eve_d = u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
+
+  //  XX this should load from the epoc snapshot
+  //  but that clobbers chk/ which is risky
   //
-  u3m_boot(u3_Host.dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
+  if ( u3_Host.eve_d < log_u->epo_d ) {
+    fprintf(stderr, "mars: pier corrupt: "
+                    "snapshot (%" PRIu64 ") out of epoc (%" PRIu64 "\r\n",
+                    u3_Host.eve_d, log_u->epo_d);
+    exit(1);
+  }
 
   u3C.slog_f = _cw_play_slog;
 
@@ -2338,7 +2345,7 @@ _cw_play(c3_i argc, c3_c* argv[])
   }
 
   if ( !_cw_play_impl(eve_d, sap_d, mel_o, sof_o, ful_o) ) {
-    fprintf(stderr, "mars: nothing to do!");
+    fprintf(stderr, "mars: nothing to do!\r\n");
   }
 }
 

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2493,35 +2493,10 @@ _cw_chop(c3_i argc, c3_c* argv[])
   u3_disk* log_u = _cw_disk_init(u3_Host.dir_c);
 
   u3_disk_kindly(log_u, u3_Host.eve_d);
+  u3_disk_chop(log_u, u3_Host.eve_d);
 
-  c3_z len_z = u3_disk_epoc_list(log_u, 0);
-
-  if ( len_z <= 2 ) {
-    fprintf(stderr, "chop: nothing to do, have a great day\r\n");
-    exit(0);  //  enjoy
-  }
-
-  c3_d* sot_d = c3_malloc(len_z * sizeof(c3_d));
-  u3_disk_epoc_list(log_u, sot_d);
-
-  //  delete all but the last two epochs
-  //
-  //    XX parameterize the number of epochs to chop
-  //
-  for ( c3_z i_z = 2; i_z < len_z; i_z++ ) {
-    fprintf(stderr, "chop: deleting epoch 0i%" PRIc3_d "\r\n", sot_d[i_z]);
-    if ( c3y != u3_disk_epoc_kill(log_u, sot_d[i_z]) ) {
-      fprintf(stderr, "chop: failed to delete epoch 0i%" PRIu64 "\r\n", sot_d[i_z]);
-      exit(1);
-    }
-  }
-
-  // cleanup
-  c3_free(sot_d);
   u3_disk_exit(log_u);
-
-  // success
-  fprintf(stderr, "chop: event log truncation complete\r\n");
+  u3m_stop();
 }
 
 /* _cw_roll(): rollover to new epoch
@@ -2579,35 +2554,10 @@ _cw_roll(c3_i argc, c3_c* argv[])
   u3_disk* log_u = _cw_disk_init(u3_Host.dir_c);
 
   u3_disk_kindly(log_u, u3_Host.eve_d);
+  u3_disk_roll(log_u, u3_Host.eve_d);
 
-  // check if there's a *current* snapshot
-  if ( log_u->dun_d != u3_Host.eve_d ) {
-    fprintf(stderr, "roll: error: snapshot is out of date, please "
-                    "start/shutdown your pier gracefully first\r\n");
-    fprintf(stderr, "roll: eve_d: %" PRIc3_d ", dun_d: %" PRIc3_d "\r\n", \
-                     u3A->eve_d, log_u->dun_d);
-    exit(1);
-  }
-
-  //  create new epoch
-  c3_d fir_d, las_d;
-  if ( c3n == u3_lmdb_gulf(log_u->mdb_u, &fir_d, &las_d) ) {
-    fprintf(stderr, "roll: failed to get first/last events\r\n");
-    exit(1);
-  }
-
-  if ( fir_d == las_d ) {
-    fprintf(stderr, "roll: latest epoch already empty\r\n");
-    exit(0);
-  }
-  else if ( c3n == u3_disk_epoc_roll(log_u, las_d) ) {
-    fprintf(stderr, "roll: failed to create new epoch\r\n");
-    exit(1);
-  }
-
-  //  success
-  c3_d epo_d = log_u->dun_d + 1;
-  fprintf(stderr, "roll: epoch rollover complete\r\n");
+  u3_disk_exit(log_u);
+  u3m_stop();
 }
 
 /* _cw_vere(): download vere

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2222,7 +2222,7 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
   //
   if ( u3_Host.eve_d < log_u->epo_d ) {
     fprintf(stderr, "mars: pier corrupt: "
-                    "snapshot (%" PRIu64 ") out of epoc (%" PRIu64 "\r\n",
+                    "snapshot (%" PRIu64 ") out of epoc (%" PRIu64 ")\r\n",
                     u3_Host.eve_d, log_u->epo_d);
     exit(1);
   }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1586,6 +1586,23 @@ _cw_info(c3_i argc, c3_c* argv[])
 
   u3_disk_slog(log_u);
   printf("\n");
+
+
+  {
+    c3_z  len_z = u3_disk_epoc_list(log_u, 0);
+    c3_d* sot_d = c3_malloc(len_z * sizeof(c3_d));
+    u3_disk_epoc_list(log_u, sot_d);
+
+    fprintf(stderr, "epocs:\r\n");
+
+    while ( len_z-- ) {
+      fprintf(stderr, "  0i%" PRIu64 "\r\n", sot_d[len_z]);
+    }
+
+    c3_free(sot_d);
+    fprintf(stderr, "\r\n");
+  }
+
   u3_lmdb_stat(log_u->mdb_u, stdout);
   u3_disk_exit(log_u);
 

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2494,19 +2494,6 @@ _cw_chop(c3_i argc, c3_c* argv[])
 
   u3_disk_kindly(log_u, u3_Host.eve_d);
 
-  //  create new epoch
-  c3_d fir_d, las_d;
-  if ( c3n == u3_lmdb_gulf(log_u->mdb_u, &fir_d, &las_d) ) {
-    fprintf(stderr, "chop: failed to get first/last events\r\n");
-    exit(1);
-  }
-
-  //  create new epoch if latest isn't empty
-  if ( (fir_d != las_d) && (c3n == u3_disk_epoc_roll(log_u, las_d)) ) {
-    fprintf(stderr, "chop: failed to create new epoch\r\n");
-    exit(1);
-  }
-
   c3_z len_z = u3_disk_epoc_list(log_u, 0);
 
   if ( len_z <= 2 ) {

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -101,6 +101,11 @@ _mars_play_batch(u3_mars* mar_u,
   u3_noun         dud;
   u3_weak         wen = u3_none;
 
+  if ( !wok_u ) {
+    fprintf(stderr, "play: failed to open event log iterator\r\n");
+    return _play_log_e;
+  }
+
   while ( c3y == u3_disk_walk_live(wok_u) ) {
     if ( c3n == u3_disk_walk_step(wok_u, &tac_u) ) {
       u3_disk_walk_done(wok_u);

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -1018,16 +1018,6 @@
         void
         u3_disk_plan(u3_disk* log_u, u3_fact* tac_u);
 
-      /* u3_disk_epoc_init(): create new epoch.
-       */
-        c3_o
-        u3_disk_epoc_roll(u3_disk* log_u, c3_d epo_d);
-
-      /* u3_disk_epoc_kill(): delete an epoch.
-       */
-        c3_o
-        u3_disk_epoc_kill(u3_disk* log_u, c3_d epo_d);
-
       /* u3_disk_epoc_last(): get latest epoch number.
        */
         c3_o
@@ -1042,6 +1032,16 @@
       */
         void
         u3_disk_kindly(u3_disk* log_u, c3_d eve_d);
+
+      /* u3_disk_chop(): delete all but the latest 2 epocs.
+       */
+        void
+        u3_disk_chop(u3_disk* log_u, c3_d epo_d);
+
+      /* u3_disk_roll(): rollover to a new epoc.
+       */
+        void
+        u3_disk_roll(u3_disk* log_u, c3_d epo_d);
 
       /* u3_disk_read_list(): synchronously read a cons list of events.
       */


### PR DESCRIPTION
This PR changes the chop command, removing log rollover so as to be effective even when (nearly) out of disk space. It also includes refactoring of the epoc lifecycle operations to centralize the enforcement of their invariants, and improves error handling throughout.