### PR TITLE
ames: do not leak stun request packets

### DIFF
--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2030,6 +2030,7 @@ _ames_hear(u3_ames* sam_u,
   //
   if ( c3y == u3_stun_is_request(hun_y, len_w) ) {
       _stun_on_request(sam_u, hun_y, adr_u);
+      c3_free(hun_y);
   }
   else if ( c3y == u3_stun_is_our_response(hun_y,
                                            sam_u->sun_u.tid_y, len_w) )


### PR DESCRIPTION
I was messing with static udp receive buffer allocation in #754. We decided to revert it in #755, but I missed one `c3_free` in the stun request packet codepath, causing a fairly significant memory leak when `vere-v3.2` was deployed on a galaxy. This restores the old free and plugs the leak.

This bug was unreleased and only appeared on `edge` and specifically only on galaxies, it showed up now because I updated the custom binary on `~fen` for unrelated reasons.