### PR TITLE
vere: adds --gc-early flag to pack and meld subcommands

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -2151,6 +2151,15 @@ u3m_boot(c3_c* dir_c, size_t len_i)
   */
   u3m_pave(nuu_o);
 
+  /* GC immediately if requested
+  */
+  if ( (c3n == nuu_o) && (u3C.wag_w & u3o_check_corrupt) ) {
+    u3l_log("boot: gc requested");
+    u3m_grab(u3_none);
+    u3C.wag_w &= ~u3o_check_corrupt;
+    u3l_log("boot: gc complete");
+  }
+
   /* Initialize the jet system.
   */
   {

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1901,6 +1901,7 @@ _cw_meld(c3_i argc, c3_c* argv[])
     { "no-demand", no_argument,       NULL, 6 },
     { "swap",      no_argument,       NULL, 7 },
     { "swap-to",   required_argument, NULL, 8 },
+    { "gc-early",  no_argument,       NULL, 9 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1928,6 +1929,11 @@ _cw_meld(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.eph = c3y;
         u3C.wag_w |= u3o_swap;
         u3C.eph_c = strdup(optarg);
+        break;
+      }
+
+      case 9: {  //  gc-early
+        u3C.wag_w |= u3o_check_corrupt;
         break;
       }
 
@@ -2063,6 +2069,7 @@ _cw_pack(c3_i argc, c3_c* argv[])
     { "no-demand", no_argument,       NULL, 6 },
     { "swap",      no_argument,       NULL, 7 },
     { "swap-to",   required_argument, NULL, 8 },
+    { "gc-early",  no_argument,       NULL, 9 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -2090,6 +2097,11 @@ _cw_pack(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.eph = c3y;
         u3C.wag_w |= u3o_swap;
         u3C.eph_c = strdup(optarg);
+        break;
+      }
+
+      case 9: {  //  gc-early
+        u3C.wag_w |= u3o_check_corrupt;
         break;
       }
 


### PR DESCRIPTION
... to support repairing errant refcounts interfering with the boot process.