### PR TITLE
build: refactor and decouple pkg builds from main build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,9 +69,10 @@ Supported values:
 - soon
 - edge
 
-#### `-Dflags=[string]`
-Provide additional compiler flags. These propagate to all build artifacts and
-dependencies.
+#### `-Dcopt=[list]`
+Provide additional compiler flags. These propagate to all build artifacts.
+
+Example: `zig build -Dcopt="-g" -Dcopt="-fno-sanitize=all"`
 
 <!-- ## LSP Integration -->
 

--- a/build.zig
+++ b/build.zig
@@ -222,6 +222,13 @@ fn build_single(
     //
     // DEPENDENCIES
     //
+    const copts: []const []const u8 = urbit_flags.items;
+
+    const pkg_c3 = b.dependency("pkg_c3", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
 
     const avahi = b.dependency("avahi", .{
         .target = target,
@@ -317,12 +324,6 @@ fn build_single(
     // Install artifacts
     //
 
-    const pkg_c3 = b.addStaticLibrary(.{
-        .name = "c3",
-        .target = target,
-        .optimize = optimize,
-    });
-
     const pkg_ent = b.addStaticLibrary(.{
         .name = "ent",
         .target = target,
@@ -354,7 +355,6 @@ fn build_single(
     });
 
     const artifacts = [_]*std.Build.Step.Compile{
-        pkg_c3,
         pkg_ent,
         pkg_ur,
         pkg_noun,
@@ -387,7 +387,6 @@ fn build_single(
         });
 
         const steps = [_]*std.Build.Step.Compile{
-            pkg_c3,
             pkg_noun,
             vere,
             urbit,
@@ -401,26 +400,6 @@ fn build_single(
             }
         }
     }
-
-    //
-    // PKG C3
-    //
-
-    pkg_c3.linkLibC();
-
-    pkg_c3.addIncludePath(b.path("pkg/c3"));
-
-    pkg_c3.addCSourceFiles(.{
-        .root = b.path("pkg/c3"),
-        .files = &.{"defs.c"},
-        .flags = urbit_flags.items,
-    });
-
-    pkg_c3.installHeadersDirectory(b.path("pkg/c3"), "c3", .{
-        .include_extensions = &.{".h"},
-    });
-
-    // b.installArtifact(pkg_c3);
 
     //
     // PKG ENT
@@ -480,7 +459,7 @@ fn build_single(
     // PKG NOUN
     //
 
-    pkg_noun.linkLibrary(pkg_c3);
+    pkg_noun.linkLibrary(pkg_c3.artifact("c3"));
     pkg_noun.linkLibrary(pkg_ent);
     pkg_noun.linkLibrary(pkg_ur);
     pkg_noun.linkLibrary(backtrace.artifact("backtrace"));
@@ -791,7 +770,7 @@ fn build_single(
     vere.linkLibrary(openssl.artifact("ssl"));
     vere.linkLibrary(urcrypt.artifact("urcrypt"));
     vere.linkLibrary(zlib.artifact("z"));
-    vere.linkLibrary(pkg_c3);
+    vere.linkLibrary(pkg_c3.artifact("c3"));
     vere.linkLibrary(pkg_ent);
     vere.linkLibrary(pkg_noun);
     vere.linkLibrary(pkg_ur);
@@ -886,7 +865,7 @@ fn build_single(
 
     urbit.linkLibrary(vere);
     urbit.linkLibrary(pkg_noun);
-    urbit.linkLibrary(pkg_c3);
+    urbit.linkLibrary(pkg_c3.artifact("c3"));
     urbit.linkLibrary(pkg_ur);
 
     urbit.linkLibrary(gmp.artifact("gmp"));
@@ -943,7 +922,7 @@ fn build_single(
             optimize,
             "hashtable-test",
             "pkg/noun/hashtable_tests.c",
-            &.{ pkg_noun, pkg_c3, gmp.artifact("gmp") },
+            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
             noun_flags.items,
         );
         add_test(
@@ -952,7 +931,7 @@ fn build_single(
             optimize,
             "jets-test",
             "pkg/noun/jets_tests.c",
-            &.{ pkg_noun, pkg_c3, gmp.artifact("gmp") },
+            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
             noun_flags.items,
         );
         add_test(
@@ -961,7 +940,7 @@ fn build_single(
             optimize,
             "nock-test",
             "pkg/noun/nock_tests.c",
-            &.{ pkg_noun, pkg_c3, gmp.artifact("gmp") },
+            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
             noun_flags.items,
         );
         add_test(
@@ -970,7 +949,7 @@ fn build_single(
             optimize,
             "retrieve-test",
             "pkg/noun/retrieve_tests.c",
-            &.{ pkg_noun, pkg_c3, gmp.artifact("gmp") },
+            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
             noun_flags.items,
         );
         add_test(
@@ -979,7 +958,7 @@ fn build_single(
             optimize,
             "serial-test",
             "pkg/noun/serial_tests.c",
-            &.{ pkg_noun, pkg_c3, gmp.artifact("gmp") },
+            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
             noun_flags.items,
         );
 
@@ -995,7 +974,7 @@ fn build_single(
                 pkg_noun,
                 pkg_ur,
                 pkg_ent,
-                pkg_c3,
+                pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
                 lmdb.artifact("lmdb"),
@@ -1015,7 +994,7 @@ fn build_single(
                 pkg_noun,
                 pkg_ur,
                 pkg_ent,
-                pkg_c3,
+                pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
                 lmdb.artifact("lmdb"),
@@ -1034,7 +1013,7 @@ fn build_single(
                 pkg_noun,
                 pkg_ur,
                 pkg_ent,
-                pkg_c3,
+                pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
                 lmdb.artifact("lmdb"),
@@ -1053,7 +1032,7 @@ fn build_single(
                 pkg_noun,
                 pkg_ur,
                 pkg_ent,
-                pkg_c3,
+                pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
                 lmdb.artifact("lmdb"),
@@ -1072,7 +1051,7 @@ fn build_single(
                 pkg_noun,
                 pkg_ur,
                 pkg_ent,
-                pkg_c3,
+                pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
                 lmdb.artifact("lmdb"),
@@ -1091,7 +1070,7 @@ fn build_single(
                 pkg_noun,
                 pkg_ur,
                 pkg_ent,
-                pkg_c3,
+                pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
                 lmdb.artifact("lmdb"),

--- a/build.zig
+++ b/build.zig
@@ -41,19 +41,11 @@ pub fn build(b: *std.Build) !void {
         "Release train (Default: once)",
     ) orelse if (release) Pace.live else Pace.once);
 
-    const flags_opt = b.option(
-        []const u8,
-        "flags",
+    const copts: []const []const u8 = b.option(
+        []const []const u8,
+        "copt",
         "Provide additional compiler flags",
-    );
-    var flags = std.ArrayList([]const u8).init(b.allocator);
-    defer flags.deinit();
-    var iter_flags = std.mem.splitSequence(u8, flags_opt orelse "", " ");
-    while (iter_flags.next()) |flag| {
-        if (flag.len != 0) {
-            try flags.appendSlice(&.{flag});
-        }
-    }
+    ) orelse &.{};
 
     const cpu_dbg = b.option(
         bool,
@@ -111,7 +103,7 @@ pub fn build(b: *std.Build) !void {
     const build_cfg: BuildCfg = .{
         .version = version,
         .pace = pace,
-        .flags = flags.items,
+        .flags = copts,
         .binary_name = binary_name,
         .cpu_dbg = cpu_dbg,
         .mem_dbg = mem_dbg,

--- a/build.zig
+++ b/build.zig
@@ -236,6 +236,12 @@ fn build_single(
         .copt = copts,
     });
 
+    const pkg_ur = b.dependency("pkg_ur", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
     const avahi = b.dependency("avahi", .{
         .target = target,
         .optimize = optimize,
@@ -330,12 +336,6 @@ fn build_single(
     // Install artifacts
     //
 
-    const pkg_ur = b.addStaticLibrary(.{
-        .name = "ur",
-        .target = target,
-        .optimize = optimize,
-    });
-
     const pkg_noun = b.addStaticLibrary(.{
         .name = "noun",
         .target = target,
@@ -355,7 +355,6 @@ fn build_single(
     });
 
     const artifacts = [_]*std.Build.Step.Compile{
-        pkg_ur,
         pkg_noun,
         vere,
         urbit,
@@ -401,37 +400,12 @@ fn build_single(
     }
 
     //
-    // PKG UR
-    //
-
-    pkg_ur.linkLibrary(murmur3.artifact("murmur3"));
-    pkg_ur.linkLibC();
-
-    pkg_ur.addIncludePath(b.path("pkg/ur"));
-
-    pkg_ur.addCSourceFiles(.{
-        .root = b.path("pkg/ur"),
-        .files = &.{
-            "bitstream.c",
-            "hashcons.c",
-            "serial.c",
-        },
-        .flags = urbit_flags.items,
-    });
-
-    pkg_ur.installHeadersDirectory(b.path("pkg/ur"), "ur", .{
-        .include_extensions = &.{".h"},
-    });
-
-    // b.installArtifact(pkg_ur);
-
-    //
     // PKG NOUN
     //
 
     pkg_noun.linkLibrary(pkg_c3.artifact("c3"));
     pkg_noun.linkLibrary(pkg_ent.artifact("ent"));
-    pkg_noun.linkLibrary(pkg_ur);
+    pkg_noun.linkLibrary(pkg_ur.artifact("ur"));
     pkg_noun.linkLibrary(backtrace.artifact("backtrace"));
     pkg_noun.linkLibrary(gmp.artifact("gmp"));
     pkg_noun.linkLibrary(murmur3.artifact("murmur3"));
@@ -742,8 +716,8 @@ fn build_single(
     vere.linkLibrary(zlib.artifact("z"));
     vere.linkLibrary(pkg_c3.artifact("c3"));
     vere.linkLibrary(pkg_ent.artifact("ent"));
+    vere.linkLibrary(pkg_ur.artifact("ur"));
     vere.linkLibrary(pkg_noun);
-    vere.linkLibrary(pkg_ur);
     vere.linkLibC();
 
     var vere_srcs = std.ArrayList([]const u8).init(b.allocator);
@@ -836,7 +810,7 @@ fn build_single(
     urbit.linkLibrary(vere);
     urbit.linkLibrary(pkg_noun);
     urbit.linkLibrary(pkg_c3.artifact("c3"));
-    urbit.linkLibrary(pkg_ur);
+    urbit.linkLibrary(pkg_ur.artifact("ur"));
 
     urbit.linkLibrary(gmp.artifact("gmp"));
     urbit.linkLibrary(h2o.artifact("h2o"));
@@ -870,7 +844,7 @@ fn build_single(
             optimize,
             "ur-test",
             "pkg/ur/tests.c",
-            &.{pkg_ur},
+            &.{pkg_ur.artifact("ur")},
             urbit_flags.items,
         );
 
@@ -942,7 +916,7 @@ fn build_single(
             &.{
                 vere,
                 pkg_noun,
-                pkg_ur,
+                pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
@@ -962,7 +936,7 @@ fn build_single(
             &.{
                 vere,
                 pkg_noun,
-                pkg_ur,
+                pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
@@ -981,7 +955,7 @@ fn build_single(
             &.{
                 vere,
                 pkg_noun,
-                pkg_ur,
+                pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
@@ -1000,7 +974,7 @@ fn build_single(
             &.{
                 vere,
                 pkg_noun,
-                pkg_ur,
+                pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
@@ -1019,7 +993,7 @@ fn build_single(
             &.{
                 vere,
                 pkg_noun,
-                pkg_ur,
+                pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
@@ -1038,7 +1012,7 @@ fn build_single(
             &.{
                 vere,
                 pkg_noun,
-                pkg_ur,
+                pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),

--- a/build.zig
+++ b/build.zig
@@ -242,12 +242,13 @@ fn build_single(
         .copt = copts,
     });
 
-    const avahi = b.dependency("avahi", .{
+    const pkg_noun = b.dependency("pkg_noun", .{
         .target = target,
         .optimize = optimize,
+        .copt = copts,
     });
 
-    const backtrace = b.dependency("backtrace", .{
+    const avahi = b.dependency("avahi", .{
         .target = target,
         .optimize = optimize,
     });
@@ -277,11 +278,6 @@ fn build_single(
         .optimize = optimize,
     });
 
-    const murmur3 = b.dependency("murmur3", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
     const natpmp = b.dependency("natpmp", .{
         .target = target,
         .optimize = optimize,
@@ -292,27 +288,7 @@ fn build_single(
         .optimize = optimize,
     });
 
-    const pdjson = b.dependency("pdjson", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
     const sigsegv = b.dependency("sigsegv", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const softblas = b.dependency("softblas", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const softfloat = b.dependency("softfloat", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const unwind = b.dependency("unwind", .{
         .target = target,
         .optimize = optimize,
     });
@@ -336,12 +312,6 @@ fn build_single(
     // Install artifacts
     //
 
-    const pkg_noun = b.addStaticLibrary(.{
-        .name = "noun",
-        .target = target,
-        .optimize = optimize,
-    });
-
     const vere = b.addStaticLibrary(.{
         .name = "vere",
         .target = target,
@@ -355,7 +325,6 @@ fn build_single(
     });
 
     const artifacts = [_]*std.Build.Step.Compile{
-        pkg_noun,
         vere,
         urbit,
     };
@@ -385,7 +354,6 @@ fn build_single(
         });
 
         const steps = [_]*std.Build.Step.Compile{
-            pkg_noun,
             vere,
             urbit,
         };
@@ -398,269 +366,6 @@ fn build_single(
             }
         }
     }
-
-    //
-    // PKG NOUN
-    //
-
-    pkg_noun.linkLibrary(pkg_c3.artifact("c3"));
-    pkg_noun.linkLibrary(pkg_ent.artifact("ent"));
-    pkg_noun.linkLibrary(pkg_ur.artifact("ur"));
-    pkg_noun.linkLibrary(backtrace.artifact("backtrace"));
-    pkg_noun.linkLibrary(gmp.artifact("gmp"));
-    pkg_noun.linkLibrary(murmur3.artifact("murmur3"));
-    pkg_noun.linkLibrary(openssl.artifact("ssl"));
-    pkg_noun.linkLibrary(pdjson.artifact("pdjson"));
-    pkg_noun.linkLibrary(sigsegv.artifact("sigsegv"));
-    pkg_noun.linkLibrary(softfloat.artifact("softfloat"));
-    pkg_noun.linkLibrary(softblas.artifact("softblas"));
-    if (t.os.tag == .linux)
-        pkg_noun.linkLibrary(unwind.artifact("unwind"));
-    pkg_noun.linkLibrary(urcrypt.artifact("urcrypt"));
-    pkg_noun.linkLibrary(whereami.artifact("whereami"));
-    pkg_noun.linkLibrary(zlib.artifact("z"));
-    pkg_noun.linkLibC();
-
-    pkg_noun.addIncludePath(b.path("pkg/noun"));
-    if (t.os.tag.isDarwin())
-        pkg_noun.addIncludePath(b.path("pkg/noun/platform/darwin"));
-    if (t.os.tag == .linux)
-        pkg_noun.addIncludePath(b.path("pkg/noun/platform/linux"));
-
-    var noun_flags = std.ArrayList([]const u8).init(b.allocator);
-    defer noun_flags.deinit();
-
-    try noun_flags.appendSlice(&.{
-        "-pedantic",
-        "-std=gnu23",
-    });
-    try noun_flags.appendSlice(urbit_flags.items);
-
-    pkg_noun.addCSourceFiles(.{
-        .root = b.path("pkg/noun"),
-        .files = &.{
-            "allocate.c",
-            "events.c",
-            "hashtable.c",
-            "imprison.c",
-            "jets.c",
-            "jets/a/add.c",
-            "jets/a/dec.c",
-            "jets/a/div.c",
-            "jets/a/gte.c",
-            "jets/a/gth.c",
-            "jets/a/lte.c",
-            "jets/a/lth.c",
-            "jets/a/max.c",
-            "jets/a/min.c",
-            "jets/a/mod.c",
-            "jets/a/mul.c",
-            "jets/a/sub.c",
-            "jets/b/bind.c",
-            "jets/b/clap.c",
-            "jets/b/drop.c",
-            "jets/b/find.c",
-            "jets/b/flop.c",
-            "jets/b/lent.c",
-            "jets/b/levy.c",
-            "jets/b/lien.c",
-            "jets/b/mate.c",
-            "jets/b/murn.c",
-            "jets/b/need.c",
-            "jets/b/reap.c",
-            "jets/b/reel.c",
-            "jets/b/roll.c",
-            "jets/b/scag.c",
-            "jets/b/skid.c",
-            "jets/b/skim.c",
-            "jets/b/skip.c",
-            "jets/b/slag.c",
-            "jets/b/snag.c",
-            "jets/b/sort.c",
-            "jets/b/turn.c",
-            "jets/b/weld.c",
-            "jets/b/zing.c",
-            "jets/c/aor.c",
-            "jets/c/bex.c",
-            "jets/c/c0n.c",
-            "jets/c/can.c",
-            "jets/c/cap.c",
-            "jets/c/cat.c",
-            "jets/c/clz.c",
-            "jets/c/ctz.c",
-            "jets/c/cut.c",
-            "jets/c/dis.c",
-            "jets/c/dor.c",
-            "jets/c/dvr.c",
-            "jets/c/end.c",
-            "jets/c/gor.c",
-            "jets/c/ham.c",
-            "jets/c/hew.c",
-            "jets/c/lsh.c",
-            "jets/c/mas.c",
-            "jets/c/met.c",
-            "jets/c/mix.c",
-            "jets/c/mor.c",
-            "jets/c/mug.c",
-            "jets/c/muk.c",
-            "jets/c/peg.c",
-            "jets/c/po.c",
-            "jets/c/pow.c",
-            "jets/c/rap.c",
-            "jets/c/rep.c",
-            "jets/c/rev.c",
-            "jets/c/rig.c",
-            "jets/c/rip.c",
-            "jets/c/rsh.c",
-            "jets/c/sqt.c",
-            "jets/c/swp.c",
-            "jets/c/xeb.c",
-            "jets/d/by_all.c",
-            "jets/d/by_any.c",
-            "jets/d/by_apt.c",
-            "jets/d/by_bif.c",
-            "jets/d/by_del.c",
-            "jets/d/by_dif.c",
-            "jets/d/by_gas.c",
-            "jets/d/by_get.c",
-            "jets/d/by_has.c",
-            "jets/d/by_int.c",
-            "jets/d/by_jab.c",
-            "jets/d/by_key.c",
-            "jets/d/by_put.c",
-            "jets/d/by_run.c",
-            "jets/d/by_uni.c",
-            "jets/d/by_urn.c",
-            "jets/d/in_apt.c",
-            "jets/d/in_bif.c",
-            "jets/d/in_del.c",
-            "jets/d/in_dif.c",
-            "jets/d/in_gas.c",
-            "jets/d/in_has.c",
-            "jets/d/in_int.c",
-            "jets/d/in_put.c",
-            "jets/d/in_rep.c",
-            "jets/d/in_run.c",
-            "jets/d/in_tap.c",
-            "jets/d/in_uni.c",
-            "jets/d/in_wyt.c",
-            "jets/e/aes_cbc.c",
-            "jets/e/aes_ecb.c",
-            "jets/e/aes_siv.c",
-            "jets/e/argon2.c",
-            "jets/e/base.c",
-            "jets/e/blake.c",
-            "jets/e/chacha.c",
-            "jets/e/crc32.c",
-            "jets/e/cue.c",
-            "jets/e/ed_add_double_scalarmult.c",
-            "jets/e/ed_add_scalarmult_scalarmult_base.c",
-            "jets/e/ed_point_add.c",
-            "jets/e/ed_puck.c",
-            "jets/e/ed_scalarmult.c",
-            "jets/e/ed_scalarmult_base.c",
-            "jets/e/ed_shar.c",
-            "jets/e/ed_sign.c",
-            "jets/e/ed_veri.c",
-            "jets/e/fein_ob.c",
-            "jets/e/fl.c",
-            "jets/e/fynd_ob.c",
-            "jets/e/hmac.c",
-            "jets/e/jam.c",
-            "jets/e/json_de.c",
-            "jets/e/json_en.c",
-            "jets/e/keccak.c",
-            "jets/e/leer.c",
-            "jets/e/loss.c",
-            "jets/e/lune.c",
-            "jets/e/mat.c",
-            "jets/e/mink.c",
-            "jets/e/mole.c",
-            "jets/e/mule.c",
-            "jets/e/parse.c",
-            "jets/e/rd.c",
-            "jets/e/rh.c",
-            "jets/e/ripe.c",
-            "jets/e/rq.c",
-            "jets/e/rs.c",
-            "jets/e/rub.c",
-            "jets/e/scot.c",
-            "jets/e/scow.c",
-            "jets/e/scr.c",
-            "jets/e/secp.c",
-            "jets/e/sha1.c",
-            "jets/e/shax.c",
-            "jets/e/slaw.c",
-            "jets/e/tape.c",
-            "jets/e/trip.c",
-            "jets/f/cell.c",
-            "jets/f/comb.c",
-            "jets/f/cons.c",
-            "jets/f/core.c",
-            "jets/f/face.c",
-            "jets/f/fine.c",
-            "jets/f/fitz.c",
-            "jets/f/flan.c",
-            "jets/f/flip.c",
-            "jets/f/flor.c",
-            "jets/f/fork.c",
-            "jets/f/help.c",
-            "jets/f/hint.c",
-            "jets/f/look.c",
-            "jets/f/loot.c",
-            "jets/f/ut_crop.c",
-            "jets/f/ut_fish.c",
-            "jets/f/ut_fuse.c",
-            "jets/f/ut_mint.c",
-            "jets/f/ut_mull.c",
-            "jets/f/ut_nest.c",
-            "jets/f/ut_rest.c",
-            "jets/g/plot.c",
-            "jets/i/lagoon.c",
-            "jets/tree.c",
-            "jets/137/tree.c",
-            "log.c",
-            "manage.c",
-            "nock.c",
-            "options.c",
-            "retrieve.c",
-            "ship.c",
-            "serial.c",
-            "trace.c",
-            "urth.c",
-            "v1/allocate.c",
-            "v1/hashtable.c",
-            "v1/jets.c",
-            "v1/manage.c",
-            "v1/nock.c",
-            "v1/vortex.c",
-            "v2/allocate.c",
-            "v2/hashtable.c",
-            "v2/jets.c",
-            "v2/manage.c",
-            "v2/nock.c",
-            "v2/vortex.c",
-            "v3/hashtable.c",
-            "v3/manage.c",
-            "v4/manage.c",
-            "vortex.c",
-            "xtract.c",
-            "zave.c",
-        },
-        .flags = noun_flags.items,
-    });
-
-    pkg_noun.installHeadersDirectory(b.path("pkg/noun"), "", .{
-        .include_extensions = &.{".h"},
-    });
-
-    pkg_noun.installHeader(b.path(switch (t.os.tag) {
-        .macos => "pkg/noun/platform/darwin/rsignal.h",
-        .linux => "pkg/noun/platform/linux/rsignal.h",
-        else => "",
-    }), "platform/rsignal.h");
-
-    // b.installArtifact(pkg_noun);
 
     //
     // VERE LIBRARY
@@ -717,7 +422,7 @@ fn build_single(
     vere.linkLibrary(pkg_c3.artifact("c3"));
     vere.linkLibrary(pkg_ent.artifact("ent"));
     vere.linkLibrary(pkg_ur.artifact("ur"));
-    vere.linkLibrary(pkg_noun);
+    vere.linkLibrary(pkg_noun.artifact("noun"));
     vere.linkLibC();
 
     var vere_srcs = std.ArrayList([]const u8).init(b.allocator);
@@ -808,7 +513,7 @@ fn build_single(
     urbit.linkLibC();
 
     urbit.linkLibrary(vere);
-    urbit.linkLibrary(pkg_noun);
+    urbit.linkLibrary(pkg_noun.artifact("noun"));
     urbit.linkLibrary(pkg_c3.artifact("c3"));
     urbit.linkLibrary(pkg_ur.artifact("ur"));
 
@@ -866,8 +571,12 @@ fn build_single(
             optimize,
             "hashtable-test",
             "pkg/noun/hashtable_tests.c",
-            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
-            noun_flags.items,
+            &.{
+                pkg_noun.artifact("noun"),
+                pkg_c3.artifact("c3"),
+                gmp.artifact("gmp"),
+            },
+            urbit_flags.items,
         );
         add_test(
             b,
@@ -875,8 +584,12 @@ fn build_single(
             optimize,
             "jets-test",
             "pkg/noun/jets_tests.c",
-            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
-            noun_flags.items,
+            &.{
+                pkg_noun.artifact("noun"),
+                pkg_c3.artifact("c3"),
+                gmp.artifact("gmp"),
+            },
+            urbit_flags.items,
         );
         add_test(
             b,
@@ -884,8 +597,12 @@ fn build_single(
             optimize,
             "nock-test",
             "pkg/noun/nock_tests.c",
-            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
-            noun_flags.items,
+            &.{
+                pkg_noun.artifact("noun"),
+                pkg_c3.artifact("c3"),
+                gmp.artifact("gmp"),
+            },
+            urbit_flags.items,
         );
         add_test(
             b,
@@ -893,8 +610,12 @@ fn build_single(
             optimize,
             "retrieve-test",
             "pkg/noun/retrieve_tests.c",
-            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
-            noun_flags.items,
+            &.{
+                pkg_noun.artifact("noun"),
+                pkg_c3.artifact("c3"),
+                gmp.artifact("gmp"),
+            },
+            urbit_flags.items,
         );
         add_test(
             b,
@@ -902,8 +623,12 @@ fn build_single(
             optimize,
             "serial-test",
             "pkg/noun/serial_tests.c",
-            &.{ pkg_noun, pkg_c3.artifact("c3"), gmp.artifact("gmp") },
-            noun_flags.items,
+            &.{
+                pkg_noun.artifact("noun"),
+                pkg_c3.artifact("c3"),
+                gmp.artifact("gmp"),
+            },
+            urbit_flags.items,
         );
 
         // vere
@@ -915,7 +640,7 @@ fn build_single(
             "pkg/vere/ames_tests.c",
             &.{
                 vere,
-                pkg_noun,
+                pkg_noun.artifact("noun"),
                 pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
@@ -935,7 +660,7 @@ fn build_single(
             "pkg/vere/boot_tests.c",
             &.{
                 vere,
-                pkg_noun,
+                pkg_noun.artifact("noun"),
                 pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
@@ -954,7 +679,7 @@ fn build_single(
             "pkg/vere/newt_tests.c",
             &.{
                 vere,
-                pkg_noun,
+                pkg_noun.artifact("noun"),
                 pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
@@ -973,7 +698,7 @@ fn build_single(
             "pkg/vere/noun_tests.c",
             &.{
                 vere,
-                pkg_noun,
+                pkg_noun.artifact("noun"),
                 pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
@@ -992,7 +717,7 @@ fn build_single(
             "pkg/vere/unix_tests.c",
             &.{
                 vere,
-                pkg_noun,
+                pkg_noun.artifact("noun"),
                 pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
@@ -1011,7 +736,7 @@ fn build_single(
             "pkg/vere/benchmarks.c",
             &.{
                 vere,
-                pkg_noun,
+                pkg_noun.artifact("noun"),
                 pkg_ur.artifact("ur"),
                 pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),

--- a/build.zig
+++ b/build.zig
@@ -230,6 +230,12 @@ fn build_single(
         .copt = copts,
     });
 
+    const pkg_ent = b.dependency("pkg_ent", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
     const avahi = b.dependency("avahi", .{
         .target = target,
         .optimize = optimize,
@@ -324,12 +330,6 @@ fn build_single(
     // Install artifacts
     //
 
-    const pkg_ent = b.addStaticLibrary(.{
-        .name = "ent",
-        .target = target,
-        .optimize = optimize,
-    });
-
     const pkg_ur = b.addStaticLibrary(.{
         .name = "ur",
         .target = target,
@@ -355,7 +355,6 @@ fn build_single(
     });
 
     const artifacts = [_]*std.Build.Step.Compile{
-        pkg_ent,
         pkg_ur,
         pkg_noun,
         vere,
@@ -402,35 +401,6 @@ fn build_single(
     }
 
     //
-    // PKG ENT
-    //
-
-    pkg_ent.linkLibC();
-
-    pkg_ent.addIncludePath(b.path("pkg/ent"));
-
-    var ent_flags = std.ArrayList([]const u8).init(b.allocator);
-    defer ent_flags.deinit();
-
-    try ent_flags.appendSlice(&.{
-        "-pedantic",
-        "-std=gnu99",
-    });
-    try ent_flags.appendSlice(urbit_flags.items);
-
-    pkg_ent.addCSourceFiles(.{
-        .root = b.path("pkg/ent"),
-        .files = &.{"ent.c"},
-        .flags = ent_flags.items,
-    });
-
-    pkg_ent.installHeadersDirectory(b.path("pkg/ent"), "ent", .{
-        .include_extensions = &.{".h"},
-    });
-
-    // b.installArtifact(pkg_ent);
-
-    //
     // PKG UR
     //
 
@@ -460,7 +430,7 @@ fn build_single(
     //
 
     pkg_noun.linkLibrary(pkg_c3.artifact("c3"));
-    pkg_noun.linkLibrary(pkg_ent);
+    pkg_noun.linkLibrary(pkg_ent.artifact("ent"));
     pkg_noun.linkLibrary(pkg_ur);
     pkg_noun.linkLibrary(backtrace.artifact("backtrace"));
     pkg_noun.linkLibrary(gmp.artifact("gmp"));
@@ -771,7 +741,7 @@ fn build_single(
     vere.linkLibrary(urcrypt.artifact("urcrypt"));
     vere.linkLibrary(zlib.artifact("z"));
     vere.linkLibrary(pkg_c3.artifact("c3"));
-    vere.linkLibrary(pkg_ent);
+    vere.linkLibrary(pkg_ent.artifact("ent"));
     vere.linkLibrary(pkg_noun);
     vere.linkLibrary(pkg_ur);
     vere.linkLibC();
@@ -911,7 +881,7 @@ fn build_single(
             optimize,
             "ent-test",
             "pkg/ent/tests.c",
-            &.{pkg_ent},
+            &.{pkg_ent.artifact("ent")},
             urbit_flags.items,
         );
 
@@ -973,7 +943,7 @@ fn build_single(
                 vere,
                 pkg_noun,
                 pkg_ur,
-                pkg_ent,
+                pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
@@ -993,7 +963,7 @@ fn build_single(
                 vere,
                 pkg_noun,
                 pkg_ur,
-                pkg_ent,
+                pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
@@ -1012,7 +982,7 @@ fn build_single(
                 vere,
                 pkg_noun,
                 pkg_ur,
-                pkg_ent,
+                pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
@@ -1031,7 +1001,7 @@ fn build_single(
                 vere,
                 pkg_noun,
                 pkg_ur,
-                pkg_ent,
+                pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
@@ -1050,7 +1020,7 @@ fn build_single(
                 vere,
                 pkg_noun,
                 pkg_ur,
-                pkg_ent,
+                pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),
@@ -1069,7 +1039,7 @@ fn build_single(
                 vere,
                 pkg_noun,
                 pkg_ur,
-                pkg_ent,
+                pkg_ent.artifact("ent"),
                 pkg_c3.artifact("c3"),
                 gmp.artifact("gmp"),
                 libuv.artifact("libuv"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,9 +42,6 @@
         },
         .openssl = .{
             .path = "./ext/openssl",
-            // .path = "../../Github/openssl-zig",
-            // .url = "https://github.com/kassane/openssl-zig/archive/724d6ed89b5b80a04161290d1f72995b7415fe8e.tar.gz",
-            // .hash = "1220a3f6278247c16e9b4876e2df2361d2a0d45f42ccd21d85066a22a65235394e7b",
         },
         .sigsegv = .{
             .path = "./ext/sigsegv",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,11 +16,11 @@
         .pkg_ur = .{
             .path = "./pkg/ur",
         },
+        .pkg_noun = .{
+            .path = "./pkg/noun",
+        },
         .avahi = .{
             .path = "./ext/avahi",
-        },
-        .backtrace = .{
-            .path = "./ext/backtrace",
         },
         .curl = .{
             .path = "./ext/curl",
@@ -37,9 +37,6 @@
         .lmdb = .{
             .path = "./ext/lmdb",
         },
-        .murmur3 = .{
-            .path = "./ext/murmur3",
-        },
         .natpmp = .{
             .path = "./ext/natpmp",
         },
@@ -49,20 +46,8 @@
             // .url = "https://github.com/kassane/openssl-zig/archive/724d6ed89b5b80a04161290d1f72995b7415fe8e.tar.gz",
             // .hash = "1220a3f6278247c16e9b4876e2df2361d2a0d45f42ccd21d85066a22a65235394e7b",
         },
-        .pdjson = .{
-            .path = "./ext/pdjson",
-        },
         .sigsegv = .{
             .path = "./ext/sigsegv",
-        },
-        .softfloat = .{
-            .path = "./ext/softfloat",
-        },
-        .softblas = .{
-            .path = "./ext/softblas",
-        },
-        .unwind = .{
-            .path = "./ext/unwind",
         },
         .urcrypt = .{
             .path = "./ext/urcrypt",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,6 +10,9 @@
         .pkg_c3 = .{
             .path = "./pkg/c3",
         },
+        .pkg_ent = .{
+            .path = "./pkg/ent",
+        },
         .avahi = .{
             .path = "./ext/avahi",
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,6 +13,9 @@
         .pkg_ent = .{
             .path = "./pkg/ent",
         },
+        .pkg_ur = .{
+            .path = "./pkg/ur",
+        },
         .avahi = .{
             .path = "./ext/avahi",
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,6 +7,9 @@
             .hash = "122033a9c16c63f66ba4c83d6c61f487b06a6435ed57201eaccb4c5703ce4cdd956e",
             .lazy = true,
         },
+        .pkg_c3 = .{
+            .path = "./pkg/c3",
+        },
         .avahi = .{
             .path = "./ext/avahi",
         },

--- a/ext/curl/build.zig.zon
+++ b/ext/curl/build.zig.zon
@@ -8,9 +8,6 @@
         },
         .openssl = .{
             .path = "../openssl",
-            // .path = "../../../../Github/openssl-zig",
-            // .url = "https://github.com/kassane/openssl-zig/archive/724d6ed89b5b80a04161290d1f72995b7415fe8e.tar.gz",
-            // .hash = "1220a3f6278247c16e9b4876e2df2361d2a0d45f42ccd21d85066a22a65235394e7b",
         },
     },
     .paths = .{

--- a/ext/h2o/build.zig.zon
+++ b/ext/h2o/build.zig.zon
@@ -11,9 +11,6 @@
         },
         .openssl = .{
             .path = "../openssl",
-            // .path = "../../../../Github/openssl-zig",
-            // .url = "https://github.com/kassane/openssl-zig/archive/724d6ed89b5b80a04161290d1f72995b7415fe8e.tar.gz",
-            // .hash = "1220a3f6278247c16e9b4876e2df2361d2a0d45f42ccd21d85066a22a65235394e7b",
         },
         .curl = .{
             .path = "../curl",

--- a/ext/openssl/build.zig.zon
+++ b/ext/openssl/build.zig.zon
@@ -7,10 +7,6 @@
             .hash = "122033a9c16c63f66ba4c83d6c61f487b06a6435ed57201eaccb4c5703ce4cdd956e",
             .lazy = true,
         },
-        // .openssl = .{
-        //     .url = "https://github.com/openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz",
-        //     .hash = "122036841d37585c881aa56891a05e16e32115c71c09eb831ab1225938603702f08d",
-        // },
         .openssl = .{
             .url = "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz",
             .hash = "122042b0a69fc3deee3c603b11046f15693046e5cfcf56858e028b9ea4dc4b78b81a",

--- a/ext/urcrypt/build.zig.zon
+++ b/ext/urcrypt/build.zig.zon
@@ -8,9 +8,6 @@
         },
         .openssl = .{
             .path = "../openssl",
-            // .path = "../../../../Github/openssl-zig",
-            // .url = "https://github.com/kassane/openssl-zig/archive/724d6ed89b5b80a04161290d1f72995b7415fe8e.tar.gz",
-            // .hash = "1220a3f6278247c16e9b4876e2df2361d2a0d45f42ccd21d85066a22a65235394e7b",
         },
         .secp256k1 = .{
             .url = "https://github.com/bitcoin-core/secp256k1/archive/refs/tags/v0.5.1.tar.gz",

--- a/pkg/c3/build.zig
+++ b/pkg/c3/build.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const copts: []const []const u8 =
+        b.option([]const []const u8, "copt", "") orelse &.{};
+
+    const pkg_c3 = b.addStaticLibrary(.{
+        .name = "c3",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    if (target.result.isDarwin() and !target.query.isNative()) {
+        const macos_sdk = b.lazyDependency("macos_sdk", .{
+            .target = target,
+            .optimize = optimize,
+        });
+        if (macos_sdk != null) {
+            pkg_c3.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            pkg_c3.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            pkg_c3.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+        }
+    }
+
+    pkg_c3.linkLibC();
+
+    pkg_c3.addIncludePath(b.path(""));
+
+    pkg_c3.addCSourceFiles(.{
+        .root = b.path(""),
+        .files = &.{"defs.c"},
+        .flags = copts,
+    });
+
+    pkg_c3.installHeader(b.path("c3.h"), "c3/c3.h");
+    pkg_c3.installHeader(b.path("defs.h"), "c3/defs.h");
+    pkg_c3.installHeader(b.path("motes.h"), "c3/motes.h");
+    pkg_c3.installHeader(b.path("portable.h"), "c3/portable.h");
+    pkg_c3.installHeader(b.path("types.h"), "c3/types.h");
+
+    b.installArtifact(pkg_c3);
+}

--- a/pkg/c3/build.zig.zon
+++ b/pkg/c3/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = "c3",
+    .version = "0.0.1",
+    .dependencies = .{
+        .macos_sdk = .{
+            .url = "https://github.com/joseluisq/macosx-sdks/releases/download/14.5/MacOSX14.5.sdk.tar.xz",
+            .hash = "122033a9c16c63f66ba4c83d6c61f487b06a6435ed57201eaccb4c5703ce4cdd956e",
+            .lazy = true,
+        },
+    },
+    .paths = .{
+        "",
+    },
+}

--- a/pkg/ent/build.zig
+++ b/pkg/ent/build.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const copts: []const []const u8 =
+        b.option([]const []const u8, "copt", "") orelse &.{};
+
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+    try flags.appendSlice(&.{
+        "-pedantic",
+        "-std=gnu99",
+    });
+    try flags.appendSlice(copts);
+
+    const pkg_ent = b.addStaticLibrary(.{
+        .name = "ent",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    pkg_ent.linkLibC();
+
+    pkg_ent.addIncludePath(b.path(""));
+
+    pkg_ent.addCSourceFiles(.{
+        .root = b.path(""),
+        .files = &.{"ent.c"},
+        .flags = flags.items,
+    });
+
+    pkg_ent.installHeader(b.path("ent.h"), "ent/ent.h");
+
+    b.installArtifact(pkg_ent);
+}

--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -1,0 +1,413 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const t = target.result;
+
+    const copts: []const []const u8 =
+        b.option([]const []const u8, "copt", "") orelse &.{};
+
+    const pkg_noun = b.addStaticLibrary(.{
+        .name = "noun",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    if (target.result.isDarwin() and !target.query.isNative()) {
+        const macos_sdk = b.lazyDependency("macos_sdk", .{
+            .target = target,
+            .optimize = optimize,
+        });
+        if (macos_sdk != null) {
+            pkg_noun.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            pkg_noun.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            pkg_noun.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+        }
+    }
+
+    const pkg_c3 = b.dependency("pkg_c3", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
+    const pkg_ent = b.dependency("pkg_ent", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
+    const pkg_ur = b.dependency("pkg_ur", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
+    const backtrace = b.dependency("backtrace", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const gmp = b.dependency("gmp", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const murmur3 = b.dependency("murmur3", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const openssl = b.dependency("openssl", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const pdjson = b.dependency("pdjson", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const sigsegv = b.dependency("sigsegv", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const softblas = b.dependency("softblas", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const softfloat = b.dependency("softfloat", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const unwind = b.dependency("unwind", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const urcrypt = b.dependency("urcrypt", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const whereami = b.dependency("whereami", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const zlib = b.dependency("zlib", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    pkg_noun.linkLibC();
+
+    pkg_noun.linkLibrary(pkg_c3.artifact("c3"));
+    pkg_noun.linkLibrary(pkg_ent.artifact("ent"));
+    pkg_noun.linkLibrary(pkg_ur.artifact("ur"));
+
+    pkg_noun.linkLibrary(backtrace.artifact("backtrace"));
+    pkg_noun.linkLibrary(gmp.artifact("gmp"));
+    pkg_noun.linkLibrary(murmur3.artifact("murmur3"));
+    pkg_noun.linkLibrary(openssl.artifact("ssl"));
+    pkg_noun.linkLibrary(pdjson.artifact("pdjson"));
+    pkg_noun.linkLibrary(sigsegv.artifact("sigsegv"));
+    pkg_noun.linkLibrary(softblas.artifact("softblas"));
+    pkg_noun.linkLibrary(softfloat.artifact("softfloat"));
+    if (t.os.tag == .linux)
+        pkg_noun.linkLibrary(unwind.artifact("unwind"));
+    pkg_noun.linkLibrary(urcrypt.artifact("urcrypt"));
+    pkg_noun.linkLibrary(whereami.artifact("whereami"));
+    pkg_noun.linkLibrary(zlib.artifact("z"));
+
+    pkg_noun.addIncludePath(b.path(""));
+    if (t.os.tag.isDarwin())
+        pkg_noun.addIncludePath(b.path("platform/darwin"));
+    if (t.os.tag == .linux)
+        pkg_noun.addIncludePath(b.path("platform/linux"));
+
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+    try flags.appendSlice(&.{
+        "-pedantic",
+        "-std=gnu23",
+    });
+    try flags.appendSlice(copts);
+
+    pkg_noun.addCSourceFiles(.{
+        .root = b.path(""),
+        .files = &c_source_files,
+        .flags = flags.items,
+    });
+
+    for (install_headers) |h| pkg_noun.installHeader(b.path(h), h);
+
+    pkg_noun.installHeader(b.path(switch (t.os.tag) {
+        .macos => "platform/darwin/rsignal.h",
+        .linux => "platform/linux/rsignal.h",
+        else => "",
+    }), "platform/rsignal.h");
+
+    b.installArtifact(pkg_noun);
+}
+
+const c_source_files = [_][]const u8{
+    "allocate.c",
+    "events.c",
+    "hashtable.c",
+    "imprison.c",
+    "jets.c",
+    "jets/a/add.c",
+    "jets/a/dec.c",
+    "jets/a/div.c",
+    "jets/a/gte.c",
+    "jets/a/gth.c",
+    "jets/a/lte.c",
+    "jets/a/lth.c",
+    "jets/a/max.c",
+    "jets/a/min.c",
+    "jets/a/mod.c",
+    "jets/a/mul.c",
+    "jets/a/sub.c",
+    "jets/b/bind.c",
+    "jets/b/clap.c",
+    "jets/b/drop.c",
+    "jets/b/find.c",
+    "jets/b/flop.c",
+    "jets/b/lent.c",
+    "jets/b/levy.c",
+    "jets/b/lien.c",
+    "jets/b/mate.c",
+    "jets/b/murn.c",
+    "jets/b/need.c",
+    "jets/b/reap.c",
+    "jets/b/reel.c",
+    "jets/b/roll.c",
+    "jets/b/scag.c",
+    "jets/b/skid.c",
+    "jets/b/skim.c",
+    "jets/b/skip.c",
+    "jets/b/slag.c",
+    "jets/b/snag.c",
+    "jets/b/sort.c",
+    "jets/b/turn.c",
+    "jets/b/weld.c",
+    "jets/b/zing.c",
+    "jets/c/aor.c",
+    "jets/c/bex.c",
+    "jets/c/c0n.c",
+    "jets/c/can.c",
+    "jets/c/cap.c",
+    "jets/c/cat.c",
+    "jets/c/clz.c",
+    "jets/c/ctz.c",
+    "jets/c/cut.c",
+    "jets/c/dis.c",
+    "jets/c/dor.c",
+    "jets/c/dvr.c",
+    "jets/c/end.c",
+    "jets/c/gor.c",
+    "jets/c/ham.c",
+    "jets/c/hew.c",
+    "jets/c/lsh.c",
+    "jets/c/mas.c",
+    "jets/c/met.c",
+    "jets/c/mix.c",
+    "jets/c/mor.c",
+    "jets/c/mug.c",
+    "jets/c/muk.c",
+    "jets/c/peg.c",
+    "jets/c/po.c",
+    "jets/c/pow.c",
+    "jets/c/rap.c",
+    "jets/c/rep.c",
+    "jets/c/rev.c",
+    "jets/c/rig.c",
+    "jets/c/rip.c",
+    "jets/c/rsh.c",
+    "jets/c/sqt.c",
+    "jets/c/swp.c",
+    "jets/c/xeb.c",
+    "jets/d/by_all.c",
+    "jets/d/by_any.c",
+    "jets/d/by_apt.c",
+    "jets/d/by_bif.c",
+    "jets/d/by_del.c",
+    "jets/d/by_dif.c",
+    "jets/d/by_gas.c",
+    "jets/d/by_get.c",
+    "jets/d/by_has.c",
+    "jets/d/by_int.c",
+    "jets/d/by_jab.c",
+    "jets/d/by_key.c",
+    "jets/d/by_put.c",
+    "jets/d/by_run.c",
+    "jets/d/by_uni.c",
+    "jets/d/by_urn.c",
+    "jets/d/in_apt.c",
+    "jets/d/in_bif.c",
+    "jets/d/in_del.c",
+    "jets/d/in_dif.c",
+    "jets/d/in_gas.c",
+    "jets/d/in_has.c",
+    "jets/d/in_int.c",
+    "jets/d/in_put.c",
+    "jets/d/in_rep.c",
+    "jets/d/in_run.c",
+    "jets/d/in_tap.c",
+    "jets/d/in_uni.c",
+    "jets/d/in_wyt.c",
+    "jets/e/aes_cbc.c",
+    "jets/e/aes_ecb.c",
+    "jets/e/aes_siv.c",
+    "jets/e/argon2.c",
+    "jets/e/base.c",
+    "jets/e/blake.c",
+    "jets/e/chacha.c",
+    "jets/e/crc32.c",
+    "jets/e/cue.c",
+    "jets/e/ed_add_double_scalarmult.c",
+    "jets/e/ed_add_scalarmult_scalarmult_base.c",
+    "jets/e/ed_point_add.c",
+    "jets/e/ed_puck.c",
+    "jets/e/ed_scalarmult.c",
+    "jets/e/ed_scalarmult_base.c",
+    "jets/e/ed_shar.c",
+    "jets/e/ed_sign.c",
+    "jets/e/ed_veri.c",
+    "jets/e/fein_ob.c",
+    "jets/e/fl.c",
+    "jets/e/fynd_ob.c",
+    "jets/e/hmac.c",
+    "jets/e/jam.c",
+    "jets/e/json_de.c",
+    "jets/e/json_en.c",
+    "jets/e/keccak.c",
+    "jets/e/leer.c",
+    "jets/e/loss.c",
+    "jets/e/lune.c",
+    "jets/e/mat.c",
+    "jets/e/mink.c",
+    "jets/e/mole.c",
+    "jets/e/mule.c",
+    "jets/e/parse.c",
+    "jets/e/rd.c",
+    "jets/e/rh.c",
+    "jets/e/ripe.c",
+    "jets/e/rq.c",
+    "jets/e/rs.c",
+    "jets/e/rub.c",
+    "jets/e/scot.c",
+    "jets/e/scow.c",
+    "jets/e/scr.c",
+    "jets/e/secp.c",
+    "jets/e/sha1.c",
+    "jets/e/shax.c",
+    "jets/e/slaw.c",
+    "jets/e/tape.c",
+    "jets/e/trip.c",
+    "jets/f/cell.c",
+    "jets/f/comb.c",
+    "jets/f/cons.c",
+    "jets/f/core.c",
+    "jets/f/face.c",
+    "jets/f/fine.c",
+    "jets/f/fitz.c",
+    "jets/f/flan.c",
+    "jets/f/flip.c",
+    "jets/f/flor.c",
+    "jets/f/fork.c",
+    "jets/f/help.c",
+    "jets/f/hint.c",
+    "jets/f/look.c",
+    "jets/f/loot.c",
+    "jets/f/ut_crop.c",
+    "jets/f/ut_fish.c",
+    "jets/f/ut_fuse.c",
+    "jets/f/ut_mint.c",
+    "jets/f/ut_mull.c",
+    "jets/f/ut_nest.c",
+    "jets/f/ut_rest.c",
+    "jets/g/plot.c",
+    "jets/i/lagoon.c",
+    "jets/tree.c",
+    "jets/137/tree.c",
+    "log.c",
+    "manage.c",
+    "nock.c",
+    "options.c",
+    "retrieve.c",
+    "ship.c",
+    "serial.c",
+    "trace.c",
+    "urth.c",
+    "v1/allocate.c",
+    "v1/hashtable.c",
+    "v1/jets.c",
+    "v1/manage.c",
+    "v1/nock.c",
+    "v1/vortex.c",
+    "v2/allocate.c",
+    "v2/hashtable.c",
+    "v2/jets.c",
+    "v2/manage.c",
+    "v2/nock.c",
+    "v2/vortex.c",
+    "v3/hashtable.c",
+    "v3/manage.c",
+    "v4/manage.c",
+    "vortex.c",
+    "xtract.c",
+    "zave.c",
+};
+
+const install_headers = [_][]const u8{
+    "allocate.h",
+    "error.h",
+    "events.h",
+    "hashtable.h",
+    "imprison.h",
+    "jets.h",
+    "jets/k.h",
+    "jets/q.h",
+    "jets/w.h",
+    "log.h",
+    "manage.h",
+    "nock.h",
+    "noun.h",
+    "options.h",
+    "retrieve.h",
+    "serial.h",
+    "ship.h",
+    "trace.h",
+    "types.h",
+    "urth.h",
+    "v1/allocate.h",
+    "v1/hashtable.h",
+    "v1/jets.h",
+    "v1/manage.h",
+    "v1/nock.h",
+    "v1/vortex.h",
+    "v2/allocate.h",
+    "v2/hashtable.h",
+    "v2/jets.h",
+    "v2/manage.h",
+    "v2/nock.h",
+    "v2/options.h",
+    "v2/vortex.h",
+    "v3/allocate.h",
+    "v3/hashtable.h",
+    "v3/jets.h",
+    "v3/manage.h",
+    "v3/nock.h",
+    "v3/vortex.h",
+    "v4/manage.h",
+    "version.h",
+    "vortex.h",
+    "xtract.h",
+    "zave.h",
+};

--- a/pkg/noun/build.zig.zon
+++ b/pkg/noun/build.zig.zon
@@ -1,0 +1,60 @@
+.{
+    .name = "noun",
+    .version = "0.0.1",
+    .dependencies = .{
+        .macos_sdk = .{
+            .url = "https://github.com/joseluisq/macosx-sdks/releases/download/14.5/MacOSX14.5.sdk.tar.xz",
+            .hash = "122033a9c16c63f66ba4c83d6c61f487b06a6435ed57201eaccb4c5703ce4cdd956e",
+            .lazy = true,
+        },
+        .pkg_c3 = .{
+            .path = "../c3",
+        },
+        .pkg_ent = .{
+            .path = "../ent",
+        },
+        .pkg_ur = .{
+            .path = "../ur",
+        },
+        .backtrace = .{
+            .path = "../../ext/backtrace",
+        },
+        .gmp = .{
+            .path = "../../ext/gmp",
+        },
+        .murmur3 = .{
+            .path = "../../ext/murmur3",
+        },
+        .openssl = .{
+            .path = "../../ext/openssl",
+        },
+        .pdjson = .{
+            .path = "../../ext/pdjson",
+        },
+        .sigsegv = .{
+            .path = "../../ext/sigsegv",
+        },
+        .softblas = .{
+            .path = "../../ext/softblas",
+        },
+        .softfloat = .{
+            .path = "../../ext/softfloat",
+        },
+        .unwind = .{
+            .path = "../../ext/unwind",
+        },
+        .urcrypt = .{
+            .path = "../../ext/urcrypt",
+        },
+        .whereami = .{
+            .path = "../../ext/whereami",
+        },
+        .zlib = .{
+            .url = "https://github.com/allyourcodebase/zlib/archive/0918e87b7629b9c6a50a08edd0ce30d849758faf.tar.gz",
+            .hash = "122034ab2a12adf8016ffa76e48b4be3245ffd305193edba4d83058adbcfa749c107",
+        },
+    },
+    .paths = .{
+        "",
+    },
+}

--- a/pkg/ur/build.zig
+++ b/pkg/ur/build.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const copts: []const []const u8 =
+        b.option([]const []const u8, "copt", "") orelse &.{};
+
+    const pkg_ur = b.addStaticLibrary(.{
+        .name = "ur",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const murmur3 = b.dependency("murmur3", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    pkg_ur.linkLibC();
+    pkg_ur.linkLibrary(murmur3.artifact("murmur3"));
+
+    pkg_ur.addIncludePath(b.path(""));
+    pkg_ur.addCSourceFiles(.{
+        .root = b.path(""),
+        .files = &.{
+            "bitstream.c",
+            "hashcons.c",
+            "serial.c",
+        },
+        .flags = copts,
+    });
+
+    pkg_ur.installHeader(b.path("bitstream.h"), "ur/bitstream.h");
+    pkg_ur.installHeader(b.path("defs.h"), "ur/defs.h");
+    pkg_ur.installHeader(b.path("hashcons.h"), "ur/hashcons.h");
+    pkg_ur.installHeader(b.path("serial.h"), "ur/serial.h");
+    pkg_ur.installHeader(b.path("ur.h"), "ur/ur.h");
+
+    b.installArtifact(pkg_ur);
+}

--- a/pkg/ur/build.zig.zon
+++ b/pkg/ur/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = "ur",
+    .version = "0.0.1",
+    .dependencies = .{
+        .murmur3 = .{
+            .path = "../../ext/murmur3",
+        },
+    },
+    .paths = .{
+        "",
+    },
+}

--- a/pkg/vere/build.zig
+++ b/pkg/vere/build.zig
@@ -1,0 +1,247 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const t = target.result;
+
+    const copts: []const []const u8 =
+        b.option([]const []const u8, "copt", "") orelse &.{};
+    const pace = b.option([]const u8, "pace", "") orelse
+        @panic("Missing required option: pace");
+    const version = b.option([]const u8, "version", "") orelse
+        @panic("Missing required option: version");
+
+    const pkg_vere = b.addStaticLibrary(.{
+        .name = "vere",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    if (target.result.isDarwin() and !target.query.isNative()) {
+        const macos_sdk = b.lazyDependency("macos_sdk", .{
+            .target = target,
+            .optimize = optimize,
+        });
+        if (macos_sdk != null) {
+            pkg_vere.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            pkg_vere.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            pkg_vere.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+        }
+    }
+
+    const pkg_c3 = b.dependency("pkg_c3", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
+    const pkg_ent = b.dependency("pkg_ent", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
+    const pkg_ur = b.dependency("pkg_ur", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
+    const pkg_noun = b.dependency("pkg_noun", .{
+        .target = target,
+        .optimize = optimize,
+        .copt = copts,
+    });
+
+    const avahi = b.dependency("avahi", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const curl = b.dependency("curl", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const gmp = b.dependency("gmp", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const h2o = b.dependency("h2o", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const libuv = b.dependency("libuv", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const lmdb = b.dependency("lmdb", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const natpmp = b.dependency("natpmp", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const openssl = b.dependency("openssl", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const urcrypt = b.dependency("urcrypt", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const zlib = b.dependency("zlib", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const pace_h = b.addWriteFile("pace.h", blk: {
+        var output = std.ArrayList(u8).init(b.allocator);
+        defer output.deinit();
+
+        try output.appendSlice(b.fmt(
+            \\#ifndef URBIT_PACE_H
+            \\#define URBIT_PACE_H
+            \\#define U3_VERE_PACE "{s}"
+            \\#endif
+            \\
+        , .{pace}));
+
+        break :blk try output.toOwnedSlice();
+    });
+
+    const version_h = b.addWriteFile("version.h", blk: {
+        var output = std.ArrayList(u8).init(b.allocator);
+        defer output.deinit();
+
+        try output.appendSlice(b.fmt(
+            \\#ifndef URBIT_VERSION_H
+            \\#define URBIT_VERSION_H
+            \\#define URBIT_VERSION "{s}"
+            \\#endif
+            \\
+        , .{version}));
+
+        break :blk try output.toOwnedSlice();
+    });
+
+    pkg_vere.addIncludePath(pace_h.getDirectory());
+    pkg_vere.addIncludePath(version_h.getDirectory());
+    pkg_vere.addIncludePath(b.path(""));
+    pkg_vere.addIncludePath(b.path("ivory"));
+    pkg_vere.addIncludePath(b.path("ca_bundle"));
+
+    if (t.os.tag == .linux) {
+        pkg_vere.linkLibrary(avahi.artifact("dns-sd"));
+    }
+    pkg_vere.linkLibrary(natpmp.artifact("natpmp"));
+    pkg_vere.linkLibrary(curl.artifact("curl"));
+    pkg_vere.linkLibrary(gmp.artifact("gmp"));
+    pkg_vere.linkLibrary(h2o.artifact("h2o"));
+    pkg_vere.linkLibrary(libuv.artifact("libuv"));
+    pkg_vere.linkLibrary(lmdb.artifact("lmdb"));
+    pkg_vere.linkLibrary(openssl.artifact("ssl"));
+    pkg_vere.linkLibrary(urcrypt.artifact("urcrypt"));
+    pkg_vere.linkLibrary(zlib.artifact("z"));
+    pkg_vere.linkLibrary(pkg_c3.artifact("c3"));
+    pkg_vere.linkLibrary(pkg_ent.artifact("ent"));
+    pkg_vere.linkLibrary(pkg_ur.artifact("ur"));
+    pkg_vere.linkLibrary(pkg_noun.artifact("noun"));
+    pkg_vere.linkLibC();
+
+    var files = std.ArrayList([]const u8).init(b.allocator);
+    defer files.deinit();
+    try files.appendSlice(&c_source_files);
+    if (t.os.tag == .macos) {
+        try files.appendSlice(&.{
+            "platform/darwin/daemon.c",
+            "platform/darwin/ptty.c",
+            "platform/darwin/mach.c",
+        });
+    }
+    if (t.os.tag == .linux) {
+        try files.appendSlice(&.{
+            "platform/linux/daemon.c",
+            "platform/linux/ptty.c",
+        });
+    }
+
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+    try flags.appendSlice(&.{
+        "-std=gnu23",
+    });
+    try flags.appendSlice(copts);
+
+    pkg_vere.addCSourceFiles(.{
+        .root = b.path(""),
+        .files = files.items,
+        .flags = flags.items,
+    });
+
+    for (install_headers) |h| pkg_vere.installHeader(b.path(h), h);
+    pkg_vere.installHeader(b.path("ivory/ivory.h"), "ivory.h");
+    pkg_vere.installHeader(b.path("ca_bundle/ca_bundle.h"), "ca_bundle.h");
+    pkg_vere.installHeader(pace_h.getDirectory().path(b, "pace.h"), "pace.h");
+    pkg_vere.installHeader(version_h.getDirectory().path(b, "version.h"), "version.h");
+
+    b.installArtifact(pkg_vere);
+}
+
+const c_source_files = [_][]const u8{
+    "auto.c",
+    "ca_bundle/ca_bundle.c",
+    "dawn.c",
+    "db/lmdb.c",
+    "disk.c",
+    "foil.c",
+    "io/ames.c",
+    "io/ames/stun.c",
+    "io/behn.c",
+    "io/conn.c",
+    "io/cttp.c",
+    "io/fore.c",
+    "io/hind.c",
+    "io/http.c",
+    "io/lick.c",
+    "io/lss.c",
+    "io/mesa.c",
+    "io/mesa/bitset.c",
+    "io/mesa/pact.c",
+    "io/term.c",
+    "io/unix.c",
+    "ivory/ivory.c",
+    "king.c",
+    "lord.c",
+    "mars.c",
+    "mdns.c",
+    "newt.c",
+    "pier.c",
+    "save.c",
+    "serf.c",
+    "time.c",
+    "ward.c",
+};
+
+const install_headers = [_][]const u8{
+    "db/lmdb.h",
+    "dns_sd.h",
+    "io/ames/stun.h",
+    "io/lss.h",
+    "io/mesa/bitset.h",
+    "io/mesa/mesa.h",
+    "io/serial.h",
+    "mars.h",
+    "mdns.h",
+    "serf.h",
+    "vere.h",
+};

--- a/pkg/vere/build.zig.zon
+++ b/pkg/vere/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "urbit",
+    .name = "vere",
     .version = "0.0.1",
     .dependencies = .{
         .macos_sdk = .{
@@ -8,52 +8,43 @@
             .lazy = true,
         },
         .pkg_c3 = .{
-            .path = "./pkg/c3",
+            .path = "../c3",
         },
         .pkg_ent = .{
-            .path = "./pkg/ent",
+            .path = "../ent",
         },
         .pkg_ur = .{
-            .path = "./pkg/ur",
+            .path = "../ur",
         },
         .pkg_noun = .{
-            .path = "./pkg/noun",
+            .path = "../noun",
         },
-        .pkg_vere = .{
-            .path = "./pkg/vere",
+        .avahi = .{
+            .path = "../../ext/avahi",
         },
         .curl = .{
-            .path = "./ext/curl",
+            .path = "../../ext/curl",
         },
         .gmp = .{
-            .path = "./ext/gmp",
+            .path = "../../ext/gmp",
         },
         .h2o = .{
-            .path = "./ext/h2o",
+            .path = "../../ext/h2o",
         },
         .libuv = .{
-            .path = "./ext/libuv",
+            .path = "../../ext/libuv",
         },
         .lmdb = .{
-            .path = "./ext/lmdb",
+            .path = "../../ext/lmdb",
         },
         .natpmp = .{
-            .path = "./ext/natpmp",
+            .path = "../../ext/natpmp",
         },
         .openssl = .{
-            .path = "./ext/openssl",
-            // .path = "../../Github/openssl-zig",
-            // .url = "https://github.com/kassane/openssl-zig/archive/724d6ed89b5b80a04161290d1f72995b7415fe8e.tar.gz",
-            // .hash = "1220a3f6278247c16e9b4876e2df2361d2a0d45f42ccd21d85066a22a65235394e7b",
-        },
-        .sigsegv = .{
-            .path = "./ext/sigsegv",
+            .path = "../../ext/openssl",
         },
         .urcrypt = .{
-            .path = "./ext/urcrypt",
-        },
-        .whereami = .{
-            .path = "./ext/whereami",
+            .path = "../../ext/urcrypt",
         },
         .zlib = .{
             .url = "https://github.com/allyourcodebase/zlib/archive/0918e87b7629b9c6a50a08edd0ce30d849758faf.tar.gz",


### PR DESCRIPTION
This refactor decouples the build phases of the Vere submodules (c3, ent, ur, noun, and vere) from the main Urbit binary Zig build by moving them into separate Zig builds within each respective pkg directory.

This change is intended to resolve certain Zig cache issues where the linker fails to locate newly added symbols in submodules when these symbols are used in dependent modules.
