### PR TITLE
+checksum jets for zuse.hoon

### DIFF
--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -274,7 +274,7 @@ const c_source_files = [_][]const u8{
     "jets/e/base.c",
     "jets/e/blake.c",
     "jets/e/chacha.c",
-    "jets/e/crc32.c",
+    "jets/e/crc.c",
     "jets/e/cue.c",
     "jets/e/ed_add_double_scalarmult.c",
     "jets/e/ed_add_scalarmult_scalarmult_base.c",

--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -267,6 +267,7 @@ const c_source_files = [_][]const u8{
     "jets/d/in_tap.c",
     "jets/d/in_uni.c",
     "jets/d/in_wyt.c",
+    "jets/e/adler.c",
     "jets/e/aes_cbc.c",
     "jets/e/aes_ecb.c",
     "jets/e/aes_siv.c",

--- a/pkg/noun/jets/136/tree.c
+++ b/pkg/noun/jets/136/tree.c
@@ -107,6 +107,23 @@ static u3j_harm _136_hex_loss_a[] = {{".2", u3we_loss}, {}};
 static u3j_harm _136_hex_lune_a[] = {{".2", u3we_lune}, {}};
 
 
+static u3j_harm _136_hex__adler32_a[] = {{".2", u3we_adler32, c3y}, {}};
+static u3j_core  _136_hex__adler_d[] =
+  { { "adler32", 7, _137_hex__adler32_a, 0, no_hashes },
+    {}
+  };
+static u3j_harm _136_hex__crc32_a[] = {{".2", u3we_crc32}, {}};
+static u3j_core _136_hex__crc_d[] =
+  { {"crc32", 7, _136_hex__crc32_a, 0, no_hashes },
+    {}
+  };
+
+static u3j_core _136_hex_checksum_d[] =
+  { { "adler", 3, 0, _136_hex__adler_d, no_hashes },
+    { "crc", 3, 0, _136_hex__crc_d, no_hashes},
+    {}
+  };
+
 static u3j_harm _136_hex__crc32_a[] = {{".2", u3we_crc32}, {}};
 
 static u3j_core _136_hex__crc_d[] = {{"crc32", 7, _136_hex__crc32_a, 0, no_hashes }, {}};
@@ -951,6 +968,7 @@ static u3j_core _136_hex_d[] =
     { "mimes",  31, 0, _136_hex_mimes_d,  no_hashes },
     { "json",   31, 0, _136_hex_json_d,   no_hashes },
     { "wasm-sur-v0", 3, 0, _136_hex_wasm_sur_d, no_hashes },
+    { "checksum", 15, 0, _136_hex_checksum_d, no_hashes},
     {}
   };
 

--- a/pkg/noun/jets/136/tree.c
+++ b/pkg/noun/jets/136/tree.c
@@ -109,7 +109,7 @@ static u3j_harm _136_hex_lune_a[] = {{".2", u3we_lune}, {}};
 
 static u3j_harm _136_hex__adler32_a[] = {{".2", u3we_adler32, c3y}, {}};
 static u3j_core  _136_hex__adler_d[] =
-  { { "adler32", 7, _137_hex__adler32_a, 0, no_hashes },
+  { { "adler32", 7, _136_hex__adler32_a, 0, no_hashes },
     {}
   };
 static u3j_harm _136_hex__crc32_a[] = {{".2", u3we_crc32}, {}};
@@ -123,10 +123,6 @@ static u3j_core _136_hex_checksum_d[] =
     { "crc", 3, 0, _136_hex__crc_d, no_hashes},
     {}
   };
-
-static u3j_harm _136_hex__crc32_a[] = {{".2", u3we_crc32}, {}};
-
-static u3j_core _136_hex__crc_d[] = {{"crc32", 7, _136_hex__crc32_a, 0, no_hashes }, {}};
 
 
 static u3j_harm _136_hex_coed__ed_scad_a[] = {{".2", u3wee_scad}, {}};

--- a/pkg/noun/jets/e/adler.c
+++ b/pkg/noun/jets/e/adler.c
@@ -1,0 +1,127 @@
+#include <imprison.h>
+#include <jets/k.h>
+#include <log.h>
+#include <nock.h>
+#include <retrieve.h>
+#include <types.h>
+#include <xtract.h>
+
+static void _x_octs(u3_noun octs, u3_atom* p_octs, u3_atom* q_octs) {
+
+  if (c3n == u3r_mean(octs,
+             2, p_octs,
+             3, q_octs, 0)){
+    u3m_bail(c3__exit);
+  }
+
+  if (c3n == u3a_is_atom(*p_octs) ||
+      c3n == u3a_is_atom(*q_octs)) {
+    u3m_bail(c3__exit);
+  }
+}
+
+static c3_o _x_octs_buffer(u3_atom* p_octs, u3_atom *q_octs,
+                           c3_w* p_octs_w, c3_y** buf_y,
+                           c3_w* len_w, c3_w* lead_w)
+{
+  if (c3n == u3r_safe_word(*p_octs, p_octs_w)) {
+    return c3n;
+  }
+
+  *len_w = u3r_met(3, *q_octs);
+
+  if (c3y == u3a_is_cat(*q_octs)) {
+    *buf_y = (c3_y*)q_octs;
+  }
+  else {
+    u3a_atom* ptr_a = u3a_to_ptr(*q_octs);
+    *buf_y = (c3_y*)ptr_a->buf_w;
+  }
+
+  *lead_w = 0;
+
+  if (*p_octs_w > *len_w) {
+    *lead_w = *p_octs_w - *len_w;
+  }
+  else {
+    *len_w = *p_octs_w;
+  }
+
+  return c3y;
+}
+
+#define BASE 65521
+#define NMAX 5552
+
+u3_noun _qe_adler32(u3_noun octs)
+{
+  u3_atom p_octs, q_octs;
+
+  _x_octs(octs, &p_octs, &q_octs);
+
+  c3_w p_octs_w, len_w, lead_w;
+  c3_y *buf_y;
+
+  if (c3n == _x_octs_buffer(&p_octs, &q_octs,
+                            &p_octs_w, &buf_y,
+                            &len_w, &lead_w)) {
+    return u3_none;
+  }
+
+  c3_w adler_w, sum2_w;
+
+  adler_w = 0x1;
+  sum2_w = 0x0;
+
+  c3_w pos_w = 0;
+
+  // Process all non-zero bytes
+  //
+  while (pos_w < len_w) {
+
+    c3_w rem_w = (len_w - pos_w);
+
+    if (rem_w > NMAX) {
+      rem_w = NMAX;
+    }
+
+    while (rem_w--) {
+      adler_w += *(buf_y + pos_w++);
+      sum2_w += adler_w;
+    }
+
+    adler_w %= BASE;
+    sum2_w %= BASE;
+  }
+
+  // Process leading zeros
+  //
+  while (pos_w < p_octs_w) {
+
+    c3_w rem_w = (p_octs_w - pos_w);
+
+    if (rem_w > NMAX) {
+      rem_w = NMAX;
+    }
+
+    // leading zeros: adler sum is unchanged
+    sum2_w += rem_w*adler_w;
+    pos_w += rem_w;
+
+    adler_w %= BASE;
+    sum2_w %= BASE;
+  }
+
+  return u3i_word(sum2_w << 16 | adler_w);
+}
+
+
+u3_noun 
+u3we_adler32(u3_noun cor)
+{
+  u3_noun octs;
+
+  u3x_mean(cor, u3x_sam, &octs, 0);
+
+  return _qe_adler32(octs);
+}

--- a/pkg/noun/jets/e/crc.c
+++ b/pkg/noun/jets/e/crc.c
@@ -31,7 +31,7 @@ u3qe_crc32(u3_noun input_octs)
   if ( tel_w > hed_w ) {
     return u3m_error("subtract-underflow");
   }
-  
+
   c3_w led_w = hed_w - tel_w;
   c3_w crc_w = 0;
 

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -235,6 +235,9 @@
     u3_noun u3we_chacha_crypt(u3_noun);
     u3_noun u3we_chacha_xchacha(u3_noun);
 
+    u3_noun u3we_adler32(u3_noun);
+    u3_noun u3we_crc32(u3_noun);
+
     u3_noun u3we_ripe(u3_noun);
 
     u3_noun u3we_make(u3_noun);


### PR DESCRIPTION
This PR implements jets for newly introduced `+checksum` core in `zuse.hoon` in #7058.
