### PR TITLE
events: do not read garbage memory on empty control files

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -456,6 +456,10 @@ _ce_patch_read_control(u3_ce_patch* pat_u)
     len_w = (c3_w) buf_u.st_size;
   }
 
+  if (0 == len_w) {
+    return c3n;
+  }
+  
   pat_u->con_u = c3_malloc(len_w);
   if ( (len_w != read(pat_u->ctl_i, pat_u->con_u, len_w)) ||
         (len_w != sizeof(u3e_control) +


### PR DESCRIPTION
This is another one of the address sanitizer catches.

For whatever reason my directed messaging fakeship ended up in a situation with empty `control.bin` and `memory.bin`. When starting up this fakeship the address sanitizer blows up here:

https://github.com/urbit/vere/blob/f5799a9e778d3e479f1e81ab0b33a4da2807218b/pkg/noun/events.c#L459-L467

`len_w` is 0, `malloc(0)` is implementation defined but does give a non-null pointer on macos, which means that on line 462 we are reading random garbage. 