### PR TITLE
stun: corrects response decoding, adds tests

### DIFF
--- a/pkg/vere/BUILD.bazel
+++ b/pkg/vere/BUILD.bazel
@@ -183,6 +183,12 @@ vere_binary(
 # TESTS
 #
 
+
+cc_library(
+  name = "ames_src",
+  hdrs = ["io/ames.c"],
+)
+
 cc_test(
     name = "ames_tests",
     timeout = "short",
@@ -192,7 +198,7 @@ cc_test(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],
-    deps = [":vere"],
+    deps = [":vere", ":ames_src"]
 )
 
 cc_test(

--- a/pkg/vere/ames_tests.c
+++ b/pkg/vere/ames_tests.c
@@ -40,13 +40,7 @@ _test_stun(void)
   c3_y    req_y[20] = {0};
   c3_i    ret_i     = 0;
 
-  struct sockaddr_in add_u;
-  memset(&add_u, 0, sizeof(add_u));
-  add_u.sin_family      = AF_INET;
-  add_u.sin_addr.s_addr = htonl(inn_u.pip_w);
-  add_u.sin_port        = htons(inn_u.por_s);
-
-  _stun_make_response(req_y, &add_u, rep_y);
+  _stun_make_response(req_y, &inn_u, rep_y);
 
   u3_lane lan_u;
 

--- a/pkg/vere/ames_tests.c
+++ b/pkg/vere/ames_tests.c
@@ -1,7 +1,6 @@
 /// @file
 
-#include "noun.h"
-#include "vere.h"
+#include "./io/ames.c"
 
 /* _setup(): prepare for tests.
 */

--- a/pkg/vere/ames_tests.c
+++ b/pkg/vere/ames_tests.c
@@ -32,15 +32,14 @@ _test_ames(void)
 }
 
 static c3_i
-_test_stun(void)
+_test_stun_addr_roundtrip(u3_lane* inn_u)
 {
-  u3_lane inn_u     = { .pip_w = 0x7f000001, .por_s = 13337 };
   c3_c    res_c[16] = {0};
   c3_y    rep_y[40];
   c3_y    req_y[20] = {0};
   c3_i    ret_i     = 0;
 
-  _stun_make_response(req_y, &inn_u, rep_y);
+  _stun_make_response(req_y, inn_u, rep_y);
 
   u3_lane lan_u;
 
@@ -49,18 +48,36 @@ _test_stun(void)
     ret_i = 1;
   }
   else {
-    if ( lan_u.pip_w != inn_u.pip_w ) {
-      fprintf(stderr, "stun: addr mismatch %x %x\r\n", lan_u.pip_w, inn_u.pip_w);
+    if ( lan_u.pip_w != inn_u->pip_w ) {
+      fprintf(stderr, "stun: addr mismatch %x %x\r\n", lan_u.pip_w, inn_u->pip_w);
       ret_i = 1;
     }
 
-    if ( lan_u.por_s != inn_u.por_s ) {
-      fprintf(stderr, "stun: addr mismatch %u %u\r\n", lan_u.por_s, inn_u.por_s);
+    if ( lan_u.por_s != inn_u->por_s ) {
+      fprintf(stderr, "stun: addr mismatch %u %u\r\n", lan_u.por_s, inn_u->por_s);
       ret_i = 1;
     }
   }
 
   return ret_i;
+}
+
+static c3_i
+_test_stun(void)
+{
+  u3_lane inn_u = { .pip_w = 0x7f000001, .por_s = 13337 };
+  c3_w    len_w = 256;
+
+  while ( len_w-- ) {
+    if ( _test_stun_addr_roundtrip(&inn_u) ) {
+      return 1;
+    }
+
+    inn_u.pip_w++;
+    inn_u.por_s++;
+  }
+
+  return 0;
 }
 
 /* main(): run all test cases.

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -1730,16 +1730,14 @@ _stun_find_xor_mapped_address(c3_y* buf_y, c3_w buf_len, u3_lane* lan_u)
 
     cur += 2;
 
-    c3_s port = htons(_ames_sift_short(buf_y + cur)) ^ cookie >> 16;
-    c3_w ip = ntohl(htonl(_ames_sift_word(buf_y + cur + 2)) ^ cookie);
-
-    lan_u->por_s = ntohs(port);
-    lan_u->pip_w = ip;
+    lan_u->por_s = ntohs(_ames_sift_short(buf_y + cur)) ^ (cookie >> 16);
+    lan_u->pip_w = ntohl(_ames_sift_word(buf_y + cur + 2)) ^ cookie;
 
     if ( u3C.wag_w & u3o_verbose ) {
-      c3_c ip_str[INET_ADDRSTRLEN];
-      inet_ntop(AF_INET, &ip, ip_str, INET_ADDRSTRLEN);
-      u3l_log("stun: hear ip:port %s:%u", ip_str, port);
+      c3_w nip_w = htonl(lan_u->pip_w);
+      c3_c nip_c[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, &nip_w, nip_c, INET_ADDRSTRLEN);
+      u3l_log("stun: hear ip:port %s:%u", nip_c, lan_u->por_s);
     }
     return c3y;
   }

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -1449,51 +1449,51 @@ _stun_on_request(u3_ames*              sam_u,
 static void
 _stun_on_response(u3_ames* sam_u, c3_y* buf_y, c3_w buf_len)
 {
-  u3_stun_state old_y = sam_u->sun_u.sat_y;
-
   u3_lane lan_u;
 
   //  Ignore STUN responses that dont' have the XOR-MAPPED-ADDRESS attribute
   if ( c3n == _stun_find_xor_mapped_address(buf_y, buf_len, &lan_u) ) {
     return;
   }
-  u3_noun wir = u3nc(c3__ames, u3_nul);
-  if (sam_u->sun_u.wok_o == c3n) {
-    // stop %ping app
-    u3_noun cad = u3nq(c3__stun, c3__stop, sam_u->sun_u.dad_y,
-                       u3nc(c3n, u3_ames_encode_lane(lan_u)));
-    u3_ovum *ovo_u = u3_ovum_init(0, c3__ames, wir, cad);
-    u3_auto_plan(&sam_u->car_u, ovo_u);
-    sam_u->sun_u.wok_o = c3y;
-  }
-  else if ( (sam_u->sun_u.sef_u.por_s != lan_u.por_s) ||
-            (sam_u->sun_u.sef_u.pip_w != lan_u.pip_w) )
+
+  if ( (sam_u->sun_u.sef_u.por_s != lan_u.por_s) ||
+       (sam_u->sun_u.sef_u.pip_w != lan_u.pip_w) )
   {
     // lane changed
+    u3_noun wir = u3nc(c3__ames, u3_nul);
     u3_noun cad = u3nq(c3__stun, c3__once, sam_u->sun_u.dad_y,
                        u3nc(c3n, u3_ames_encode_lane(lan_u)));
-    u3_ovum *ovo_u = u3_ovum_init(0, c3__ames, wir, cad);
-    u3_auto_plan(&sam_u->car_u, ovo_u);
+    u3_auto_plan(&sam_u->car_u,
+                 u3_ovum_init(0, c3__ames, wir, cad));
   }
-  else {
-    u3z(wir);
+  else if ( c3n == sam_u->sun_u.wok_o ) {
+    // stop %ping app
+    u3_noun wir = u3nc(c3__ames, u3_nul);
+    u3_noun cad = u3nq(c3__stun, c3__stop, sam_u->sun_u.dad_y,
+                       u3nc(c3n, u3_ames_encode_lane(lan_u)));
+    u3_auto_plan(&sam_u->car_u,
+                 u3_ovum_init(0, c3__ames, wir, cad));
+    sam_u->sun_u.wok_o = c3y;
   }
+
   sam_u->sun_u.sef_u = lan_u;
 
   switch ( sam_u->sun_u.sat_y ) {
-  case STUN_OFF: break;       //  ignore; stray response
-  case STUN_KEEPALIVE: break; //  ignore; duplicate response
-  case STUN_TRYING: {
-    sam_u->sun_u.sat_y = STUN_KEEPALIVE;
-    if ( ent_getentropy(sam_u->sun_u.tid_y, 12) ) {
-      u3l_log("stun: getentropy fail: %s", strerror(errno));
-      _stun_on_lost(sam_u);
-    }
-    else {
-      uv_timer_start(&sam_u->sun_u.tim_u, _stun_timer_cb, 25*1000, 0);
-    }
-  } break;
-  default: assert("programmer error");
+    case STUN_OFF:       break; //  ignore; stray response
+    case STUN_KEEPALIVE: break; //  ignore; duplicate response
+
+    case STUN_TRYING: {
+      sam_u->sun_u.sat_y = STUN_KEEPALIVE;
+      if ( ent_getentropy(sam_u->sun_u.tid_y, 12) ) {
+        u3l_log("stun: getentropy fail: %s", strerror(errno));
+        _stun_on_lost(sam_u);
+      }
+      else {
+        uv_timer_start(&sam_u->sun_u.tim_u, _stun_timer_cb, 25*1000, 0);
+      }
+    } break;
+
+    default: assert("programmer error");
   }
 }
 

--- a/pkg/vere/mdns.c
+++ b/pkg/vere/mdns.c
@@ -61,7 +61,7 @@ static void resolve_cb(DNSServiceRef sref,
   payload->sref = sref;
   payload->port = port;
 
-  char *start = name;
+  const char *start = name;
   if (strncmp(name, "fake-", 4) == 0) {
     payload->fake = 1;
     start = name + 5;


### PR DESCRIPTION
While debugging urbit/urbit#6936, we discovered that the STUN client implementation is incorrectly parsing ip/port pairs from responses. This has no effect on the behavior of informal pinging as written, which is only using the responses to detect changes in network topology. But we may want to use those values at some point, so it's best to correct them sooner rather than later.

This PR includes tests, and some minor refactoring of the STUN protocol implementations to facilitate testing.