### PR TITLE
play: exit if binary version mismatches latest epoch's

### DIFF
--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1235,7 +1235,7 @@ _disk_epoc_roll(u3_disk* log_u, c3_d epo_d)
     fprintf(stderr, "disk: failed to read metadata\r\n");
     goto fail3;
   }
-  
+
   u3_lmdb_exit(log_u->mdb_u);
   log_u->mdb_u = 0;
 
@@ -1416,7 +1416,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
    *  5. clobber old log/data.mdb with new log/tmp/data.mdb
    *  6. open epoch lmdb and set it in log_u
    */
-  
+
   //  NB: requires that log_u->mdb_u is initialized to log/data.mdb
   //  XX: put old log in separate pointer (old_u?)?
 
@@ -1509,7 +1509,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
     fprintf(stderr, "disk: failed to save metadata\r\n");
     return c3n;
   }
-  
+
   //  atomic truncation of old log
   //
   u3_lmdb_exit(log_u->mdb_u);
@@ -1605,7 +1605,7 @@ u3_disk_kindly(u3_disk* log_u, c3_d eve_d)
     } break;
 
     case U3D_VER3: {
-      if ( (0 == log_u->epo_d) || 
+      if ( (0 == log_u->epo_d) ||
            (c3y == _disk_vere_diff(log_u)) )
       {
         if ( c3n == _disk_epoc_roll(log_u, eve_d) ) {
@@ -1780,6 +1780,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
 {
   u3_disk* log_u = c3_calloc(sizeof(*log_u));
   log_u->liv_o = c3n;
+  log_u->mis_o = c3n;
   log_u->ted_o = c3n;
   log_u->cb_u  = cb_u;
   log_u->red_u = 0;
@@ -1983,6 +1984,10 @@ try_init:
               c3_free(log_u);
               return 0;
             }
+          }
+
+          if ( c3y == _disk_vere_diff(log_u) ) {
+            log_u->mis_o = c3y;
           }
 
           return log_u;

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2256,6 +2256,11 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
   //
   u3_disk* log_u = _cw_disk_init(u3_Host.dir_c);
 
+  if ( c3y == log_u->mis_o ) {
+    fprintf(stderr, "mars: binary version mismatch\r\n");
+    exit(1);
+  }
+
   //  Handle SIGTSTP as if it was SIGINT.
   //
   //    Configured here using signal() so as to be immediately available.

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -554,6 +554,7 @@
           u3_dire*         com_u;               //  log directory
           c3_o             liv_o;               //  live
           c3_w             ver_w;               //  version (see version.h)
+          c3_o             mis_o;               //  version/epoch mismatch
           void*            mdb_u;               //  lmdb env of current epoch
           c3_d             sen_d;               //  commit requested
           c3_d             dun_d;               //  committed


### PR DESCRIPTION
The invariant that replay should not occur across binary versions was previously unenforced. This enforces it by setting a flag in the disk struct to indicate version mismatch between ourselves and the latest epoch's binary version number (saved in `vere.txt`).

Then, in the synchronous replay function, we exit if the same flag is set.

Questions:
- Should we instruct the user to downgrade to a previous version before exit?
- Should we make `_disk_epoc_meta` public (i.e. `u3_disk_epoc_meta`) so we can provide the specific version to revert to in the error message?

Note: Whitespace is cleaned up here automatically thanks to my editor and I don't see why not to include them in this PR. Happy to revert with request though as I don't really care either way.