### PR TITLE
Revert "u3: restore old-style, efficient reap to u3m_love()"

### DIFF
--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -898,31 +898,6 @@ u3h_take(u3p(u3h_root) har_p)
   return u3h_take_with(har_p, u3a_take);
 }
 
-/* _ch_take_uni_cb(): take a key/value pair, put into [dst_p].
-*/
-static void
-_ch_take_uni_cb(u3_cell kev, void* wit)
-{
-  u3a_cell* kev_u = u3a_to_ptr(kev);
-  u3_noun     key = u3a_take(kev_u->hed);
-  u3_noun     val = u3a_take(kev_u->tel);
-
-  {
-    u3p(u3h_root) dst_p = *(u3p(u3h_root)*)wit;
-    u3h_put(dst_p, key, val);
-  }
-
-  u3z(key);
-}
-
-/* u3h_take_uni(): take entries from [src_p], put into [dst_p].
-*/
-void
-u3h_take_uni(u3p(u3h_root) dst_p, u3p(u3h_root) src_p)
-{
-  u3h_walk_with(src_p, _ch_take_uni_cb, &dst_p);
-}
-
 /* _ch_mark_buck(): mark bucket for gc.
 */
 c3_w

--- a/pkg/noun/hashtable.h
+++ b/pkg/noun/hashtable.h
@@ -179,11 +179,6 @@
         u3p(u3h_root)
         u3h_take(u3p(u3h_root) har_p);
 
-      /* u3h_take_uni(): take entries from [src_p], put into [dst_p].
-      */
-        void
-        u3h_take_uni(u3p(u3h_root) dst_p, u3p(u3h_root) src_p);
-
       /* u3h_wyt(): number of entries
       */
         c3_w

--- a/pkg/noun/jets.c
+++ b/pkg/noun/jets.c
@@ -1981,65 +1981,94 @@ u3j_rite_mine(u3j_rite* rit_u, u3_noun clu, u3_noun cor)
   u3t_off(glu_o);
 }
 
-/* _cj_reap_hank(): promote call site.
+/* _cj_take_hank_cb(): u3h_take_with cb for taking hanks
 */
-static void
-_cj_reap_hank(u3_cell kev)
+static u3p(u3j_hank)
+_cj_take_hank_cb(u3p(u3j_hank) nah_p)
 {
-  u3a_cell* kev_u = u3a_to_ptr(kev);
-  u3j_hank* nah_u = u3to(u3j_hank, kev_u->tel);
-  u3j_hank* han_u;
-  u3_weak     got;
-  u3_noun     key;
+  u3j_hank* nah_u = u3to(u3j_hank, nah_p);
+  u3j_hank* han_u = u3a_walloc(c3_wiseof(u3j_hank));
 
   if ( u3_none == nah_u->hax ) {
-    return;
+    han_u->hax = u3_none;
+    // han_u->sit_u left uninitialized, will be ignored
   }
-
-  //  you have to keep what you take
-  //
-  key = u3a_take(kev_u->hed);
-  got = u3h_git(u3R->jed.han_p, key);
-
-  //  promote
-  //
-  if ( u3_none == got ) {
-    han_u      = u3a_walloc(c3_wiseof(u3j_hank));
+  else {
     han_u->hax = u3a_take(nah_u->hax);
     u3j_site_take(&(han_u->sit_u), &(nah_u->sit_u));
   }
-  //  integrate
-  //
-  else {
-    u3_weak old;
 
-    han_u      = u3to(u3j_hank, got);
-    old        = han_u->hax;
-    han_u->hax = u3a_take(nah_u->hax);
-    u3j_site_take(&(nah_u->sit_u), &(nah_u->sit_u));
-    u3j_site_merge(&(han_u->sit_u), &(nah_u->sit_u));
+  return u3of(u3j_hank, han_u);
+}
 
-    if ( u3_none != old ) {
-      u3z(old);
-    }
+/* u3j_take(): copy junior jet state.
+*/
+u3a_jets
+u3j_take(u3a_jets jed_u)
+{
+  jed_u.war_p = u3h_take(jed_u.war_p);
+  jed_u.cod_p = u3h_take(jed_u.cod_p);
+  jed_u.han_p = u3h_take_with(jed_u.han_p, _cj_take_hank_cb);
+  jed_u.bas_p = u3h_take(jed_u.bas_p);
+  return jed_u;
+}
+
+/* _cj_merge_hank_cb(): u3h_uni_with cb for integrating taken hanks
+**  NB "transfers" or frees hanks in jed_u.han_p
+*/
+static void
+_cj_merge_hank_cb(u3_noun kev, void* wit)
+{
+  u3p(u3h_root) han_p = *(u3p(u3h_root)*)wit;
+  u3j_hank* nah_u;
+  u3_noun key;
+  u3p(u3j_hank) nah_p;
+  u3x_cell(kev, &key, &nah_p);
+
+  nah_u = u3to(u3j_hank, nah_p);
+
+  if ( u3_none == nah_u->hax ) {
+    u3a_wfree(nah_u);
   }
+  else {
+    u3j_hank* han_u;
+    u3_weak     got = u3h_git(u3R->jed.han_p, key);
 
-  u3h_put(u3R->jed.han_p, key, u3of(u3j_hank, han_u));
-  u3z(key);
+    if ( u3_none == got )  {
+      han_u = nah_u;
+    }
+    else {
+      han_u = u3to(u3j_hank, got);
+
+      if ( u3_none != han_u->hax ) {
+        u3z(han_u->hax);
+      }
+      han_u->hax = nah_u->hax;
+
+      u3j_site_merge(&(han_u->sit_u), &(nah_u->sit_u));
+      u3a_wfree(nah_u);
+    }
+
+    u3h_put(han_p, key, u3of(u3j_hank, han_u));
+  }
 }
 
 /* u3j_reap(): promote jet state.
 */
 void
-u3j_reap(u3a_jets* jed_u)
+u3j_reap(u3a_jets jed_u)
 {
-  u3h_take_uni(u3R->jed.cod_p, jed_u->cod_p);
-  //  call sites must be reaped before the warm dashboard;
-  //  they may contain references to labels on this road
-  //
-  u3h_walk(jed_u->han_p, _cj_reap_hank);
-  u3h_take_uni(u3R->jed.war_p, jed_u->war_p);
-  u3h_take_uni(u3R->jed.bas_p, jed_u->bas_p);
+  u3h_uni(u3R->jed.war_p, jed_u.war_p);
+  u3h_free(jed_u.war_p);
+
+  u3h_uni(u3R->jed.cod_p, jed_u.cod_p);
+  u3h_free(jed_u.cod_p);
+
+  u3h_walk_with(jed_u.han_p, _cj_merge_hank_cb, &u3R->jed.han_p);
+  u3h_free(jed_u.han_p);
+
+  u3h_uni(u3R->jed.bas_p, jed_u.bas_p);
+  u3h_free(jed_u.bas_p);
 }
 
 /* _cj_ream(): ream list of battery [bash registry] pairs. RETAIN.

--- a/pkg/noun/jets.h
+++ b/pkg/noun/jets.h
@@ -215,7 +215,12 @@
       /* u3j_reap(): promote jet state.
       */
         void
-        u3j_reap(u3a_jets* jed_u);
+        u3j_reap(u3a_jets jed_u);
+
+      /* u3j_take(): copy junior jet state.
+      */
+        u3a_jets
+        u3j_take(u3a_jets jed_u);
 
       /* u3j_rite_mine(): mine cor with clu, using u3j_rite for caching
       */

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1007,20 +1007,23 @@ u3m_love(u3_noun pro)
   //
   u3m_fall();
 
-  //  copy product off our stack
+  //  copy product and caches off our stack
   //
-  pro = u3a_take(pro);
-
-  //  integrate junior caches
-  //
-  u3j_reap(&jed_u);
-  u3n_reap(byc_p);
-  u3z_reap(per_p);
+  pro   = u3a_take(pro);
+  jed_u = u3j_take(jed_u);
+  byc_p = u3n_take(byc_p);
+  per_p = u3h_take(per_p);
 
   //  pop the stack
   //
   u3R->cap_p = u3R->ear_p;
   u3R->ear_p = 0;
+
+  //  integrate junior caches
+  //
+  u3j_reap(jed_u);
+  u3n_reap(byc_p);
+  u3z_reap(u3z_memo_keep, per_p);
 
   return pro;
 }

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -2879,11 +2879,12 @@ _cn_take_prog_dat(u3n_prog* dst_u, u3n_prog* src_u)
   }
 }
 
-/*  _cn_take_prog(): take junior u3n_prog.
+/*  _cn_take_prog_cb(): u3h_take_with cb for taking junior u3n_prog's.
 */
-static u3n_prog*
-_cn_take_prog(u3n_prog* pog_u)
+static u3p(u3n_prog)
+_cn_take_prog_cb(u3p(u3n_prog) pog_p)
 {
+  u3n_prog* pog_u = u3to(u3n_prog, pog_p);
   u3n_prog* gop_u;
 
   if ( c3y == pog_u->byc_u.own_o ) {
@@ -2899,8 +2900,17 @@ _cn_take_prog(u3n_prog* pog_u)
   }
 
   _cn_take_prog_dat(gop_u, pog_u);
+  // _n_prog_take_dat(gop_u, pog_u, c3n);
 
-  return gop_u;
+  return u3of(u3n_prog, gop_u);
+}
+
+/* u3n_take(): copy junior bytecode state.
+*/
+u3p(u3h_root)
+u3n_take(u3p(u3h_root) har_p)
+{
+  return u3h_take_with(har_p, _cn_take_prog_cb);
 }
 
 /* _cn_merge_prog_dat(): copy references from src_u u3n_prog to dst_u.
@@ -2935,36 +2945,29 @@ _cn_merge_prog_dat(u3n_prog* dst_u, u3n_prog* src_u)
   }
 }
 
-/* _cn_reap_prog_cb(): promote junior bytecode entry.
+/*  _cn_merge_prog_cb(): u3h_walk_with cb for integrating taken u3n_prog's.
 */
 static void
-_cn_reap_prog_cb(u3_cell kev)
+_cn_merge_prog_cb(u3_noun kev, void* wit)
 {
-  u3a_cell* kev_u = u3a_to_ptr(kev);
-  u3_noun     key = u3a_take(kev_u->hed);
-  u3n_prog* pog_u = u3to(u3n_prog, kev_u->tel);
-  u3_weak     got = u3h_git(u3R->byc.har_p, key);
+  u3p(u3h_root) har_p = *(u3p(u3h_root)*)wit;
+  u3n_prog*     pog_u;
+  u3_weak         got;
+  u3_noun         key;
+  u3p(u3n_prog) pog_p;
+  u3x_cell(kev, &key, &pog_p);
 
-  //  promote
-  //
-  if ( u3_none == got ) {
-    pog_u = _cn_take_prog(pog_u);
-  }
-  //  integrate
-  //
-  else {
+  pog_u = u3to(u3n_prog, pog_p);
+  got   = u3h_git(har_p, key);
+
+  if ( u3_none != got ) {
     u3n_prog* sep_u = u3to(u3n_prog, got);
-    _cn_take_prog_dat(pog_u, pog_u);
     _cn_merge_prog_dat(sep_u, pog_u);
+    u3a_free(pog_u);
     pog_u = sep_u;
   }
 
-  //  we must always put, because we have taken.
-  //  we must always keep what we have taken,
-  //  or we can break relocation pointers.
-  //
-  u3h_put(u3R->byc.har_p, key, u3of(u3n_prog, pog_u));
-  u3z(key);
+  u3h_put(har_p, key, u3of(u3n_prog, pog_u));
 }
 
 /* u3n_reap(): promote bytecode state.
@@ -2972,7 +2975,9 @@ _cn_reap_prog_cb(u3_cell kev)
 void
 u3n_reap(u3p(u3h_root) har_p)
 {
-  u3h_walk(har_p, _cn_reap_prog_cb);
+  u3h_walk_with(har_p, _cn_merge_prog_cb, &u3R->byc.har_p);
+  // NB *not* u3n_free, _cn_merge_prog_cb() transfers u3n_prog's
+  u3h_free(har_p);
 }
 
 /* _n_ream(): ream program call sites

--- a/pkg/noun/nock.h
+++ b/pkg/noun/nock.h
@@ -116,6 +116,11 @@
       void
       u3n_reap(u3p(u3h_root) har_p);
 
+    /* u3n_take(): copy junior bytecode state.
+     */
+      u3p(u3h_root)
+      u3n_take(u3p(u3h_root) har_p);
+
     /* u3n_mark(): mark bytecode cache.
      */
       c3_w

--- a/pkg/noun/zave.c
+++ b/pkg/noun/zave.c
@@ -125,7 +125,10 @@ u3z_uniq(u3z_cid cid, u3_noun som)
 /* u3z_reap(): promote memoization cache state.
 */
 void
-u3z_reap(u3p(u3h_root) per_p)
+u3z_reap(u3z_cid cid, u3p(u3h_root) har_p)
 {
-  u3h_take_uni(u3R->cax.per_p, per_p);
+  u3_assert(u3z_memo_toss != cid);
+
+  u3h_uni(_har(u3R, cid), har_p);
+  u3h_free(har_p);
 }

--- a/pkg/noun/zave.h
+++ b/pkg/noun/zave.h
@@ -50,10 +50,10 @@
       u3_noun
       u3z_uniq(u3z_cid cid, u3_noun som);
 
-    /* u3z_reap(): promote persistent memoization cache.
+    /* u3z_reap(): promote memoization cache state.
     */
       void
-      u3z_reap(u3p(u3h_root) per_p);
+      u3z_reap(u3z_cid cid, u3p(u3h_root) har_p);
 
     /* u3z_free(): free memoization cache.
     */


### PR DESCRIPTION
Reverts urbit/vere#538

My ship ran into a refcounting bug during pre-release testing of vere-v3.0. The only part of the release that touches the relevant codepath is this PR, so we have decided to revert it.