### PR TITLE
main: restore SIGTSTP handler after replay

### DIFF
--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -3111,6 +3111,7 @@ main(c3_i   argc,
     //  validate whether we can execute disk migration
     if ( u3_Host.ops_u.nuu == c3n ) {
       _cw_play_impl(0, 0, c3n, c3n, c3n);
+      signal(SIGTSTP, _stop_exit);
       //  XX  unmap loom, else parts of the snapshot could be left in memory
     }
 


### PR DESCRIPTION
CTRL+z to force kill an urbit process has been broken for some time. This was caused by our SIGTSTP handler being overwritten in `_cw_play_imp` that gets called not only during replay but on every boot if we're not a new pier.