### PR TITLE
v3-migrate: ream before reclaiming bytecode caches

### DIFF
--- a/pkg/noun/v3/manage.c
+++ b/pkg/noun/v3/manage.c
@@ -36,6 +36,10 @@ u3m_v3_migrate()
   u3R_v2 = &u3H_v2->rod_u;
   u3R_v2->cap_p = u3R_v2->mat_p = u3a_v2_outa(u3H_v2);
 
+  u3R = (u3a_road*)u3R_v2;
+  u3H = (u3v_home*)u3H_v2;
+  u3a_ream();
+
   //  free bytecode caches in old road
   u3j_v2_reclaim();
   u3n_v2_reclaim();


### PR DESCRIPTION
Some ships migrating to vere-v3.0 experienced "loom: corrupt" when reclaiming the bytecode caches when running the v3 migration. This PR does fix the issue, but it may or may not be exactly right. @joemfb will have to take a look.