### PR TITLE
nix: fix vere compilation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,6 +150,13 @@ doesn't match the version of `clang` installed on your system. To address this,
 run `clang --version` and pass the version number via
 `--clang_version="<version_string>"` to the failing command.
 
+If build fails on nix/NixOS, you should pass `ACLOCAL_PATH` environment
+variable to bazel, using `--action_env=ACLOCAL_PATH=$ACLOCAL_PATH`, like so:
+
+```
+bazel build :urbit --action_env=ACLOCAL_PATH=$ACLOCAL_PATH
+```
+
 [^1]: If you're interested in digging into the details of the build system,
       check out [`WORKSPACE.bazel`](WORKSPACE.bazel),
       [`BUILD.bazel`](BUILD.bazel), [`bazel/`](bazel), and the multiple

--- a/bazel/third_party/avahi/avahi.BUILD
+++ b/bazel/third_party/avahi/avahi.BUILD
@@ -17,7 +17,7 @@ configure_make(
         "@platforms//os:macos": ["--jobs=`sysctl -n hw.logicalcpu`"],
         "//conditions:default": ["--jobs=`nproc`"],
     }),
-    configure_options = ["--with-dbus-system-address='unix:path=/var/run/dbus/system_bus_socket' --with-xml=none --disable-libevent --disable-glib --disable-gobject --disable-gdbm --disable-qt3 --disable-qt4 --disable-qt5 --disable-gtk --disable-gtk3 --disable-mono --disable-monodoc --disable-python --disable-libdaemon --enable-compat-libdns_sd --disable-rpath"],
+    configure_options = ["--with-dbus-system-address='unix:path=/var/run/dbus/system_bus_socket' --with-xml=none --disable-libevent --disable-glib --disable-gobject --disable-gdbm --disable-qt3 --disable-qt4 --disable-qt5 --disable-gtk --disable-gtk3 --disable-mono --disable-monodoc --disable-python --disable-libdaemon --enable-compat-libdns_sd --disable-rpath --with-distro=none"],
     lib_source = ":all",
     # out_include_dir = "avahi-compat-libdns_sd",
     deps = ["@dbus"],

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701626906,
-        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
+        "lastModified": 1712849433,
+        "narHash": "sha256-flQtf/ZPJgkLY/So3Fd+dGilw2DKIsiwgMEn7BbBHL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
+        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701473968,
-        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -104,12 +104,16 @@
         ]
         ++ (with pkgs; [
           autoconf
+          autoconf-archive
           automake
-          bazel_5
+          bazel_6
           binutils # for `nm`
           jdk11_headless
           libtool
           m4
+          pkg-config
+          git
+          perl
         ]);
         extraBuildCommands = ''
           chmod +w usr


### PR DESCRIPTION
Resolves #628

I would need someone on normal linux and mac to double check, if the avahi `--with-distro=none` does not break builds. [nixpkgs sets this](https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/development/libraries/avahi/default.nix#L169), however, because avahi's configure does not support detecting nixos, or falling back to "none".
