### PR TITLE
Add %jinx hint to Vere.

### DIFF
--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -618,6 +618,7 @@
 #   define c3__jato   c3_s4('j','a','t','o')
 #   define c3__jet    c3_s3('j','e','t')
 #   define c3__jetd   c3_s4('j','e','t','d')
+#   define c3__jinx   c3_s4('j','i','n','x')
 #   define c3__just   c3_s4('j','u','s','t')
 #   define c3__k      c3_s1('k')
 #   define c3__khan   c3_s4('k','h','a','n')

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -367,6 +367,20 @@ _cm_signal_deep(c3_w mil_w)
     );
   }
 
+  u3m_timer_set(mil_w);
+
+  // factor into own function, call here and in _n_hint_fore() TODO
+  // _n_hint_hind() will look like this w/ deinstall handler instead
+  // return void b/c just clearing timer, no args
+
+  u3t_boot();
+}
+
+/* u3m_timer_set
+*/
+void
+u3m_timer_set(c3_w mil_w)
+{
   if ( mil_w ) {
     struct itimerval itm_u;
 
@@ -381,8 +395,18 @@ _cm_signal_deep(c3_w mil_w)
       rsignal_install_handler(SIGVTALRM, _cm_signal_handle_alrm);
     }
   }
+}
 
-  u3t_boot();
+/* u3m_timer_clear
+*/
+void
+u3m_timer_clear()
+{
+  struct itimerval itm_u;
+
+  timerclear(&itm_u.it_interval);
+
+  rsignal_deinstall_handler(SIGVTALRM);
 }
 
 /* _cm_signal_done():

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -198,4 +198,14 @@
         c3_w
         u3m_pack(void);
 
+      /* u3m_timer_set: set the timer.
+      */
+        void
+        u3m_timer_set(c3_w mil_w);
+      
+      /* u3m_timer_clear: clear the timer.
+      */
+        void
+        u3m_timer_clear(void);
+
 #endif /* ifndef U3_MANAGE_H */

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1062,6 +1062,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
           case c3__meme:
           case c3__nara:
           case c3__hela:
+          case c3__jinx:
           case c3__bout: {
             u3_noun fen = u3_nul;
             c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
@@ -1104,15 +1105,6 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
         tot_w += _n_comp(ops, hod, c3n, c3n);
         ++tot_w; _n_emit(ops, SLOG);
         tot_w += _n_comp(ops, nef, los_o, tel_o);
-        break;
-
-      case c3__jinx:
-        fprintf(stderr, "nock: jinx not implemented\r\n");
-        fprintf(stderr, "zep: %x hod: %x nef: %x\r\n", zep, u3x_at(1, hod), u3x_at(1, nef));
-        tot_w += _n_comp(ops, hod, c3n, c3n);
-        ++tot_w; _n_emit(ops, u3nc(BUSH, zep)); // overflows to SUSH
-        tot_w += _n_comp(ops, nef, los_o, c3n);
-        ++tot_w; _n_emit(ops, DROP);
         break;
 
       // germ and sole are unused...
@@ -1935,6 +1927,26 @@ _n_hint_fore(u3_cell hin, u3_noun bus, u3_noun* clu)
       *clu = u3nt(u3k(tag), *clu, now);
     } break;
 
+    case c3__jinx: {
+      if (c3y == u3a_is_atom(*clu)) {
+        // clu is in Urbit time, but we need Unix time
+        mpz_t clu_mp;
+        u3r_mp(clu_mp, *clu);
+        mpz_t urs_mp, tim_mp;
+        mpz_init(urs_mp);
+        mpz_init(tim_mp);
+        mpz_tdiv_q_2exp(tim_mp, clu_mp, 48);
+        mpz_mul_ui(tim_mp, tim_mp, 1000);
+        mpz_tdiv_q_2exp(urs_mp, tim_mp, 16);
+        c3_w mil_w = u3i_mp(urs_mp);
+        u3m_timer_set(mil_w); // set ITIMER (mil_w is in microseconds)
+        mpz_clear(clu_mp);
+        mpz_clear(tim_mp);
+      }
+      u3z(*clu);
+      *clu = c3__jinx;
+    } break;
+
     case c3__nara: {
       u3_noun pri, tan;
       if ( c3y == u3r_cell(*clu, &pri, &tan) ) {
@@ -1996,7 +2008,11 @@ static void
 _n_hint_hind(u3_noun tok, u3_noun pro)
 {
   u3_noun p_tok, q_tok, r_tok;
-  if ( (c3y == u3r_trel(tok, &p_tok, &q_tok, &r_tok)) && (c3__bout == p_tok) ) {
+  if (c3__jinx == tok) {
+    u3m_timer_clear();
+    // call fn in u3m to cancel ITIMER (we know no parent timer now until we add nesting)
+  }
+  else if ( (c3y == u3r_trel(tok, &p_tok, &q_tok, &r_tok)) && (c3__bout == p_tok) ) {
     // get the microseconds elapsed
     u3_atom delta = u3ka_sub(u3i_chub(u3t_trace_time()), u3k(r_tok));
 

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -16,6 +16,8 @@
 #include "xtract.h"
 #include "zave.h"
 
+#include <stdio.h>
+
 // define to have each opcode printed as it executes,
 // along with some other debugging info
 #        undef VERBOSE_BYTECODE
@@ -1022,8 +1024,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
       case c3__meme:
       case c3__nara:
       case c3__hela:
-      case c3__bout:
-      case c3__jinx: {
+      case c3__bout: {
         u3_noun fen = u3_nul;
         c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
         // add appropriate hind opcode
@@ -1061,8 +1062,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
           case c3__meme:
           case c3__nara:
           case c3__hela:
-          case c3__bout:
-          case c3__jinx: {
+          case c3__bout: {
             u3_noun fen = u3_nul;
             c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
             // add appropriate hind opcode
@@ -1104,6 +1104,15 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
         tot_w += _n_comp(ops, hod, c3n, c3n);
         ++tot_w; _n_emit(ops, SLOG);
         tot_w += _n_comp(ops, nef, los_o, tel_o);
+        break;
+
+      case c3__jinx:
+        fprintf(stderr, "nock: jinx not implemented\r\n");
+        fprintf(stderr, "zep: %x hod: %x nef: %x\r\n", zep, u3x_at(1, hod), u3x_at(1, nef));
+        tot_w += _n_comp(ops, hod, c3n, c3n);
+        ++tot_w; _n_emit(ops, u3nc(BUSH, zep)); // overflows to SUSH
+        tot_w += _n_comp(ops, nef, los_o, c3n);
+        ++tot_w; _n_emit(ops, DROP);
         break;
 
       // germ and sole are unused...
@@ -1874,11 +1883,6 @@ _n_hilt_fore(u3_noun hin, u3_noun bus, u3_noun* out)
       *out = u3_nul;
     } break;
 
-    case c3__jinx: {
-      u3_atom now = u3i_chub(u3t_trace_time());
-      *out = u3i_cell(tag, now);
-    } break;
-
     default: {
       *out = u3_nul;
     } break;
@@ -1900,13 +1904,6 @@ _n_hilt_hind(u3_noun tok, u3_noun pro)
     u3_atom delta = u3ka_sub(u3i_chub(u3t_trace_time()), u3k(q_tok));
     c3_c str_c[64];
     u3a_print_time(str_c, "took", u3r_chub(0, delta));
-    u3t_slog(u3nc(0, u3i_string(str_c)));
-    u3z(delta);
-  }
-  else if ( (c3y == u3r_cell(tok, &p_tok, &q_tok)) && (c3__jinx == p_tok) ) {
-    u3_atom delta = u3ka_sub(u3i_chub(u3t_trace_time()), u3k(q_tok));
-    c3_c str_c[64];
-    u3a_print_time(str_c, "jinxed at", u3r_chub(0, delta));
     u3t_slog(u3nc(0, u3i_string(str_c)));
     u3z(delta);
   }
@@ -1934,11 +1931,6 @@ _n_hint_fore(u3_cell hin, u3_noun bus, u3_noun* clu)
 
   switch ( tag ) {
     case c3__bout: {
-      u3_atom now = u3i_chub(u3t_trace_time());
-      *clu = u3nt(u3k(tag), *clu, now);
-    } break;
-
-    case c3__jinx: {
       u3_atom now = u3i_chub(u3t_trace_time());
       *clu = u3nt(u3k(tag), *clu, now);
     } break;

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1022,7 +1022,8 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
       case c3__meme:
       case c3__nara:
       case c3__hela:
-      case c3__bout: {
+      case c3__bout:
+      case c3__jinx: {
         u3_noun fen = u3_nul;
         c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
         // add appropriate hind opcode
@@ -1060,7 +1061,8 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
           case c3__meme:
           case c3__nara:
           case c3__hela:
-          case c3__bout: {
+          case c3__bout:
+          case c3__jinx: {
             u3_noun fen = u3_nul;
             c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
             // add appropriate hind opcode
@@ -1872,6 +1874,11 @@ _n_hilt_fore(u3_noun hin, u3_noun bus, u3_noun* out)
       *out = u3_nul;
     } break;
 
+    case c3__jinx: {
+      u3_atom now = u3i_chub(u3t_trace_time());
+      *out = u3i_cell(tag, now);
+    } break;
+
     default: {
       *out = u3_nul;
     } break;
@@ -1893,6 +1900,13 @@ _n_hilt_hind(u3_noun tok, u3_noun pro)
     u3_atom delta = u3ka_sub(u3i_chub(u3t_trace_time()), u3k(q_tok));
     c3_c str_c[64];
     u3a_print_time(str_c, "took", u3r_chub(0, delta));
+    u3t_slog(u3nc(0, u3i_string(str_c)));
+    u3z(delta);
+  }
+  else if ( (c3y == u3r_cell(tok, &p_tok, &q_tok)) && (c3__jinx == p_tok) ) {
+    u3_atom delta = u3ka_sub(u3i_chub(u3t_trace_time()), u3k(q_tok));
+    c3_c str_c[64];
+    u3a_print_time(str_c, "jinxed at", u3r_chub(0, delta));
     u3t_slog(u3nc(0, u3i_string(str_c)));
     u3z(delta);
   }
@@ -1920,6 +1934,11 @@ _n_hint_fore(u3_cell hin, u3_noun bus, u3_noun* clu)
 
   switch ( tag ) {
     case c3__bout: {
+      u3_atom now = u3i_chub(u3t_trace_time());
+      *clu = u3nt(u3k(tag), *clu, now);
+    } break;
+
+    case c3__jinx: {
       u3_atom now = u3i_chub(u3t_trace_time());
       *clu = u3nt(u3k(tag), *clu, now);
     } break;


### PR DESCRIPTION
Resolves proposed UIP (unnumbered).

Adds a `%jinx` hint to Vere which permits a computation's timeout to be specified in Urbit time.

```
> ~>  %jinx.[~s4]  =|(i=@ |-(?:(=(10.000.000 i) i $(i +(i)))))
10.000.000

> ~>  %jinx.[~s3|  =|(i=@ |-(?:(=(10.000.000 i) i $(i +(i)))))
recover: dig: alrm
crud: %belt event failed
call: failed
```
