### PR TITLE
gitignore MODULE.bazel and lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /.user.bazelrc
 /bazel-*
 /urbit
+MODULE.bazel
+MODULE.bazel.lock
 
 # Swap files.
 *.swo


### PR DESCRIPTION
I can't think of a reason `MODULE.bazel` and `MODULE.bazel.lock`, both of which are auto-generated, shouldn't be in the `.gitignore` file.  I keep manually ignoring them.