### PR TITLE
ames: libnatpmp for real this time

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -217,6 +217,15 @@ versioned_http_file(
     version = "721fa05",
 )
 
+versioned_http_archive(
+    name = "natpmp",
+    build_file = "//bazel/third_party/natpmp:natpmp.BUILD",
+    sha256 = "0684ed2c8406437e7519a1bd20ea83780db871b3a3a5d752311ba3e889dbfc70",
+    strip_prefix = "libnatpmp-{version}",
+    url = "http://miniupnp.free.fr/files/libnatpmp-{version}.tar.gz",
+    version = "20230423",
+)
+
 versioned_http_file(
     name = "solid_pill",
     sha256 = "8b658fcee6978e2b19004a54233cab953e77ea0bb6c3a04d1bfda4ddc6be63c5",

--- a/bazel/third_party/natpmp/natpmp.BUILD
+++ b/bazel/third_party/natpmp/natpmp.BUILD
@@ -1,0 +1,8 @@
+cc_library(
+    name = "natpmp",
+    srcs = ["natpmp.c", "getgateway.c"],
+    hdrs = ["natpmp.h", "getgateway.h", "natpmp_declspec.h"],
+    copts = ["-O3"],
+    linkstatic = True,
+    visibility = ["//visibility:public"],
+)

--- a/pkg/vere/BUILD.bazel
+++ b/pkg/vere/BUILD.bazel
@@ -140,6 +140,7 @@ vere_library(
         "@lmdb",
         "@openssl",
         "@uv",
+        "@natpmp",
     ] + select({
         "@platforms//os:macos": [],
         "@platforms//os:linux": [

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -3200,6 +3200,11 @@ _ames_io_exit(u3_auto* car_u)
   uv_close(&sam_u->had_u, _ames_exit_cb);
   uv_close((uv_handle_t*)&sam_u->sun_u.dns_u, 0);
   uv_close((uv_handle_t*)&sam_u->sun_u.tim_u, 0);
+  uv_close((uv_handle_t*)&sam_u->nat_u.tim_u, 0);
+
+  if (uv_is_active((uv_handle_t*)&sam_u->nat_u.pol_u)) {
+    uv_close((uv_handle_t*)&sam_u->nat_u.pol_u, 0);
+  }
 }
 
 /* _ames_io_info(): produce status info.

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -3202,7 +3202,8 @@ _ames_io_exit(u3_auto* car_u)
   uv_close((uv_handle_t*)&sam_u->sun_u.tim_u, 0);
   uv_close((uv_handle_t*)&sam_u->nat_u.tim_u, 0);
 
-  if (uv_is_active((uv_handle_t*)&sam_u->nat_u.pol_u)) {
+  uv_handle_type handle = uv_handle_get_type((uv_handle_t *)&sam_u->nat_u.pol_u);
+  if ( UV_UNKNOWN_HANDLE !=  handle) {
     uv_close((uv_handle_t*)&sam_u->nat_u.pol_u, 0);
   }
 }

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2817,7 +2817,11 @@ natpmp_init(uv_timer_t *handle)
     return;
   }
 
-  uv_poll_init(u3L, &sam_u->nat_u.pol_u, sam_u->nat_u.req_u.s);
+  err_i = uv_poll_init(u3L, &sam_u->nat_u.pol_u, sam_u->nat_u.req_u.s);
+
+  if (err_i != 0) {
+    return;
+  }
 
   sendnewportmappingrequest(&sam_u->nat_u.req_u, NATPMP_PROTOCOL_UDP, por_s, por_s, 7200);
 

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -7,6 +7,7 @@
 #include "ur.h"
 
 #include "zlib.h"
+#include "natpmp.h"
 
 #include <ent.h>
 
@@ -71,6 +72,11 @@ typedef enum u3_stun_state {
       u3_lane        sef_u;             //  our lane, if we know it
       c3_o           wok_o;             //  STUN worked, set on first success
     } sun_u;                            //
+    struct {
+      natpmp_t       req_u;             //  libnatpmp struct for mapping request
+      uv_poll_t      pol_u;             //  handle waits on libnatpmp socket
+      uv_timer_t     tim_u;             //  every two hours if mapping succeeds
+    } nat_u;                            //  libnatpmp stuff for port forwarding
     c3_o             nal_o;             //  lane cache backcompat flag
     struct {                            //    config:
       c3_o           net_o;             //  can send
@@ -2765,6 +2771,51 @@ _ames_recv_cb(uv_udp_t*        wax_u,
   }
 }
 
+static void natpmp_init(uv_timer_t* handle);
+
+static void
+natpmp_cb(uv_poll_t* handle,
+          c3_i        status,
+          c3_i        events)
+{
+  u3_ames* sam_u = handle->data;
+
+  natpmpresp_t response;
+  c3_i res_i = readnatpmpresponseorretry(&sam_u->nat_u.req_u, &response);
+  if ( NATPMP_TRYAGAIN == res_i ) {
+    return;
+  }
+
+  uv_poll_stop(handle);
+
+  if ( 0 != res_i ) {
+    u3l_log("ames: natpmp error %i", res_i);
+    closenatpmp(&sam_u->nat_u.req_u);
+    return;
+  }
+
+  u3l_log("ames: mapped public port %hu to localport %hu lifetime %u",
+         response.pnu.newportmapping.mappedpublicport,
+         response.pnu.newportmapping.privateport,
+         response.pnu.newportmapping.lifetime);
+
+  closenatpmp(&sam_u->nat_u.req_u);
+  sam_u->nat_u.tim_u.data = sam_u;
+  uv_timer_start(&sam_u->nat_u.tim_u, natpmp_init, 7200000, 0);
+}
+
+static void
+natpmp_init(uv_timer_t *handle)
+{
+  u3_ames* sam_u = handle->data;
+  c3_s por_s = sam_u->pir_u->por_s;
+
+  sendnewportmappingrequest(&sam_u->nat_u.req_u, NATPMP_PROTOCOL_UDP, por_s, por_s, 7200);
+
+  sam_u->nat_u.pol_u.data = sam_u;
+  uv_poll_start(&sam_u->nat_u.pol_u, UV_READABLE, natpmp_cb);
+}
+
 static void
 _mdns_dear_bail(u3_ovum* egg_u, u3_noun lud)
 {
@@ -2885,6 +2936,11 @@ _ames_io_start(u3_ames* sam_u)
     u3z(our);
 
     mdns_init(por_s, !sam_u->pir_u->fak_o, our_s, _ames_put_dear, (void *)sam_u);
+
+    if ( c3n == sam_u->pir_u->fak_o ) {
+      uv_timer_start(&sam_u->nat_u.tim_u, natpmp_init, 0, 0);
+    }
+
     c3_free(our_s);
   }
 
@@ -3227,6 +3283,12 @@ u3_ames_io_init(u3_pier* pir_u)
   uv_timer_init(u3L, &sam_u->sun_u.tim_u);
   sam_u->sun_u.tim_u.data = sam_u;
   sam_u->sun_u.dns_u.data = sam_u;
+
+  //  initialize libnatpmp
+  sam_u->nat_u.tim_u.data = sam_u;
+  initnatpmp(&sam_u->nat_u.req_u, 0, 0);
+  uv_timer_init(u3L, &sam_u->nat_u.tim_u);
+  uv_poll_init(u3L, &sam_u->nat_u.pol_u, sam_u->nat_u.req_u.s);
 
   //  enable forwarding on galaxies only
   u3_noun who = u3i_chubs(2, sam_u->pir_u->who_d);

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2778,6 +2778,11 @@ natpmp_cb(uv_poll_t* handle,
           c3_i        status,
           c3_i        events)
 {
+
+  if (status != 0) {
+    return;
+  }
+
   u3_ames* sam_u = handle->data;
 
   natpmpresp_t response;


### PR DESCRIPTION
This is #593 that got reverted in #644 because it broke `urbit/urbit` CI. This PR fixes the issue which was unconditionally calling `uv_poll_init` on a socket that was initialized with `initnatpmp` without checking if `initnatpmp` returned an error first.