### PR TITLE
main: really ignore SIGPIPE

### DIFF
--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -964,10 +964,10 @@ u3_king_commence()
 
   //  Ignore SIGPIPE signals.
   {
-    struct sigaction sig_s = {{0}};
-    sigemptyset(&(sig_s.sa_mask));
-    sig_s.sa_handler = SIG_IGN;
-    sigaction(SIGPIPE, &sig_s, 0);
+    sigset_t set_s;
+    sigemptyset(&set_s);
+    sigaddset(&set_s, SIGPIPE);
+    pthread_sigmask(SIG_BLOCK, &set_s, NULL);
   }
 
   //  boot the ivory pill

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1151,10 +1151,10 @@ _cw_init_io(uv_loop_t* lup_u)
   //  Ignore SIGPIPE signals.
   //
   {
-    struct sigaction sig_s = {{0}};
-    sigemptyset(&(sig_s.sa_mask));
-    sig_s.sa_handler = SIG_IGN;
-    sigaction(SIGPIPE, &sig_s, 0);
+    sigset_t set_s;
+    sigemptyset(&set_s);
+    sigaddset(&set_s, SIGPIPE);
+    pthread_sigmask(SIG_BLOCK, &set_s, NULL);
   }
 
   //  configure pipe to daemon process


### PR DESCRIPTION
When testing 410 with vere-v3.2 I've repeatedly ran into an issue where my ship turns off every few days. This was caused by the king receiving a `SIGPIPE`, something we ostensibly are ignoring with `sigaction`, [however](https://www.linuxjournal.com/article/2121):

```
In a multi-threaded application, there is always the question of which thread the signal will actually 
be delivered to. Or does it get delivered to all the threads? [...]

If it is an asynchronous signal, it could go to any of the threads that haven't masked out 
that signal using sigprocmask().
```

Our "multi-threaded" application is the libuv thread pool. Using `pthread_sigmask` fixes the issue since all child threads inherit the signal mask.