### PR TITLE
lick: add `:` to prints to match other vanes

### DIFF
--- a/pkg/vere/io/lick.c
+++ b/pkg/vere/io/lick.c
@@ -224,7 +224,7 @@ _lick_close_chan(u3_chan* can_u)
     dev = _lick_string_to_path(gen_u->nam_c+1);
     mar = u3i_string("disconnect");
     dat = u3_nul;
-    
+
     cad = u3nq(c3__soak, dev, mar, dat);
 
     u3_auto_peer(
@@ -333,7 +333,7 @@ _lick_mkdirp(c3_c* por_c)
   c3_c pax_c[2048];
 
   strncpy(pax_c, por_c, sizeof(pax_c));
-  
+
   c3_c* fas_c = strchr(pax_c + 1, '/');
 
   while ( fas_c ) {
@@ -422,7 +422,7 @@ _lick_sock_err_chdir:
 static void
 _lick_ef_shut(u3_lick* lic_u, u3_noun nam)
 {
-  c3_c* nam_c = _lick_it_path(nam); 
+  c3_c* nam_c = _lick_it_path(nam);
 
   u3_port* cur_u = lic_u->gen_u;
   u3_port* las_u = NULL;
@@ -434,7 +434,7 @@ _lick_ef_shut(u3_lick* lic_u, u3_noun nam)
       if( las_u == NULL ) {
         lic_u->gen_u = cur_u->nex_u;
       }
-      else { 
+      else {
         las_u->nex_u = cur_u->nex_u;
       }
       c3_free(cur_u);
@@ -501,7 +501,7 @@ _lick_ef_spit(u3_lick* lic_u, u3_noun nam, u3_noun dat)
 
   if( c3y == gen_u->con_o ) {
     _lick_send_noun(gen_u->san_u->can_u, dat);
-  } 
+  }
   else {
     u3_noun dev, wir, cad, mar;
     u3z(dat);
@@ -538,11 +538,11 @@ _lick_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
     if ( (c3__spin == tag) ) {
       _lick_ef_spin(lic_u, u3k(tmp)); // execute spin command
       ret_o = c3y;
-    } 
+    }
     else if ( (c3__shut == tag) ) {
       _lick_ef_shut(lic_u, u3k(tmp)); // execute shut command
       ret_o = c3y;
-    } 
+    }
     else if ( c3__spit == tag ) {
       if ( c3y == u3r_cell(tmp, &nam, &dat) ) {
         _lick_ef_spit(lic_u, u3k(nam), u3k(dat));
@@ -633,9 +633,9 @@ u3_lick_io_init(u3_pier* pir_u)
   strcat(pax_c, URB_DEV_PATH);
 
   if ( -1 == stat(pax_c, &st) ) {
-    u3l_log("lick init mkdir %s",pax_c );
+    u3l_log("lick: init mkdir %s",pax_c );
     if ( mkdir(pax_c, 0700) && (errno != EEXIST) ) {
-      u3l_log("lick cannot make directory");
+      u3l_log("lick: cannot make directory");
       u3_king_bail();
     }
   }


### PR DESCRIPTION
This was bugging me:
```
lick init mkdir bus/.urb/dev
ames: live on 31519 (localhost only)
conn: listening on bus/.urb/conn.sock
```

This PR adds a `:` to all `%lick` debug prints so that it matches behavior of all the other vanes.