### PR TITLE
http: do not double free scry cache path

### DIFF
--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -714,7 +714,6 @@ _http_cache_scry_cb(void* vod_p, u3_noun nun)
   }
 
   u3h_put(htd_u->nax_p, peq_u->pax, nun);
-  u3z(peq_u->pax);
   c3_free(peq_u);
 }
 

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -714,6 +714,7 @@ _http_cache_scry_cb(void* vod_p, u3_noun nun)
   }
 
   u3h_put(htd_u->nax_p, peq_u->pax, nun);
+  u3z(peq_u->pax);
   c3_free(peq_u);
 }
 
@@ -728,6 +729,8 @@ _http_req_cache(u3_hreq* req_u)
 
   u3_noun url = u3dc("scot", 't', _http_vec_to_atom(req_u->rec_u->path));
   u3_weak sac = u3h_get(htd_u->sax_p, url);
+  u3z(url);
+  
   if ( u3_none == sac ) {
     return c3n;
   }
@@ -738,7 +741,7 @@ _http_req_cache(u3_hreq* req_u)
     req_u->peq_u        = c3_malloc(sizeof(*req_u->peq_u));
     req_u->peq_u->req_u = req_u;
     req_u->peq_u->htd_u = htd_u;
-    req_u->peq_u->pax   = sac;
+    req_u->peq_u->pax   = u3k(sac);
 
     req_u->sat_e = u3_rsat_peek;
 


### PR DESCRIPTION
Resolves #604

The root of the issue here is that `sax_p` and `nax_p` contain the same noun. The value from `sax_p` later becomes the key for `nax_p`. When we later free both maps in `_http_io_exit` we end up with a double free.
