### PR TITLE
serf: do not install ivory pill for now

### DIFF
--- a/pkg/vere/serf.c
+++ b/pkg/vere/serf.c
@@ -717,24 +717,24 @@ _serf_play_life(u3_serf* sef_u, u3_noun eve)
   //
   //    XX support -J
   //
-  {
-    c3_d  len_d = u3_Ivory_pill_len;
-    c3_y* byt_y = u3_Ivory_pill;
-    u3_cue_xeno* sil_u = u3s_cue_xeno_init_with(ur_fib27, ur_fib28);
-    u3_weak pil;
-
-    if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) {
-      u3l_log("lite: unable to cue ivory pill");
-      exit(1);
-    }
-
-    u3s_cue_xeno_done(sil_u);
-
-    if ( c3n == u3v_boot_lite(pil)) {
-      u3l_log("lite: boot failed");
-      exit(1);
-    }
-  }
+//  {
+//    c3_d  len_d = u3_Ivory_pill_len;
+//    c3_y* byt_y = u3_Ivory_pill;
+//    u3_cue_xeno* sil_u = u3s_cue_xeno_init_with(ur_fib27, ur_fib28);
+//    u3_weak pil;
+//
+//    if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) {
+//      u3l_log("lite: unable to cue ivory pill");
+//      exit(1);
+//    }
+//
+//    u3s_cue_xeno_done(sil_u);
+//
+//    if ( c3n == u3v_boot_lite(pil)) {
+//      u3l_log("lite: boot failed");
+//      exit(1);
+//    }
+//  }
 
   gon = u3m_soft(0, u3v_life, eve);
 


### PR DESCRIPTION
#749 introduced an issue where CI on urbit/urbit suddenly became dog slow. This was eventually traced down to the fact that jets registered by the ivory pill in the serf were extremely slow to check for because of missing structural sharing. The only reason to install the ivory pill in the serf is to have stacktraces when arvo fails to compile in CI. Removing that feature is acceptable to keep things moving for now.