### PR TITLE
jets: for new atom ops

### DIFF
--- a/pkg/c3/defs.h
+++ b/pkg/c3/defs.h
@@ -5,6 +5,7 @@
 
 #include "portable.h"
 #include "types.h"
+#include <limits.h>
 
 #include <errno.h>
 
@@ -51,7 +52,19 @@
 
     /* Bit counting.
     */
-#     define c3_bits_word(w) ((w) ? (32 - __builtin_clz(w)) : 0)
+#if   (32 == (CHAR_BIT * __SIZEOF_INT__))
+#     define c3_lz_w __builtin_clz
+#     define c3_tz_w __builtin_ctz
+#     define c3_pc_w __builtin_popcount
+#elif (32 == (CHAR_BIT * __SIZEOF_LONG__))
+#     define c3_lz_w __builtin_clzl
+#     define c3_tz_w __builtin_ctzl
+#     define c3_pc_w __builtin_popcountl
+#else
+#     error  "port me"
+#endif
+
+#     define c3_bits_word(w) ((w) ? (32 - c3_lz_w(w)) : 0)
 
     /* Min and max.
     */

--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -54,7 +54,7 @@ u3h_new(void)
 static c3_w
 _ch_popcount(c3_w num_w)
 {
-  return __builtin_popcount(num_w);
+  return c3_pc_w(num_w);
 }
 
 /* _ch_buck_new(): create new bucket.

--- a/pkg/noun/jets/c/clz.c
+++ b/pkg/noun/jets/c/clz.c
@@ -1,0 +1,75 @@
+/// @file
+
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+u3_atom
+u3qc_clz(u3_atom boq, u3_atom sep, u3_atom a)
+{
+  if ( !_(u3a_is_cat(boq)) || (boq >= 32) ) {
+    return u3m_bail(c3__fail);
+  }
+
+  if ( !_(u3a_is_cat(sep)) ) {
+    return u3m_bail(c3__fail);
+  }
+
+  c3_g boq_g = boq;
+  c3_w sep_w = sep;
+  c3_w tot_w = sep_w << boq_g;
+
+  if ( (tot_w >> boq_g) != sep_w ) {
+    return u3m_bail(c3__fail);
+  }
+
+  c3_w met_w = u3r_met(0, a);
+
+  if ( met_w <= tot_w ) {
+    tot_w -= met_w;
+    return u3i_word(tot_w);
+  }
+  else {
+    c3_w wid_w = tot_w >>  5;
+    c3_w bit_w = tot_w  & 31;
+    c3_w wor_w;
+
+    if ( bit_w ) {
+      wor_w  = u3r_word(wid_w, a);
+      wor_w &= (1 << bit_w) - 1;
+
+      if ( wor_w ) {
+        return bit_w - (32 - c3_lz_w(wor_w));
+      }
+    }
+
+    while ( wid_w-- ) {
+      wor_w = u3r_word(wid_w, a);
+
+      if ( wor_w ) {
+        bit_w += c3_lz_w(wor_w);
+        break;
+      }
+
+      bit_w += 32;
+    }
+
+    return u3i_word(bit_w);
+  }
+}
+
+u3_noun
+u3wc_clz(u3_noun cor)
+{
+  u3_atom boq, sep, vat;
+  {
+    u3_noun sam = u3h(u3t(cor));
+    u3_noun bit = u3h(sam);
+
+    u3x_bite(bit, &boq, &sep);
+    vat = u3x_atom(u3t(sam));
+  }
+
+  return u3qc_clz(boq, sep, vat);
+}

--- a/pkg/noun/jets/c/ctz.c
+++ b/pkg/noun/jets/c/ctz.c
@@ -1,0 +1,34 @@
+/// @file
+
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+u3_atom
+u3qc_ctz(u3_atom a)
+{
+  c3_w wor_w, i_w;
+
+  if ( 0 == a ) {
+    return 0;
+  }
+
+  do {
+    wor_w = u3r_word(i_w++, a);
+  }
+  while ( !wor_w );
+
+  {
+    c3_w bit_d = i_w - 1;
+    bit_d *= 32;
+    bit_d += c3_tz_w(wor_w);
+    return u3i_chub(bit_d);
+  }
+}
+
+u3_noun
+u3wc_ctz(u3_noun cor)
+{
+  return u3qc_ctz(u3x_atom(u3h(u3t(cor))));
+}

--- a/pkg/noun/jets/c/ctz.c
+++ b/pkg/noun/jets/c/ctz.c
@@ -8,7 +8,7 @@
 u3_atom
 u3qc_ctz(u3_atom a)
 {
-  c3_w wor_w, i_w;
+  c3_w wor_w, i_w = 0;
 
   if ( 0 == a ) {
     return 0;

--- a/pkg/noun/jets/c/ham.c
+++ b/pkg/noun/jets/c/ham.c
@@ -1,0 +1,27 @@
+/// @file
+
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+u3_atom
+u3qc_ham(u3_atom a)
+{
+  c3_w len_w = u3r_met(5, a);
+  c3_d pop_d = 0;
+  c3_w wor_w;
+
+  for ( c3_w i_w = 0; i_w < len_w; i_w++ ) {
+    wor_w  = u3r_word(i_w, a);
+    pop_d += c3_pc_w(wor_w);
+  }
+
+  return u3i_chub(pop_d);
+}
+
+u3_noun
+u3wc_ham(u3_noun cor)
+{
+  return u3qc_ham(u3x_atom(u3h(u3t(cor))));
+}

--- a/pkg/noun/jets/c/hew.c
+++ b/pkg/noun/jets/c/hew.c
@@ -1,0 +1,87 @@
+/// @file
+
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+static c3_w
+_hew_in(c3_g     a_g,
+        c3_w   pos_w,
+        u3_atom  vat,
+        u3_noun  sam,
+        u3_noun* out)
+{
+  u3_noun h, t, *l, *r;
+
+  while ( c3y == u3r_cell(sam, &h, &t) ) {
+    *out  = u3i_defcons(&l, &r);
+    pos_w = _hew_in(a_g, pos_w, vat, h, l);
+    sam   = t;
+    out   = r;
+  }
+
+  if ( !_(u3a_is_cat(sam)) ) {
+    return u3m_bail(c3__fail);
+  }
+
+  if ( !sam ) {
+    *out = 0;
+    return pos_w;
+  }
+  else {
+    c3_w     wid_w = (c3_w)sam;
+    c3_w     new_w = pos_w + wid_w;
+    u3i_slab sab_u;
+
+    if ( new_w < pos_w ) {
+      return u3m_bail(c3__fail);
+    }
+
+    u3i_slab_init(&sab_u, a_g, wid_w);
+    u3r_chop(a_g, pos_w, wid_w, 0, sab_u.buf_w, vat);
+
+    *out = u3i_slab_mint(&sab_u);
+    return new_w;
+  }
+}
+
+u3_noun
+u3qc_hew(u3_atom boq,
+         u3_atom sep,
+         u3_atom vat,
+         u3_noun sam)
+{
+  if ( !_(u3a_is_cat(boq)) || (boq >= 32) ) {
+    return u3m_bail(c3__fail);
+  }
+
+  if ( !_(u3a_is_cat(sep)) ) {
+    return u3m_bail(c3__fail);
+  }
+
+  u3_noun pro;
+  c3_w  pos_w = _hew_in((c3_g)boq, (c3_w)sep, vat, sam, &pro);
+  return u3nt(pro, boq, u3i_word(pos_w));
+}
+
+u3_noun
+u3wc_hew(u3_noun cor)
+{
+  u3_atom boq, sep, vat;
+  u3_noun sam;
+  {
+    u3_noun pay = u3t(cor);
+    u3_noun con = u3t(pay);
+    u3_noun gat = u3t(con);       // outer gate
+    u3_noun cam = u3h(u3t(gat));  // outer sample
+    u3_noun   d = u3h(con);
+
+    boq = u3x_atom(u3h(d));
+    sep = u3x_atom(u3t(d));
+    vat = u3x_atom(u3t(cam));
+    sam = u3h(pay);
+  }
+
+  return u3qc_hew(boq, sep, vat, sam);
+}

--- a/pkg/noun/jets/c/rig.c
+++ b/pkg/noun/jets/c/rig.c
@@ -1,0 +1,82 @@
+/// @file
+
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+c3_d
+u3qc_rig_s(c3_g foq_g,
+           c3_w sep_w,
+           c3_g toq_g)
+{
+  c3_d sep_d = sep_w;
+
+  if ( foq_g >= toq_g ) {
+    return sep_d << (foq_g - toq_g);
+  }
+  else {
+    c3_g dif_g = toq_g - foq_g;
+
+    sep_d += (1 << dif_g) - 1;
+    return sep_d >> dif_g;
+  }
+}
+
+u3_noun
+u3qc_rig(u3_atom foq,
+         u3_atom sep,
+         u3_atom toq)
+{
+  if ( c3y == u3r_sing(foq, toq) ) {
+    return u3k(sep);
+  }
+
+  if (  (c3y == u3a_is_cat(foq)) && (foq < 32)
+     && (c3y == u3a_is_cat(toq)) && (toq < 32)
+     && (c3y == u3a_is_cat(sep)) )
+  {
+    c3_d sep_d = u3qc_rig_s((c3_g)foq, (c3_w)sep, (c3_g)toq);
+    return u3i_chub(sep_d);
+  }
+
+  if ( c3y == u3qa_gth(foq, toq) ) {
+    u3_atom d = u3qa_sub(foq, toq);
+    u3_atom e = u3qc_lsh(0, d, sep);
+    u3z(d);
+    return e;
+  }
+  else {
+    u3_atom d = u3qa_sub(toq, foq);
+    u3_atom e = u3qc_rsh(0, d, sep);
+    u3_atom f = u3qc_end(0, d, sep);
+
+    if ( f ) {
+      e = u3i_vint(e);
+      u3z(f);
+    }
+
+    u3z(d);
+    return e;
+  }
+}
+
+u3_noun
+u3wc_rig(u3_noun cor)
+{
+  u3_atom boq, sep, vat;
+  {
+    u3_noun sam = u3h(u3t(cor));
+    u3_noun bit = u3h(sam);
+
+    if ( c3y == u3a_is_atom(bit) ) {
+      return 0;
+    }
+
+    boq = u3x_atom(u3h(bit));
+    sep = u3x_atom(u3t(bit));
+    vat = u3x_atom(u3t(sam));
+  }
+
+  return u3qc_rig(boq, sep, vat);
+}

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -62,6 +62,7 @@
     u3_noun u3qc_dvr(u3_atom, u3_atom);
     u3_noun u3qc_end(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_gor(u3_atom, u3_atom);
+    u3_noun u3qc_ham(u3_atom);
     u3_noun u3qc_lsh(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_mas(u3_atom);
     u3_noun u3qc_met(u3_atom, u3_atom);

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -71,10 +71,13 @@
     u3_noun u3qc_rap(u3_atom, u3_noun);
     u3_noun u3qc_rep(u3_atom, u3_atom, u3_noun);
     u3_noun u3qc_rev(u3_atom, u3_atom, u3_atom);
+    u3_noun u3qc_rig(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_rip(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_rsh(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_swp(u3_atom, u3_atom);
     u3_noun u3qc_sqt(u3_atom);
+
+    c3_d u3qc_rig_s(c3_g, c3_w, c3_g);
 
     u3_noun u3_po_find_prefix(c3_y one, c3_y two, c3_y three);
     u3_noun u3_po_find_suffix(c3_y one, c3_y two, c3_y three);

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -53,6 +53,7 @@
     u3_noun u3qc_can(u3_atom, u3_noun);
     u3_noun u3qc_cap(u3_atom);
     u3_noun u3qc_cat(u3_atom, u3_atom, u3_atom);
+    u3_noun u3qc_clz(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_con(u3_atom, u3_atom);
     u3_noun u3qc_cut(u3_atom, u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_dis(u3_atom, u3_atom);

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -55,6 +55,7 @@
     u3_noun u3qc_cat(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_clz(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_con(u3_atom, u3_atom);
+    u3_noun u3qc_ctz(u3_atom);
     u3_noun u3qc_cut(u3_atom, u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_dis(u3_atom, u3_atom);
     u3_noun u3qc_dor(u3_atom, u3_atom);

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -63,6 +63,7 @@
     u3_noun u3qc_end(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_gor(u3_atom, u3_atom);
     u3_noun u3qc_ham(u3_atom);
+    u3_noun u3qc_hew(u3_atom, u3_atom, u3_atom, u3_noun);
     u3_noun u3qc_lsh(u3_atom, u3_atom, u3_atom);
     u3_noun u3qc_mas(u3_atom);
     u3_noun u3qc_met(u3_atom, u3_atom);

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2552,17 +2552,17 @@ u3j_core _k138_d[] =
 };
 
 
-static u3j_harm _137_two_clz_a[] = {{".2", u3wc_clz, c3y}, {}};
-static u3j_harm _137_two_ctz_a[] = {{".2", u3wc_ctz, c3y}, {}};
-static u3j_harm _137_two_ham_a[] = {{".2", u3wc_ham, c3y}, {}};
+static u3j_harm _137_two_clz_a[] = {{".2", u3wc_clz, c3n}, {}};
+static u3j_harm _137_two_ctz_a[] = {{".2", u3wc_ctz, c3n}, {}};
+static u3j_harm _137_two_ham_a[] = {{".2", u3wc_ham, c3n}, {}};
 
-static u3j_harm _137_two__hew_fun_a[] = {{".2", u3wc_hew, c3y}, {}};
+static u3j_harm _137_two__hew_fun_a[] = {{".2", u3wc_hew, c3n}, {}};
 static u3j_core _137_two__hew_d[] =
   { { "fun", 15, _137_two__hew_fun_a, 0, no_hashes },
     {}
   };
 
-static u3j_harm _137_two_rig_a[] = {{".2", u3wc_rig, c3y}, {}};
+static u3j_harm _137_two_rig_a[] = {{".2", u3wc_rig, c3n}, {}};
 
 static u3j_core _137_two_d[] =
 { { "tri", 3, 0, _138_tri_d, no_hashes, _140_tri_ho },

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2555,6 +2555,13 @@ u3j_core _k138_d[] =
 static u3j_harm _137_two_clz_a[] = {{".2", u3wc_clz, c3y}, {}};
 static u3j_harm _137_two_ctz_a[] = {{".2", u3wc_ctz, c3y}, {}};
 static u3j_harm _137_two_ham_a[] = {{".2", u3wc_ham, c3y}, {}};
+
+static u3j_harm _137_two__hew_fun_a[] = {{".2", u3wc_hew, c3y}, {}};
+static u3j_core _137_two__hew_d[] =
+  { { "fun", 15, _137_two__hew_fun_a, 0, no_hashes },
+    {}
+  };
+
 static u3j_harm _137_two_rig_a[] = {{".2", u3wc_rig, c3y}, {}};
 
 static u3j_core _137_two_d[] =
@@ -2596,6 +2603,7 @@ static u3j_core _137_two_d[] =
   { "end",  7, _140_two_end_a, 0, no_hashes },
   { "gor",  7, _140_two_gor_a, 0, no_hashes },
   { "ham",  7, _137_two_ham_a, 0, no_hashes },
+  { "hew", 7, 0, _137_two__hew_d, no_hashes },
   { "jam",  7, _140_two_jam_a, 0, no_hashes },
   { "lsh",  7, _140_two_lsh_a, 0, no_hashes },
   { "mat",  7, _140_two_mat_a, 0, no_hashes },

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2554,6 +2554,7 @@ u3j_core _k138_d[] =
 
 static u3j_harm _137_two_clz_a[] = {{".2", u3wc_clz, c3y}, {}};
 static u3j_harm _137_two_ctz_a[] = {{".2", u3wc_ctz, c3y}, {}};
+static u3j_harm _137_two_ham_a[] = {{".2", u3wc_ham, c3y}, {}};
 static u3j_harm _137_two_rig_a[] = {{".2", u3wc_rig, c3y}, {}};
 
 static u3j_core _137_two_d[] =
@@ -2594,6 +2595,7 @@ static u3j_core _137_two_d[] =
   { "dor",  7, _140_two_dor_a, 0, no_hashes },
   { "end",  7, _140_two_end_a, 0, no_hashes },
   { "gor",  7, _140_two_gor_a, 0, no_hashes },
+  { "ham",  7, _137_two_ham_a, 0, no_hashes },
   { "jam",  7, _140_two_jam_a, 0, no_hashes },
   { "lsh",  7, _140_two_lsh_a, 0, no_hashes },
   { "mat",  7, _140_two_mat_a, 0, no_hashes },

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2552,6 +2552,8 @@ u3j_core _k138_d[] =
 };
 
 
+static u3j_harm _137_two_rig_a[] = {{".2", u3wc_rig, c3y}, {}};
+
 static u3j_core _137_two_d[] =
 { { "tri", 3, 0, _138_tri_d, no_hashes, _140_tri_ho },
 
@@ -2599,6 +2601,7 @@ static u3j_core _137_two_d[] =
   { "rap",  7, _140_two_rap_a, 0, no_hashes },
   { "rep",  7, _140_two_rep_a, 0, no_hashes },
   { "rev",  7, _140_two_rev_a, 0, no_hashes },
+  { "rig",  7, _137_two_rig_a, 0, no_hashes },
   { "rip",  7, _140_two_rip_a, 0, no_hashes },
   { "rsh",  7, _140_two_rsh_a, 0, no_hashes },
   { "swp",  7, _140_two_swp_a, 0, no_hashes },

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2552,6 +2552,95 @@ u3j_core _k138_d[] =
 };
 
 
+static u3j_core _137_two_d[] =
+{ { "tri", 3, 0, _138_tri_d, no_hashes, _140_tri_ho },
+
+  { "find", 7, _140_two_find_a, 0, no_hashes },
+  { "flop", 7, _140_two_flop_a, 0, no_hashes },
+  { "lent", 7, _140_two_lent_a, 0, no_hashes },
+  { "levy", 7, _140_two_levy_a, 0, no_hashes },
+  { "lien", 7, _140_two_lien_a, 0, no_hashes },
+  { "murn", 7, _140_two_murn_a, 0, no_hashes },
+  { "need", 7, _140_two_need_a, 0, no_hashes },
+  { "mate", 7, _138_two_mate_a, 0, no_hashes },
+  { "reap", 7, _140_two_reap_a, 0, no_hashes },
+  { "reel", 7, _140_two_reel_a, 0, no_hashes },
+  { "roll", 7, _140_two_roll_a, 0, no_hashes },
+  { "skid", 7, _140_two_skid_a, 0, no_hashes },
+  { "skim", 7, _140_two_skim_a, 0, no_hashes },
+  { "skip", 7, _140_two_skip_a, 0, no_hashes },
+  { "scag", 7, _140_two_scag_a, 0, no_hashes },
+  { "slag", 7, _140_two_slag_a, 0, no_hashes },
+  { "snag", 7, _140_two_snag_a, 0, no_hashes },
+  { "sort", 7, _140_two_sort_a, 0, no_hashes },
+  { "turn", 7, _140_two_turn_a, 0, no_hashes },
+  { "weld", 7, _140_two_weld_a, 0, no_hashes },
+  { "welp", 7, _140_two_welp_a, 0, no_hashes },
+  { "zing", 7, _140_two_zing_a, 0, no_hashes },
+
+  { "bex",  7, _140_two_bex_a, 0, no_hashes },
+  { "cat",  7, _140_two_cat_a, 0, no_hashes },
+  { "can",  7, _140_two_can_a, 0, no_hashes },
+  { "con",  7, _140_two_con_a, 0, no_hashes },
+  { "cue",  7, _140_two_cue_a, 0, no_hashes },
+  { "cut",  7, _140_two_cut_a, 0, no_hashes },
+  { "dis",  7, _140_two_dis_a, 0, no_hashes },
+  { "dor",  7, _140_two_dor_a, 0, no_hashes },
+  { "end",  7, _140_two_end_a, 0, no_hashes },
+  { "gor",  7, _140_two_gor_a, 0, no_hashes },
+  { "jam",  7, _140_two_jam_a, 0, no_hashes },
+  { "lsh",  7, _140_two_lsh_a, 0, no_hashes },
+  { "mat",  7, _140_two_mat_a, 0, no_hashes },
+  { "met",  7, _140_two_met_a, 0, no_hashes },
+  { "mix",  7, _140_two_mix_a, 0, no_hashes },
+  { "mor",  7, _140_two_mor_a, 0, no_hashes },
+  { "mug",  7, _140_two_mug_a, 0, no_hashes },
+  { "muk", 59, _140_two_muk_a, 0, no_hashes },
+  { "rap",  7, _140_two_rap_a, 0, no_hashes },
+  { "rep",  7, _140_two_rep_a, 0, no_hashes },
+  { "rev",  7, _140_two_rev_a, 0, no_hashes },
+  { "rip",  7, _140_two_rip_a, 0, no_hashes },
+  { "rsh",  7, _140_two_rsh_a, 0, no_hashes },
+  { "swp",  7, _140_two_swp_a, 0, no_hashes },
+  { "rub",  7, _140_two_rub_a, 0, no_hashes },
+  { "pow",  7, _140_two_pow_a, 0, no_hashes },
+  { "sqt",  7, _140_two_sqt_a, 0, no_hashes },
+  { "xeb",  7, _140_two_xeb_a, 0, no_hashes },
+
+  { "by", 7, 0, _138_two__by_d, no_hashes },
+  { "in", 7, 0, _139_two__in_d, no_hashes },
+  {}
+};
+
+static u3j_core _137_one_d[] =
+{ { "two", 3, 0, _137_two_d, no_hashes },
+
+  { "add", 7, _140_one_add_a, 0, no_hashes },
+  { "dec", 7, _140_one_dec_a, 0, no_hashes },
+  { "div", 7, _140_one_div_a, 0, no_hashes },
+  { "dvr", 7, _140_one_dvr_a, 0, no_hashes },
+  { "gte", 7, _140_one_gte_a, 0, no_hashes },
+  { "gth", 7, _140_one_gth_a, 0, no_hashes },
+  { "lte", 7, _140_one_lte_a, 0, no_hashes },
+  { "lth", 7, _140_one_lth_a, 0, no_hashes },
+  { "max", 7, _140_one_max_a, 0, no_hashes },
+  { "min", 7, _140_one_min_a, 0, no_hashes },
+  { "mod", 7, _140_one_mod_a, 0, no_hashes },
+  { "mul", 7, _140_one_mul_a, 0, no_hashes },
+  { "sub", 7, _140_one_sub_a, 0, no_hashes },
+
+  { "cap", 7, _140_one_cap_a, 0, no_hashes },
+  { "mas", 7, _140_one_mas_a, 0, no_hashes },
+  { "peg", 7, _140_one_peg_a, 0, no_hashes },
+  {}
+};
+
+u3j_core _k137_d[] =
+{ { "one", 3, 0, _137_one_d, no_hashes },
+  {}
+};
+
+
 //  TODO: probably need different ha hashes
 
 static u3j_core _a50_two__by_d[] =
@@ -2621,7 +2710,7 @@ static u3j_core _d[] =
 { { "k140", 0, 0, _k140_d, _k140_ha,  0, (u3j_core*) 140,     0 },
   { "k139", 0, 0, _k139_d, no_hashes, 0, (u3j_core*) 139,     0 },
   { "k138", 0, 0, _k138_d, no_hashes, 0, (u3j_core*) 138,     0 },
-  { "k137", 0, 0, _k138_d, no_hashes, 0, (u3j_core*) 137,     0 },
+  { "k137", 0, 0, _k137_d, no_hashes, 0, (u3j_core*) 137,     0 },
   { "a50",  0, 0, _a50_d,  _k140_ha,  0, (u3j_core*) c3__a50, 0 },
   {}
 };

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2553,6 +2553,7 @@ u3j_core _k138_d[] =
 
 
 static u3j_harm _137_two_clz_a[] = {{".2", u3wc_clz, c3y}, {}};
+static u3j_harm _137_two_ctz_a[] = {{".2", u3wc_ctz, c3y}, {}};
 static u3j_harm _137_two_rig_a[] = {{".2", u3wc_rig, c3y}, {}};
 
 static u3j_core _137_two_d[] =
@@ -2586,6 +2587,7 @@ static u3j_core _137_two_d[] =
   { "can",  7, _140_two_can_a, 0, no_hashes },
   { "clz",  7, _137_two_clz_a, 0, no_hashes },
   { "con",  7, _140_two_con_a, 0, no_hashes },
+  { "ctz",  7, _137_two_ctz_a, 0, no_hashes },
   { "cue",  7, _140_two_cue_a, 0, no_hashes },
   { "cut",  7, _140_two_cut_a, 0, no_hashes },
   { "dis",  7, _140_two_dis_a, 0, no_hashes },

--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2552,6 +2552,7 @@ u3j_core _k138_d[] =
 };
 
 
+static u3j_harm _137_two_clz_a[] = {{".2", u3wc_clz, c3y}, {}};
 static u3j_harm _137_two_rig_a[] = {{".2", u3wc_rig, c3y}, {}};
 
 static u3j_core _137_two_d[] =
@@ -2583,6 +2584,7 @@ static u3j_core _137_two_d[] =
   { "bex",  7, _140_two_bex_a, 0, no_hashes },
   { "cat",  7, _140_two_cat_a, 0, no_hashes },
   { "can",  7, _140_two_can_a, 0, no_hashes },
+  { "clz",  7, _137_two_clz_a, 0, no_hashes },
   { "con",  7, _140_two_con_a, 0, no_hashes },
   { "cue",  7, _140_two_cue_a, 0, no_hashes },
   { "cut",  7, _140_two_cut_a, 0, no_hashes },

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -64,6 +64,7 @@
     u3_noun u3wc_dvr(u3_noun);
     u3_noun u3wc_end(u3_noun);
     u3_noun u3wc_gor(u3_noun);
+    u3_noun u3wc_ham(u3_noun);
     u3_noun u3wc_lsh(u3_noun);
     u3_noun u3wc_mas(u3_noun);
     u3_noun u3wc_met(u3_noun);

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -55,6 +55,7 @@
     u3_noun u3wc_can(u3_noun);
     u3_noun u3wc_cap(u3_noun);
     u3_noun u3wc_cat(u3_noun);
+    u3_noun u3wc_clz(u3_noun);
     u3_noun u3wc_con(u3_noun);
     u3_noun u3wc_cut(u3_noun);
     u3_noun u3wc_dis(u3_noun);

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -74,6 +74,7 @@
     u3_noun u3wc_rap(u3_noun);
     u3_noun u3wc_rep(u3_noun);
     u3_noun u3wc_rev(u3_noun);
+    u3_noun u3wc_rig(u3_noun);
     u3_noun u3wc_rip(u3_noun);
     u3_noun u3wc_rsh(u3_noun);
     u3_noun u3wc_swp(u3_noun);

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -65,6 +65,7 @@
     u3_noun u3wc_end(u3_noun);
     u3_noun u3wc_gor(u3_noun);
     u3_noun u3wc_ham(u3_noun);
+    u3_noun u3wc_hew(u3_noun);
     u3_noun u3wc_lsh(u3_noun);
     u3_noun u3wc_mas(u3_noun);
     u3_noun u3wc_met(u3_noun);

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -57,6 +57,7 @@
     u3_noun u3wc_cat(u3_noun);
     u3_noun u3wc_clz(u3_noun);
     u3_noun u3wc_con(u3_noun);
+    u3_noun u3wc_ctz(u3_noun);
     u3_noun u3wc_cut(u3_noun);
     u3_noun u3wc_dis(u3_noun);
     u3_noun u3wc_dor(u3_noun);


### PR DESCRIPTION
Adds jets for the operations in urbit/urbit#6961, to support urbit/urbit#6932.