### PR TITLE
Revert "ames: add libnatpmp for automatic port forwarding"

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -217,15 +217,6 @@ versioned_http_file(
     version = "721fa05",
 )
 
-versioned_http_archive(
-    name = "natpmp",
-    build_file = "//bazel/third_party/natpmp:natpmp.BUILD",
-    sha256 = "0684ed2c8406437e7519a1bd20ea83780db871b3a3a5d752311ba3e889dbfc70",
-    strip_prefix = "libnatpmp-{version}",
-    url = "http://miniupnp.free.fr/files/libnatpmp-{version}.tar.gz",
-    version = "20230423",
-)
-
 versioned_http_file(
     name = "solid_pill",
     sha256 = "8b658fcee6978e2b19004a54233cab953e77ea0bb6c3a04d1bfda4ddc6be63c5",

--- a/bazel/third_party/natpmp/natpmp.BUILD
+++ b/bazel/third_party/natpmp/natpmp.BUILD
@@ -1,8 +1,0 @@
-cc_library(
-    name = "natpmp",
-    srcs = ["natpmp.c", "getgateway.c"],
-    hdrs = ["natpmp.h", "getgateway.h", "natpmp_declspec.h"],
-    copts = ["-O3"],
-    linkstatic = True,
-    visibility = ["//visibility:public"],
-)

--- a/pkg/vere/BUILD.bazel
+++ b/pkg/vere/BUILD.bazel
@@ -140,7 +140,6 @@ vere_library(
         "@lmdb",
         "@openssl",
         "@uv",
-        "@natpmp",
     ] + select({
         "@platforms//os:macos": [],
         "@platforms//os:linux": [


### PR DESCRIPTION
Reverts urbit/vere#593

This is very likely what is breaking `urbit/urbit` CI.