### PR TITLE
fix nock 9 crashing pier if axis is cell

### DIFF
--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1400,7 +1400,7 @@ _n_comp(u3_noun* ops, u3_noun fol, c3_o los_o, c3_o tel_o)
 
     case 9:
       u3x_cell(arg, &hed, &tel);
-      if ( (1 == hed) || (3 == u3qc_cap(hed)) ) {
+      if ( (1 == hed) || (3 == u3qc_cap(u3x_atom(hed))) ) {
         u3_noun mac = u3nq(7, u3k(tel), 2, u3nt(u3nc(0, 1), 0, u3k(hed)));
         tot_w += _n_comp(ops, mac, los_o, tel_o);
         u3z(mac);


### PR DESCRIPTION
Solves #660 

Prevents Nock 9 from crashing the pier if the axis argument is a cell. Without the check Vere may call `u3qc_cap` on a cell, leading to a segfault or an assertion failure:

```
Assertion '_(u3a_is_atom(b))' failed in pkg/noun/retrieve.c:1011
```

To reproduce the bug, run in Dojo:

```
.*(0 [9 [2 2] 0 1])
```

Is there a way to add a unit test to guard against a downgrade?