### PR TITLE
trace: when profiling, dump a sampling trace

### DIFF
--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -23,6 +23,9 @@ static c3_o _ct_lop_o;
 /// Nock PID.
 static pid_t _nock_pid_i = 0;
 
+/// dump trace file.
+static FILE* _filt_u = NULL;
+
 /// JSON trace file.
 static FILE* _file_u = NULL;
 
@@ -208,6 +211,28 @@ u3t_samp(void)
     // it can cause memory errors.
     return;
   }
+
+  u3_noun don = u3R->pro.don;
+  while ( u3_nul != don ) {
+    u3_noun dot = u3h(don);
+
+    while ( u3_nul != dot ) {
+      u3_noun dit = u3h(dot);
+      c3_w    len_w = u3r_met(3, dit);
+      c3_c*   dit_c = ( c3y == u3a_is_cat(dit) )
+                      ? &dit
+                      : ((u3a_atom*)u3a_to_ptr(dit))->buf_w;
+      fprintf(_filt_u, "/%.*s", len_w, dit_c);
+
+      dot = u3t(dot);
+    }
+    fprintf(_filt_u, "\n");
+
+    don = u3t(don);
+  }
+  fprintf(_filt_u, "1\n\n");
+
+  return;
 
   c3_w old_wag = u3C.wag_w;
   u3C.wag_w &= ~u3o_debug_cpu;
@@ -547,6 +572,24 @@ u3t_init(void)
   u3T.far_o = c3n;
   u3T.coy_o = c3n;
   u3T.euq_o = c3n;
+
+  if ( ( u3C.wag_w & u3o_debug_cpu ) && !_filt_u ) {
+    c3_c fil_c[2048];
+    snprintf(fil_c, 2048, "%s/.urb/put/trace", u3C.dir_c);
+
+    struct stat st;
+    if (  (-1 == stat(fil_c, &st))
+      && (-1 == c3_mkdir(fil_c, 0700)) )
+    {
+      fprintf(stderr, "mkdir: %s failed: %s\r\n", fil_c, strerror(errno));
+      return;
+    }
+
+    snprintf(fil_c, 2048, "%s/.urb/put/trace/dump.txt", u3C.dir_c);
+
+    _filt_u = c3_fopen(fil_c, "w");
+    fprintf(_filt_u, "\n\n\n");
+  }
 }
 
 c3_w


### PR DESCRIPTION
Whenever we run under the profiling flag (`-P` `--profile`), we now collect sampling traces into `.urb/put/trace/dump.txt`.

We take care to format the output in a way that's compatible with flamegraph tooling. Specifically, we avoid writing into the first couple lines of the file, and suffix every trace with a counter (always 1), to mimic dtrace output.

(See also [brendangregg/FlameGraph](https://github.com/brendangregg/FlameGraph).)

We have not yet cleaned up old code in `u3t_samp`.

---

After running some ship with `--profile`, we can use [the flamegraph scripts](https://github.com/brendangregg/FlameGraph) to turn the dump into an svg:

```bash
./stackcollapse.pl ~/piers/some-ship/.urb/put/trace/dump.txt | ./flamegraph.pl > dump.svg
```

If the ship ran `-build-file %/sys/hoon/hoon` under the profiler, the resulting svg might look something like this:

![image](https://github.com/urbit/vere/assets/3829764/f41dedd6-d196-4d4d-9890-2f19f61dc999)
