### PR TITLE
disk: parameterize lmdb map size

### DIFF
--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -31,15 +31,6 @@ struct _u3_disk_walk {
   c3_o          liv_o;
 };
 
-// for u3_lmdb_init() calls
-static const size_t siz_i =
-#if (defined(U3_CPU_aarch64) && defined(U3_OS_linux))
-  // 500 GiB is as large as musl on aarch64 wants to allow
-  0x7d00000000;
-#else
-  0x10000000000;
-#endif
-
 #undef VERBOSE_DISK
 #undef DISK_TRACE_JAM
 #undef DISK_TRACE_CUE
@@ -680,7 +671,7 @@ u3_disk_save_meta_meta(c3_c* log_c,
 {
   MDB_env* dbm_u;
 
-  if ( 0 == (dbm_u = u3_lmdb_init(log_c, siz_i)) ) {
+  if ( 0 == (dbm_u = u3_lmdb_init(log_c, u3_Host.ops_u.siz_i)) ) {
     fprintf(stderr, "disk: failed to initialize meta-lmdb\r\n");
     return c3n;
   }
@@ -1240,7 +1231,7 @@ _disk_epoc_roll(u3_disk* log_u, c3_d epo_d)
   log_u->mdb_u = 0;
 
   //  initialize db of new epoch
-  if ( 0 == (log_u->mdb_u = u3_lmdb_init(epo_c, siz_i)) ) {
+  if ( 0 == (log_u->mdb_u = u3_lmdb_init(epo_c, u3_Host.ops_u.siz_i)) ) {
     fprintf(stderr, "disk: failed to initialize database\r\n");
     c3_free(log_u);
     goto fail3;
@@ -1499,7 +1490,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
     return c3n;
   }
 
-  if ( 0 == (log_u->mdb_u = u3_lmdb_init(tmp_c, siz_i)) ) {
+  if ( 0 == (log_u->mdb_u = u3_lmdb_init(tmp_c, u3_Host.ops_u.siz_i)) ) {
     fprintf(stderr, "disk: failed to initialize database at %s\r\n",
                     tmp_c);
     return c3n;
@@ -1533,7 +1524,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
                     strerror(errno));
   }
 
-  if ( 0 == (log_u->mdb_u = u3_lmdb_init(epo_c, siz_i)) ) {
+  if ( 0 == (log_u->mdb_u = u3_lmdb_init(epo_c, u3_Host.ops_u.siz_i)) ) {
     fprintf(stderr, "disk: failed to initialize database at %s\r\n",
                     epo_c);
     return c3n;
@@ -1736,7 +1727,7 @@ _disk_epoc_load(u3_disk* log_u, c3_d lat_d)
   snprintf(epo_c, 8192, "%s/0i%" PRIc3_d, log_u->com_u->pax_c, lat_d);
 
   //  initialize latest epoch's db
-  if ( 0 == (log_u->mdb_u = u3_lmdb_init(epo_c, siz_i)) ) {
+  if ( 0 == (log_u->mdb_u = u3_lmdb_init(epo_c, u3_Host.ops_u.siz_i)) ) {
     fprintf(stderr, "disk: failed to initialize database at %s\r\n",
                     epo_c);
     return _epoc_fail;
@@ -1880,7 +1871,7 @@ u3_disk_init(c3_c* pax_c, u3_disk_cb cb_u)
 
     if ( c3y == exs_o ) {
       //  load the old data.mdb file
-      if ( 0 == (log_u->mdb_u = u3_lmdb_init(log_c, siz_i)) ) {
+      if ( 0 == (log_u->mdb_u = u3_lmdb_init(log_c, u3_Host.ops_u.siz_i)) ) {
         fprintf(stderr, "disk: failed to initialize lmdb\r\n");
         c3_free(log_u);
         return 0;

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -297,6 +297,7 @@ _main_getopt(c3_i argc, c3_c** argv)
     { "swap-to",             required_argument, NULL, 8 },
     { "toss",                required_argument, NULL, 9 },
     { "behn-allow-blocked",  no_argument,       NULL, 10 },
+    { "lmdb-map-size",       required_argument, NULL, 12 },
     //
     { NULL, 0, NULL, 0 },
   };
@@ -338,6 +339,12 @@ _main_getopt(c3_i argc, c3_c** argv)
       }
       case 10: { //  behn-allow-blocked
         u3_Host.ops_u.beb = c3y;
+        break;
+      }
+      case 12: { //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNu32, &u3_Host.ops_u.siz_i) ) {
+          return c3n;
+        }
         break;
       }
       //  special args
@@ -2989,6 +2996,16 @@ main(c3_i   argc,
 
   if ( c3y == u3_Host.ops_u.tex ) {
     u3_Host.bot_f = _stop_on_boot_completed_cb;
+  }
+
+  if ( !u3_Host.ops_u.siz_i ) {
+    u3_Host.ops_u.siz_i =
+#if (defined(U3_CPU_aarch64) && defined(U3_OS_linux))
+  // 500 GiB is as large as musl on aarch64 wants to allow
+  0x7d00000000;
+#else
+  0x10000000000;
+#endif
   }
 
 #if 0

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -193,6 +193,14 @@ _main_init(void)
   u3_Host.ops_u.lut_y = 31;     /* aka 2G */
   u3_Host.ops_u.lom_y = 31;
 
+  u3_Host.ops_u.siz_i =
+#if (defined(U3_CPU_aarch64) && defined(U3_OS_linux))
+  // 500 GiB is as large as musl on aarch64 wants to allow
+  0x7d00000000;
+#else
+  0x10000000000;
+#endif
+
   u3C.eph_c = 0;
   u3C.tos_w = 0;
 }
@@ -342,7 +350,7 @@ _main_getopt(c3_i argc, c3_c** argv)
         break;
       }
       case 12: { //  lmdb-map-size
-        if ( 1 != sscanf(optarg, "%" SCNu32, &u3_Host.ops_u.siz_i) ) {
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
           return c3n;
         }
         break;
@@ -1576,10 +1584,11 @@ _cw_info(c3_i argc, c3_c* argv[])
   c3_w arg_w;
 
   static struct option lop_u[] = {
-    { "loom",      required_argument, NULL, c3__loom },
-    { "no-demand", no_argument,       NULL, 6 },
-    { "swap",      no_argument,       NULL, 7 },
-    { "swap-to",   required_argument, NULL, 8 },
+    { "loom",          required_argument, NULL, c3__loom },
+    { "no-demand",     no_argument,       NULL, 6 },
+    { "swap",          no_argument,       NULL, 7 },
+    { "swap-to",       required_argument, NULL, 8 },
+    { "lmdb-map-size", required_argument, NULL, 9 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1607,6 +1616,13 @@ _cw_info(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.eph = c3y;
         u3C.wag_w |= u3o_swap;
         u3C.eph_c = strdup(optarg);
+        break;
+      }
+
+      case 9: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
         break;
       }
 
@@ -1751,10 +1767,11 @@ _cw_cram(c3_i argc, c3_c* argv[])
   c3_w arg_w;
 
   static struct option lop_u[] = {
-    { "loom",      required_argument, NULL, c3__loom },
-    { "no-demand", no_argument,       NULL, 6 },
-    { "swap",      no_argument,       NULL, 7 },
-    { "swap-to",   required_argument, NULL, 8 },
+    { "loom",          required_argument, NULL, c3__loom },
+    { "no-demand",     no_argument,       NULL, 6 },
+    { "swap",          no_argument,       NULL, 7 },
+    { "swap-to",       required_argument, NULL, 8 },
+    { "lmdb-map-size", required_argument, NULL, 9 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1782,6 +1799,13 @@ _cw_cram(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.eph = c3y;
         u3C.wag_w |= u3o_swap;
         u3C.eph_c = strdup(optarg);
+        break;
+      }
+
+      case 9: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
         break;
       }
 
@@ -1847,11 +1871,12 @@ _cw_queu(c3_i argc, c3_c* argv[])
   c3_c* roc_c = 0;
 
   static struct option lop_u[] = {
-    { "loom",        required_argument, NULL, c3__loom },
-    { "no-demand",   no_argument,       NULL, 6 },
-    { "swap",      no_argument,       NULL, 7 },
-    { "swap-to",   required_argument, NULL, 8 },
-    { "replay-from", required_argument, NULL, 'r' },
+    { "loom",          required_argument, NULL, c3__loom },
+    { "no-demand",     no_argument,       NULL, 6 },
+    { "swap",          no_argument,       NULL, 7 },
+    { "swap-to",       required_argument, NULL, 8 },
+    { "lmdb-map-size", required_argument, NULL, 9 },
+    { "replay-from",   required_argument, NULL, 'r' },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1879,6 +1904,13 @@ _cw_queu(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.eph = c3y;
         u3C.wag_w |= u3o_swap;
         u3C.eph_c = strdup(optarg);
+        break;
+      }
+
+      case 9: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
         break;
       }
 
@@ -1955,11 +1987,12 @@ _cw_meld(c3_i argc, c3_c* argv[])
   c3_w arg_w;
 
   static struct option lop_u[] = {
-    { "loom",      required_argument, NULL, c3__loom },
-    { "no-demand", no_argument,       NULL, 6 },
-    { "swap",      no_argument,       NULL, 7 },
-    { "swap-to",   required_argument, NULL, 8 },
-    { "gc-early",  no_argument,       NULL, 9 },
+    { "loom",          required_argument, NULL, c3__loom },
+    { "no-demand",     no_argument,       NULL, 6 },
+    { "swap",          no_argument,       NULL, 7 },
+    { "swap-to",       required_argument, NULL, 8 },
+    { "gc-early",      no_argument,       NULL, 9 },
+    { "lmdb-map-size", required_argument, NULL, 10 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1992,6 +2025,13 @@ _cw_meld(c3_i argc, c3_c* argv[])
 
       case 9: {  //  gc-early
         u3C.wag_w |= u3o_check_corrupt;
+        break;
+      }
+
+      case 10: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
         break;
       }
 
@@ -2123,11 +2163,12 @@ _cw_pack(c3_i argc, c3_c* argv[])
   c3_w arg_w;
 
   static struct option lop_u[] = {
-    { "loom",      required_argument, NULL, c3__loom },
-    { "no-demand", no_argument,       NULL, 6 },
-    { "swap",      no_argument,       NULL, 7 },
-    { "swap-to",   required_argument, NULL, 8 },
-    { "gc-early",  no_argument,       NULL, 9 },
+    { "loom",          required_argument, NULL, c3__loom },
+    { "no-demand",     no_argument,       NULL, 6 },
+    { "swap",          no_argument,       NULL, 7 },
+    { "swap-to",       required_argument, NULL, 8 },
+    { "gc-early",      no_argument,       NULL, 9 },
+    { "lmdb-map-size", required_argument, NULL, 10 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -2160,6 +2201,13 @@ _cw_pack(c3_i argc, c3_c* argv[])
 
       case 9: {  //  gc-early
         u3C.wag_w |= u3o_check_corrupt;
+        break;
+      }
+
+      case 10: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
         break;
       }
 
@@ -2504,10 +2552,11 @@ _cw_chop(c3_i argc, c3_c* argv[])
   c3_w arg_w;
 
   static struct option lop_u[] = {
-    { "loom",      required_argument, NULL, c3__loom },
-    { "no-demand", no_argument,       NULL, 6 },
-    { "swap",      no_argument,       NULL, 7 },
-    { "swap-to",   required_argument, NULL, 8 },
+    { "loom",          required_argument, NULL, c3__loom },
+    { "no-demand",     no_argument,       NULL, 6 },
+    { "swap",          no_argument,       NULL, 7 },
+    { "swap-to",       required_argument, NULL, 8 },
+    { "lmdb-map-size", required_argument, NULL, 9 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -2535,6 +2584,13 @@ _cw_chop(c3_i argc, c3_c* argv[])
         u3_Host.ops_u.eph = c3y;
         u3C.wag_w |= u3o_swap;
         u3C.eph_c = strdup(optarg);
+        break;
+      }
+
+      case 9: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
         break;
       }
 
@@ -2585,7 +2641,8 @@ _cw_roll(c3_i argc, c3_c* argv[])
   c3_w arg_w;
 
   static struct option lop_u[] = {
-    { "loom", required_argument, NULL, c3__loom },
+    { "loom",          required_argument, NULL, c3__loom },
+    { "lmdb-map-size", required_argument, NULL, 6 },
     { NULL, 0, NULL, 0 }
   };
 
@@ -2593,6 +2650,13 @@ _cw_roll(c3_i argc, c3_c* argv[])
 
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
+      case 6: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
+        break;
+      }
+
       case c3__loom: {
         if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
           exit(1);
@@ -2996,16 +3060,6 @@ main(c3_i   argc,
 
   if ( c3y == u3_Host.ops_u.tex ) {
     u3_Host.bot_f = _stop_on_boot_completed_cb;
-  }
-
-  if ( !u3_Host.ops_u.siz_i ) {
-    u3_Host.ops_u.siz_i =
-#if (defined(U3_CPU_aarch64) && defined(U3_OS_linux))
-  // 500 GiB is as large as musl on aarch64 wants to allow
-  0x7d00000000;
-#else
-  0x10000000000;
-#endif
   }
 
 #if 0

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -320,6 +320,7 @@
         u3_even* vex_u;                     //  --prop-*, boot enhancements
 
         c3_o    beb;                        //  --behn-allow-blocked
+        c3_z    siz_i;                      //  --lmdb-map-size
       } u3_opts;
 
     /* u3_host: entire host.


### PR DESCRIPTION
Adds `--lmdb-map-size` to specify LMDB's initial memory mapping size, intended for use by users who need a size smaller than our default of 500G. Note: `case 12` to avoid collision with the other arg added in #654.