### PR TITLE
disk: fix broken chop error message

### DIFF
--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1632,9 +1632,7 @@ u3_disk_chop(u3_disk* log_u, c3_d eve_d)
   u3_disk_epoc_list(log_u, sot_d);
 
   if ( len_z <= 2 ) {
-    fprintf(stderr, "chop: nothing to do, try running roll first\r\n"
-                    "chop: for more info see "
-                    "https://docs.urbit.org/manual/running/vere#chop\r\n");
+    fprintf(stderr, "chop: nothing to do, try running roll first\r\nchop: for more info see https://docs.urbit.org/manual/running/vere#chop\r\n");
     exit(0);  //  enjoy
   }
 


### PR DESCRIPTION
#635 broke the develop branch and therefore broke CI on `urbit/urbit`. It's a real C moment that CI failed to catch this one.