### PR TITLE
http: dynamic responses for empty cache entries

### DIFF
--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -111,6 +111,8 @@ typedef struct _u3_httd {
   u3p(u3h_root)      nax_p;             //  scry->noun cache
 } u3_httd;
 
+static u3_weak _http_rec_to_httq(h2o_req_t* rec_u);
+static u3_hreq* _http_req_prepare(h2o_req_t* rec_u, u3_hreq* (*new_f)(u3_hcon*, h2o_req_t*));
 static void _http_serv_free(u3_http* htp_u);
 static void _http_serv_start_all(u3_httd* htd_u);
 static void _http_form_free(u3_httd* htd_u);
@@ -673,7 +675,19 @@ _http_cache_respond(u3_hreq* req_u, u3_noun nun) {
   u3_httd* htd_u = req_u->hon_u->htp_u->htd_u;
 
   if ( u3_nul == nun ) {
-    h2o_send_error_404(rec_u, "Not Found", "not found", 0);
+    u3_weak req = _http_rec_to_httq(rec_u);
+    if ( u3_none == req ) {
+      if ( (u3C.wag_w & u3o_verbose) ) {
+        u3l_log("strange %.*s request", (c3_i)rec_u->method.len,
+                rec_u->method.base);
+      }
+      c3_c* msg_c = "bad request";
+      h2o_send_error_generic(rec_u, 400, msg_c, msg_c, 0);
+    }
+    else {
+      u3_hreq* req_u = _http_req_prepare(rec_u, _http_req_new);
+      _http_req_dispatch(req_u, req);
+    }
   }
   else if ( u3_none == u3r_at(7, nun) ) {
     h2o_send_error_500(rec_u, "Internal Server Error", "scry failed", 0);


### PR DESCRIPTION
If the cache entry for any given url was cleared, this would be indicated by a null entry for that url, and vere would serve a 404 for those cases, instead of falling back to the normal, dynamic behavior of injecting the request into eyre.

Here, we make eyre serve from the cache only if there is a full cache entry for the url, and have it proceed into normal request injection logic otherwise.

This way, setting a cached response for some url no longer means giving up dynamic responses on that url for the rest of time.

Recent versions of eyre exhibit the same behavior. As such, in practice, this code won't change the observed behavior without a similarly-patched version of eyre. For that, see the sister PR, urbit/urbit#6909.

The bulk of the updated logic in `_http_cache_respond()` comes from `_http_rec_accept()`, but due to differences in cache checking behavior it isn't a 1:1 match, so it seemed simplest for now to just duplicate the logic, rather than introduce another intermediary request handling function.

Resolves urbit/urbit#6702.
