### PR TITLE
mesa: improvements

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,7 @@ const main_targets = .{
 const supported_targets: []const std.Target.Query = &(main_targets ++ .{
     .{ .cpu_arch = .aarch64, .os_tag = .linux, .abi = .gnu },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
+    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu, .glibc_version = std.SemanticVersion{ .major = 2, .minor = 27, .patch = 0 } },
 });
 
 const targets: []const std.Target.Query = &main_targets;
@@ -179,7 +180,7 @@ fn buildBinary(
 
     try global_flags.appendSlice(cfg.flags);
     try global_flags.appendSlice(&.{
-        "-g",
+        "-g3",
         "-Wall",
         "-Werror",
     });
@@ -227,6 +228,7 @@ fn buildBinary(
         "-Wno-unused-variable",
         "-Wno-unused-function",
         "-Wno-gnu",
+        "-fno-omit-frame-pointer",
         "-fms-extensions",
         "-DU3_GUARD_PAGE", // pkg_noun
         "-DU3_OS_ENDIAN_little=1", // pkg_c3

--- a/ext/libuv/build.zig
+++ b/ext/libuv/build.zig
@@ -118,13 +118,10 @@ const uv_srcs_unix = uv_srcs ++ [_][]const u8{
 };
 
 const uv_srcs_linux = uv_srcs_unix ++ [_][]const u8{
-    "unix/linux-core.c",
-    "unix/linux-inotify.c",
-    "unix/linux-syscalls.c",
+    "unix/linux.c",
     "unix/procfs-exepath.c",
     "unix/random-getrandom.c",
     "unix/random-sysctl-linux.c",
-    "unix/epoll.c",
 };
 
 const uv_srcs_macos = uv_srcs_unix ++ [_][]const u8{

--- a/ext/libuv/build.zig.zon
+++ b/ext/libuv/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.0.1",
     .dependencies = .{
         .libuv = .{
-            .url = "https://dist.libuv.org/dist/v1.44.2/libuv-v1.44.2.tar.gz",
-            .hash = "12206db5d8fcba5f3a3df8538493884ce3e93f22fbfc2f96374088585e2de6a48c81",
+            .url = "https://dist.libuv.org/dist/v1.50.0/libuv-v1.50.0.tar.gz",
+            .hash = "12207ac22e5e40afe515b7c319237785113c97ee84a75f7c66c1a0e7cc6e743debeb",
         },
     },
     .paths = .{

--- a/ext/murmur3/build.zig
+++ b/ext/murmur3/build.zig
@@ -22,6 +22,7 @@ pub fn build(b: *std.Build) void {
 
     const common_flags = [_][]const u8{
         "-fno-sanitize=all",
+        "-O3",
         "-Wall",
     };
 

--- a/ext/urcrypt/build.zig
+++ b/ext/urcrypt/build.zig
@@ -57,6 +57,7 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{
             "-O2",
+            "-fno-omit-frame-pointer",
             "-fno-sanitize=all",
             "-g",
             "-Wall",
@@ -105,6 +106,7 @@ fn libaes_siv(
         },
         .flags = &.{
             "-O2",
+            "-fno-omit-frame-pointer",
             "-fno-sanitize=all",
         },
     });
@@ -147,6 +149,7 @@ fn libsecp256k1(
             "-fno-sanitize=all",
             "-g",
             "-O2",
+            "-fno-omit-frame-pointer",
             "-std=c89",
             "-pedantic",
             "-Wno-long-long",
@@ -200,6 +203,7 @@ fn libargon2(
 
     const flags = .{
         "-O2",
+        "-fno-omit-frame-pointer",
         "-fno-sanitize=all",
         "-Wno-unused-value",
         "-Wno-unused-function",
@@ -275,6 +279,7 @@ fn libblake3(
             }),
             .flags = &.{
                 "-O2",
+                "-fno-omit-frame-pointer",
                 "-fno-sanitize=all",
             },
         });
@@ -284,6 +289,7 @@ fn libblake3(
             .files = &(common_files ++ .{"blake3_neon.c"}),
             .flags = &.{
                 "-O2",
+                "-fno-omit-frame-pointer",
                 "-fno-sanitize=all",
                 "-DBLAKE3_USE_NEON=1",
             },
@@ -332,6 +338,7 @@ fn libed25519(
         },
         .flags = &.{
             "-O2",
+            "-fno-omit-frame-pointer",
             "-fno-sanitize=all",
             "-Wno-unused-result",
         },
@@ -370,6 +377,7 @@ fn libge_additions(
         .files = &.{"ge-additions.c"},
         .flags = &.{
             "-O2",
+            "-fno-omit-frame-pointer",
             "-fno-sanitize=all",
             "-Werror",
             "-pedantic",
@@ -407,6 +415,7 @@ fn libkeccak_tiny(
         .files = &.{"keccak-tiny.c"},
         .flags = &.{
             "-O2",
+            "-fno-omit-frame-pointer",
             "-fno-sanitize=all",
             "-std=c11",
             "-Wextra",
@@ -445,6 +454,7 @@ fn libmonocypher(
         .files = &.{"monocypher.c"},
         .flags = &.{
             "-O2",
+            "-fno-omit-frame-pointer",
             "-fno-sanitize=all",
         },
     });
@@ -490,6 +500,7 @@ fn libscrypt(
         },
         .flags = &.{
             "-O2",
+            "-fno-omit-frame-pointer",
             "-fno-sanitize=all",
             "-D_FORTIFY_SOURCE=2",
         },

--- a/pkg/vere/arena.h
+++ b/pkg/vere/arena.h
@@ -1,0 +1,46 @@
+#ifndef VERE_ARENA_H
+#define VERE_ARENA_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+
+typedef struct {
+    char* dat;
+    char* beg;
+    char* end;
+} arena;
+
+#define new(a, t, n)  (t*)arena_alloc(a, sizeof(t), _Alignof(t), n)
+
+static void* arena_alloc(arena* a, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count)
+{
+    ptrdiff_t padding = -(uintptr_t)a->beg & (align - 1);
+    ptrdiff_t available = a->end - a->beg - padding;
+    if (available < 0 || count > available/size) {
+        abort();
+    }
+    void *p = a->beg + padding;
+    a->beg += padding + count*size;
+    return memset(p, 0, count*size);
+}
+
+static arena arena_create(ptrdiff_t cap)
+{
+    arena a = {0};
+    a.dat = (char*)malloc(cap);
+    a.beg = a.dat;
+    a.end = a.beg ? a.beg+cap : 0;
+    return a;
+}
+
+
+static void arena_free(arena* a)
+{
+  free(a->dat);
+  a = (arena*)0;
+}
+
+#endif

--- a/pkg/vere/arena.h
+++ b/pkg/vere/arena.h
@@ -24,7 +24,8 @@ static void* arena_alloc(arena* a, ptrdiff_t size, ptrdiff_t align, ptrdiff_t co
     }
     void *p = a->beg + padding;
     a->beg += padding + count*size;
-    return memset(p, 0, count*size);
+    return p;
+    // return memset(p, 0, count*size);
 }
 
 static arena arena_create(ptrdiff_t cap)

--- a/pkg/vere/build.zig
+++ b/pkg/vere/build.zig
@@ -240,8 +240,10 @@ const install_headers = [_][]const u8{
     "io/mesa/bitset.h",
     "io/mesa/mesa.h",
     "io/serial.h",
+    "arena.h",
     "mars.h",
     "mdns.h",
     "serf.h",
     "vere.h",
+    "verstable.h",
 };

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2950,5 +2950,6 @@ u3_ames_io_init(u3_pier* pir_u)
 
   // XX declare void pointer to u3_host and add sam_u in it
   u3_Host.sam_u = sam_u;
+  u3_Host.imp_u = sam_u->zar_u.pip_w;
   return car_u;
 }

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2915,7 +2915,8 @@ u3_ames_io_init(u3_pier* pir_u)
   sam_u->lax_p = u3h_new_cache(500000);
 
   u3_assert( !uv_udp_init(u3L, &sam_u->wax_u) );
-  uv_udp_init(u3L, &u3_Host.wax_u);
+  // c3_i err_i = uv_recv_buffer_size((uv_handle_t*)&u3_Host.wax_u, &lel_i);
+  u3_assert( !uv_udp_init_ex(u3L, &u3_Host.wax_u, UV_UDP_RECVMMSG) );
   sam_u->wax_u.data = sam_u;
 
   sam_u->sil_u = u3s_cue_xeno_init();

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2915,7 +2915,6 @@ u3_ames_io_init(u3_pier* pir_u)
   sam_u->lax_p = u3h_new_cache(500000);
 
   u3_assert( !uv_udp_init(u3L, &sam_u->wax_u) );
-  // c3_i err_i = uv_recv_buffer_size((uv_handle_t*)&u3_Host.wax_u, &lel_i);
   u3_assert( !uv_udp_init_ex(u3L, &u3_Host.wax_u, UV_UDP_RECVMMSG) );
   sam_u->wax_u.data = sam_u;
 

--- a/pkg/vere/io/lss.c
+++ b/pkg/vere/io/lss.c
@@ -165,6 +165,9 @@ static c3_o _lss_verifier_check_hash(lss_verifier* los_u, c3_w i, c3_w height, l
 
 c3_o lss_verifier_ingest(lss_verifier* los_u, c3_y* leaf_y, c3_w leaf_w, lss_pair* pair) {
   // verify leaf
+  /* los_u->counter++; */
+  /* return c3y; */
+
   lss_hash h;
   _subtree_root(h, leaf_y, leaf_w, los_u->counter << los_u->steps);
   if ( c3n == _lss_verifier_check_hash(los_u, los_u->counter, 0, h) ) {

--- a/pkg/vere/io/lss.c
+++ b/pkg/vere/io/lss.c
@@ -191,22 +191,17 @@ c3_o lss_verifier_ingest(lss_verifier* los_u, c3_y* leaf_y, c3_w leaf_w, lss_pai
   return c3y;
 }
 
-void lss_verifier_init(lss_verifier* los_u, c3_w steps, c3_w leaves, lss_hash* proof) {
+void lss_verifier_init(lss_verifier* los_u, c3_w steps, c3_w leaves, lss_hash* proof, arena* are_u) {
   c3_w proof_w = lss_proof_size(leaves);
   c3_w pairs_w = c3_bits_word(leaves);
   los_u->steps = steps;
   los_u->leaves = leaves;
   los_u->counter = 0;
-  los_u->pairs = c3_calloc(pairs_w * sizeof(lss_pair));
+  los_u->pairs = new(are_u, lss_pair, pairs_w);
   memcpy(los_u->pairs[0][0], proof[0], sizeof(lss_hash));
   for (c3_w i = 1; i < proof_w; i++) {
     memcpy(los_u->pairs[i-1][1], proof[i], sizeof(lss_hash));
   }
-}
-
-void lss_verifier_free(lss_verifier* los_u) {
-  c3_free(los_u->pairs);
-  c3_free(los_u);
 }
 
 void lss_complete_inline_proof(lss_hash* proof, c3_y* leaf_y, c3_w leaf_w) {

--- a/pkg/vere/io/lss.h
+++ b/pkg/vere/io/lss.h
@@ -6,6 +6,7 @@
 
 #include "noun.h"
 #include "ur/ur.h"
+#include "arena.h"
 
 c3_w lss_proof_size(c3_w leaves);
 
@@ -51,9 +52,7 @@ typedef struct _lss_verifier {
 
 c3_o lss_verifier_ingest(lss_verifier* ver_u, c3_y* leaf_y, c3_w leaf_w, lss_pair* pair);
 
-void lss_verifier_init(lss_verifier* ver_u, c3_w steps, c3_w leaves, lss_hash* proof);
-
-void lss_verifier_free(lss_verifier* ver_u);
+void lss_verifier_init(lss_verifier* ver_u, c3_w steps, c3_w leaves, lss_hash* proof, arena* are_u);
 
 // Hashes the provided leaf and writes it to proof[0]. The leaf may be any size.
 void lss_complete_inline_proof(lss_hash* proof, c3_y* leaf_y, c3_w leaf_w);

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -1297,6 +1297,9 @@ _realise_lane(u3_noun lan) {
     if ( (c3n == u3_Host.ops_u.net) ) {
       lan_u.sin_addr.s_addr = htonl(0x7f000001);
       lan_u.sin_port = htons(_ames_czar_port(lan));
+    } else {
+      lan_u.sin_addr.s_addr = htonl(u3_Host.imp_u[lan]);
+      lan_u.sin_port = htons(_ames_czar_port(lan));
     }
   } else {
     u3_noun tag, pip, por;

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -3010,14 +3010,9 @@ _mesa_io_talk(u3_auto* car_u)
   uv_udp_recv_start(&u3_Host.wax_u, _mesa_alloc, _mesa_recv_cb);
 
   c3_i rec_i = 2 * 1024 * 1024;
-  c3_i lel_i = 0;
-  c3_i err_i = uv_recv_buffer_size((uv_handle_t*)&u3_Host.wax_u, &rec_i);
-  err_i = uv_recv_buffer_size((uv_handle_t*)&u3_Host.wax_u, &lel_i);
-  /* u3l_log("ames: recv buffer size %i %i %s", err_i, lel_i, uv_strerror(err_i)); */
+  uv_recv_buffer_size((uv_handle_t*)&u3_Host.wax_u, &rec_i);
 
-  err_i = uv_send_buffer_size((uv_handle_t*)&u3_Host.wax_u, &rec_i);
-  err_i = uv_send_buffer_size((uv_handle_t*)&u3_Host.wax_u, &lel_i);
-  /* u3l_log("ames: send buffer size %i %i %s", err_i, lel_i, uv_strerror(err_i)); */
+  uv_send_buffer_size((uv_handle_t*)&u3_Host.wax_u, &rec_i);
 
   sam_u->car_u.liv_o = c3y;
   //u3z(rac); u3z(who);

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -762,8 +762,6 @@ static void _mesa_handle_ack(u3_gage* gag_u, u3_pact_stat* pat_u)
   gag_u->rtt_w = (rtt_d + (gag_u->rtt_w * 7)) >> 3;
   gag_u->rtv_w = (err_d + (gag_u->rtv_w * 7)) >> 3;
   gag_u->rto_w = _clamp_rto(gag_u->rtt_w + (4*gag_u->rtv_w));
-  gag_u->wnd_w++;
-
 
   if ( gag_u->wnd_w < gag_u->sst_w ) {
     gag_u->wnd_w++;

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -885,7 +885,7 @@ u3_mesa_decode_lane(u3_atom lan) {
   //  convert incoming localhost to outgoing localhost
   //
 
-  adr_u.sin_addr.s_addr = u3_Host.ops_u.net ? (c3_w)lan_d : htonl(0x7f000001);
+  adr_u.sin_addr.s_addr = ( u3_Host.ops_u.net == c3y ) ? (c3_w)lan_d : htonl(0x7f000001);
   adr_u.sin_port = htons((c3_s)(lan_d >> 32));
 
   return adr_u;
@@ -931,7 +931,7 @@ _mesa_send_cb(uv_udp_send_t* req_u, c3_i sas_i)
 static void _mesa_send_buf(u3_mesa* sam_u, sockaddr_in add_u, c3_y* buf_y, c3_w len_w)
 {
 
-  add_u.sin_addr.s_addr = u3_Host.ops_u.net ? add_u.sin_addr.s_addr : htonl(0x7f000001);
+  add_u.sin_addr.s_addr = ( u3_Host.ops_u.net == c3y ) ? add_u.sin_addr.s_addr  : htonl(0x7f000001);
   /* add_u.sin_family = AF_INET; */
 
   if ( u3_Host.ops_u.net && (add_u.sin_addr.s_addr == 0 || add_u.sin_addr.s_addr == 0xffffffff) ) {

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -806,10 +806,11 @@ _mesa_req_get_cwnd(u3_pend_req* req_u)
   c3_w rem_w = _mesa_req_get_remaining(req_u);
   /* u3l_log("rem_w %u wnd_w %u", rem_w, req_u->gag_u->wnd_w); */
 
-  u3l_log("rem_w %u", rem_w);
-  u3l_log("wnd_w %u", req_u->gag_u->wnd_w);
-  u3l_log("out_d %"PRIu64, req_u->out_d);
-  return c3_min(rem_w, _safe_sub((c3_d)req_u->gag_u->wnd_w, req_u->out_d));
+  /* u3l_log("rem_w %u", rem_w); */
+  /* u3l_log("wnd_w %u", req_u->gag_u->wnd_w); */
+  /* u3l_log("out_d %"PRIu64, req_u->out_d); */
+  return c3_min(rem_w, _safe_sub(500, req_u->out_d));
+  /* return c3_min(rem_w, _safe_sub((c3_d)req_u->gag_u->wnd_w, req_u->out_d)); */
   /* return c3_min(rem_w, 5000 - req_u->out_d); */
 }
 
@@ -1096,6 +1097,7 @@ _try_resend(u3_pend_req* req_u, c3_d nex_d)
   u3_mesa_pact *pac_u = &req_u->pic_u->pac_u;
 
   c3_y buf_y[PACT_SIZE];
+  c3_w muna = 0;
   for ( c3_d i_d = req_u->lef_d; i_d < nex_d; i_d++ ) {
     //  TODO: make fast recovery different from slow
     //  TODO: track skip count but not dupes, since dupes are meaningless
@@ -1108,6 +1110,7 @@ _try_resend(u3_pend_req* req_u, c3_d nex_d)
       c3_w len_w = mesa_etch_pact_to_buf(buf_y, PACT_SIZE, pac_u);
       _mesa_send_modal(req_u->per_u, buf_y, len_w);
       _mesa_req_pact_resent(req_u, &pac_u->pek_u.nam_u);
+      muna++;
     }
   }
 
@@ -1115,7 +1118,9 @@ _try_resend(u3_pend_req* req_u, c3_d nex_d)
     req_u->gag_u->sst_w = c3_max(1, req_u->gag_u->wnd_w / 2);
     req_u->gag_u->wnd_w = req_u->gag_u->sst_w;
     req_u->gag_u->rto_w = _clamp_rto(req_u->gag_u->rto_w * 2);
+    /* req_u->out_d = 0; */
     u3l_log("loss");
+    u3l_log("resent %u", muna);
     u3l_log("counter %u hav_d %"PRIu64 " nex_d %"PRIu64 " ack_d %"PRIu64 " lef_d %"PRIu64 " old_d %"PRIu64, req_u->los_u->counter, req_u->hav_d, req_u->nex_d, req_u->ack_d, req_u->lef_d, req_u->old_d);
     _log_gage(req_u->gag_u);
   }
@@ -1225,7 +1230,7 @@ _mesa_req_pact_done(u3_pend_req*  req_u,
   // received duplicate
   if ( c3y == bitset_has(&req_u->was_u, nam_u->fra_d) ) {
     // MESA_LOG(sam_u, DUPE);
-    _update_resend_timer(req_u);
+    /* _update_resend_timer(req_u); */
     return;
   }
 

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -26,6 +26,11 @@
 
 static c3_o dop_o = c3n;
 
+static c3_y are_y[524288];
+static c3_d tim_y[200000] = {0};
+static c3_w tidx = 0;
+static c3_o done = c3n;
+
 #define MESA_DEBUG     c3y
 //#define MESA_TEST
 #define RED_TEXT    "\033[0;31m"
@@ -267,6 +272,7 @@ typedef struct _u3_mesa {
   jum_map            jum_u;       //  jumbo cache
   gag_map            gag_u;       //  lane cache
   pit_map            pit_u;       //  (map path [our=? las=(set lane)])
+  req_map            req_u;       //  (map [rift path] u3_pend_req)
   c3_c*              dns_c;       //  turf (urb.otrg)
   c3_d               tim_d;       //  XX: remove
   arena              are_u;       //  per packet arena
@@ -281,7 +287,6 @@ typedef struct _u3_peer {
   u3_lane_state  dir_u;  //  direct lane state
   c3_y           imp_y;  //  galaxy @p
   u3_lane_state  ind_u;  //  indirect lane state
-  req_map        req_u;  //  (map [rift path] u3_pend_req)
 } u3_peer;
 
 typedef struct _u3_pend_req {
@@ -303,7 +308,9 @@ typedef struct _u3_pend_req {
   u3_mesa_pict*          pic_u; // preallocated request packet
   u3_pact_stat*          wat_u; // ((mop @ud packet-state) lte)
   u3_bitset              was_u; // ((mop @ud ?) lte)
-  c3_y                   pad_y[64];
+  c3_c*                  pek_c;
+  c3_w                   pek_w;
+  c3_d                   pek_d;
   //  stats TODO: use
   c3_d                   beg_d; // date when request began
   arena                  are_u;
@@ -362,7 +369,7 @@ _log_buf(c3_y* buf_y, c3_w len_w)
 static void
 _log_gage(u3_gage* gag_u)
 {
-  u3l_log("gauge");
+  u3l_log("gauge at %p", gag_u);
   u3l_log("rtt: %f", ((double)gag_u->rtt_w / 1000));
   u3l_log("rto: %f", ((double)gag_u->rto_w / 1000));
   u3l_log("rttvar: %f", ((double)gag_u->rtv_w / 1000));
@@ -436,7 +443,7 @@ _abs_dif(c3_d ayy_d, c3_d bee_d)
 
 static c3_d
 _clamp_rto(c3_d rto_d) {
-  return c3_min(c3_max(rto_d, 1000 * 1000), 25000 * 1000); // ~s25 max backoff
+  return c3_min(c3_max(rto_d, 200 * 1000), 25000 * 1000); // ~s25 max backoff
 }
 
 static inline c3_o
@@ -554,7 +561,7 @@ _mesa_request_key(u3_mesa_name* nam_u)
 static void
 _init_gage(u3_gage* gag_u)  //  microseconds
 {
-  gag_u->rto_w = 1000 * 1000;  // ~s1
+  gag_u->rto_w = 200 * 1000;  // ~s1
   gag_u->rtt_w = 1000 * 1000;  // ~s1
   gag_u->rtv_w = 1000 * 1000;  // ~s1
   /* gag_u->rto_w = 200 * 1000;  // ~s1 */
@@ -609,12 +616,8 @@ _mesa_put_peer(u3_mesa* sam_u, u3_ship her_u, u3_peer* per_u)
 */
 static u3_pend_req*
 _mesa_get_request(u3_mesa* sam_u, u3_mesa_name* nam_u) {
-  u3_peer* per_u = _mesa_get_peer(sam_u, nam_u->her_u);
-  if ( !per_u ) {
-    return NULL;
-  }
   u3_str key_u = {nam_u->pat_c, nam_u->pat_s};
-  req_map_itr itr_u = vt_get(&per_u->req_u, key_u);
+  req_map_itr itr_u = vt_get(&sam_u->req_u, key_u);
   if ( vt_is_end(itr_u) ) {
     return NULL;
   }
@@ -624,61 +627,47 @@ _mesa_get_request(u3_mesa* sam_u, u3_mesa_name* nam_u) {
 static void
 _mesa_del_request_cb(uv_handle_t* han_u) {
   u3_pend_req* req_u = han_u->data;
+  u3l_log("freeing %p", req_u->pic_u->pac_u.pek_u.nam_u.pat_c);
   arena_free(&req_u->are_u);
 }
 
 static void
 _mesa_del_request(u3_mesa* sam_u, u3_mesa_name* nam_u) {
-  u3_peer* per_u = _mesa_get_peer(sam_u, nam_u->her_u);
-  if ( !per_u ) {
-    return;
-  }
-
   u3_str key_u = {nam_u->pat_c, nam_u->pat_s};
-  req_map_itr itr_u = vt_get(&per_u->req_u, key_u);
+  req_map_itr itr_u = vt_get(&sam_u->req_u, key_u);
 
   if ( vt_is_end(itr_u) ) {
     return;
   }
 
   u3_pend_req* req_u = itr_u.data->val;
-    // u3l_log("wat_u %p", req_u->wat_u);
-  // u3l_log("was_u buf %p", req_u->was_u.buf_y);
-  uv_timer_stop(&req_u->tim_u);
-  vt_erase(&per_u->req_u, key_u);
-  req_u->tim_u.data = req_u;
-  uv_close((uv_handle_t*)&req_u->tim_u, _mesa_del_request_cb);
+  vt_erase(&sam_u->req_u, key_u);
+  if ( (u3_pend_req*)CTAG_WAIT != req_u ) {
+    uv_timer_stop(&req_u->tim_u);
+    req_u->tim_u.data = req_u;
+    uv_close((uv_handle_t*)&req_u->tim_u, _mesa_del_request_cb);
+  }
 }
 
 /* _mesa_put_request(): save new pending request state for nam_u
 */
-static u3_pend_req*
+static void
 _mesa_put_request(u3_mesa* sam_u, u3_mesa_name* nam_u, u3_pend_req* req_u) {
-  u3_peer* per_u = _mesa_get_peer(sam_u, nam_u->her_u);
-  if ( !per_u ) {
-    return NULL;
-  }
   u3_pend_req* old_u = _mesa_get_request(sam_u, nam_u);
-  u3_pend_req* new_u = req_u;
-  if ( old_u == NULL ) {
+  if ( old_u == NULL || old_u == (u3_pend_req*)CTAG_WAIT ) {
+    if ( req_u == old_u ) {
+      return;
+    }
     /* u3l_log("putting fresh req %p", new_u); */
-    memcpy(new_u, req_u, sizeof(u3_pend_req));
-    new_u->per_u = per_u;
-
+    u3l_log("putting %p", nam_u->pat_c);
     u3_str key_u = {nam_u->pat_c, nam_u->pat_s};
-    req_map_itr itr_u = vt_insert(&per_u->req_u, key_u, new_u);
+    req_map_itr itr_u = vt_insert(&sam_u->req_u, key_u, req_u);
 
     if ( vt_is_end(itr_u) ) {
       fprintf(stderr, "mesa: cannot allocate memory for request, dying");
       u3_king_bail();
     }
-
-  } else {
-    new_u = old_u;
-    memcpy(new_u, req_u, sizeof(u3_pend_req));
   }
-
-  return new_u;
 }
 
 /* _ames_czar_port(): udp port for galaxy.
@@ -773,6 +762,8 @@ static void _mesa_handle_ack(u3_gage* gag_u, u3_pact_stat* pat_u)
   gag_u->rtt_w = (rtt_d + (gag_u->rtt_w * 7)) >> 3;
   gag_u->rtv_w = (err_d + (gag_u->rtv_w * 7)) >> 3;
   gag_u->rto_w = _clamp_rto(gag_u->rtt_w + (4*gag_u->rtv_w));
+  gag_u->wnd_w++;
+
 
   if ( gag_u->wnd_w < gag_u->sst_w ) {
     gag_u->wnd_w++;
@@ -809,8 +800,8 @@ _mesa_req_get_cwnd(u3_pend_req* req_u)
   /* u3l_log("rem_w %u", rem_w); */
   /* u3l_log("wnd_w %u", req_u->gag_u->wnd_w); */
   /* u3l_log("out_d %"PRIu64, req_u->out_d); */
-  return c3_min(rem_w, _safe_sub(500, req_u->out_d));
-  /* return c3_min(rem_w, _safe_sub((c3_d)req_u->gag_u->wnd_w, req_u->out_d)); */
+  /* return c3_min(rem_w, _safe_sub(2500, req_u->out_d)); */
+  return c3_min(rem_w, _safe_sub((c3_d)req_u->gag_u->wnd_w, req_u->out_d));
   /* return c3_min(rem_w, 5000 - req_u->out_d); */
 }
 
@@ -818,9 +809,8 @@ _mesa_req_get_cwnd(u3_pend_req* req_u)
 **
 */
 static void
-_mesa_req_pact_resent(u3_pend_req* req_u, u3_mesa_name* nam_u)
+_mesa_req_pact_resent(u3_pend_req* req_u, u3_mesa_name* nam_u, c3_d now_d)
 {
-  c3_d now_d = _get_now_micros();
   // if we dont have pending request noop
   if ( NULL == req_u ) {
     return;
@@ -834,20 +824,19 @@ _mesa_req_pact_resent(u3_pend_req* req_u, u3_mesa_name* nam_u)
 **   after 1-RT first packet is handled in _mesa_req_pact_init()
 */
 static void
-_mesa_req_pact_sent(u3_pend_req* req_u, u3_mesa_name* nam_u)
+_mesa_req_pact_sent(u3_pend_req* req_u, c3_d fra_d, c3_d now_d)
 {
-  c3_d now_d = _get_now_micros();
   // if we already have pending request
   if ( NULL != req_u ) {
-    if( req_u->nex_d == nam_u->fra_d ) {
+    if( req_u->nex_d == fra_d ) {
       req_u->nex_d++;
+      req_u->out_d++;
     }
-    req_u->out_d++;
     // TODO: optional assertions?
     /* req_u->wat_u[nam_u->fra_w] = (u3_pact_stat){now_d, 0, 1, 0 }; */
-    req_u->wat_u[nam_u->fra_d].sen_d = now_d;
-    req_u->wat_u[nam_u->fra_d].sip_y = 0;
-    req_u->wat_u[nam_u->fra_d].tie_y = 1;
+    req_u->wat_u[fra_d].sen_d = now_d;
+    req_u->wat_u[fra_d].sip_y = 0;
+    req_u->wat_u[fra_d].tie_y++;
 
     #ifdef MESA_DEBUG
       /* u3l_log("bitset_put %"PRIu64, nam_u->fra_d); */
@@ -875,10 +864,10 @@ static void
 _mesa_alloc(uv_handle_t* had_u, size_t len_i, uv_buf_t* buf)
 {
   u3_mesa* sam_u = (u3_mesa*)had_u->data;
-  sam_u->are_u = arena_create(16384);
-  c3_c* ptr_v = new(&sam_u->are_u, c3_c, 4096);
+  sam_u->are_u.beg = (char*)are_y;
+  c3_c* ptr_v = new(&sam_u->are_u, c3_c, 400000);
   buf->base = ptr_v;
-  buf->len = 4096;
+  buf->len = 400000;
 }
 
 /* u3_mesa_decode_lane(): deserialize noun to lane; 0.0.0.0:0 if invalid
@@ -915,13 +904,6 @@ static void _mesa_free_seal(u3_seal* sel_u)
   c3_free(sel_u);
 }
 
-static u3_noun _mesa_get_now() {
-  struct timeval tim_u;
-  gettimeofday(&tim_u, 0);
-  u3_noun res = u3_time_in_tv(&tim_u);
-  return res;
-}
-
 static void
 _mesa_send_cb(uv_udp_send_t* req_u, c3_i sas_i)
 {
@@ -937,6 +919,98 @@ _mesa_send_cb(uv_udp_send_t* req_u, c3_i sas_i)
   }
 
   _mesa_free_seal(sel_u);
+}
+
+static void
+_mesa_send_cb2(uv_udp_send_t* req_u, c3_i sas_i)
+{
+  if ( sas_i ) {
+    u3l_log("mesa: send fail_async: %s", uv_strerror(sas_i));
+    //sam_u->fig_u.net_o = c3n;
+  }
+  c3_free(req_u);
+}
+
+typedef struct _send_helper {
+  uv_udp_send_t snd_u;
+  u3_pend_req* req_u;
+  c3_d fra_d;
+} send_helper;
+
+static void
+_mesa_send_cb3(uv_udp_send_t* snt_u, c3_i sas_i)
+{
+  send_helper* snd_u = (send_helper*)snt_u;
+  if ( sas_i ) {
+    u3l_log("mesa: send fail_async: %s", uv_strerror(sas_i));
+    //sam_u->fig_u.net_o = c3n;
+  } else {
+    // _mesa_req_pact_sent(snd_u->req_u, snd_u->fra_d);
+  }
+  c3_free(snd_u);
+}
+
+static void _mesa_send_buf2(u3_mesa* sam_u, struct sockaddr** ads_u, uv_buf_t** bfs_u, c3_w* int_u, c3_w num_w)
+{
+
+  /* add_u.sin_family = AF_INET; */
+
+ /* if ( u3_Host.ops_u.net && (add_u.sin_addr.s_addr == 0 || add_u.sin_addr.s_addr == 0xffffffff) ) { */
+  /*   return; */
+  /* } */
+
+#ifdef MESA_DEBUG
+  /* c3_c* sip_c = inet_ntoa(add_u.sin_addr); */
+  // u3l_log("mesa: sending packet to %s:%u", sip_c, por_s);
+#endif
+  c3_w tot_w = 0;
+  while (tot_w < num_w) {
+    c3_i sas_i = uv_udp_try_send2(&u3_Host.wax_u, num_w-tot_w, bfs_u+tot_w, int_u+tot_w, ads_u+tot_w, 0);
+    if ( sas_i < 0 ) {
+      u3l_log("ames: send fail_sync: %s", uv_strerror(sas_i));
+      break;
+    }
+    tot_w += (c3_d)sas_i;
+  }
+//  else if ( sas_i < (c3_i)num_w) {
+//    for ( c3_i i = sas_i; i < (c3_i)num_w; i++) {
+//      uv_udp_send_t* req_u = c3_malloc(sizeof(*req_u));
+//      uv_udp_send(req_u, &u3_Host.wax_u, bfs_u[i], 1, ads_u[0], _mesa_send_cb2);
+//    }
+//  }
+}
+static void _mesa_send_buf3(sockaddr_in add_u, uv_buf_t buf_u, u3_pend_req* req_u, c3_d fra_d)
+{
+
+  add_u.sin_addr.s_addr = ( u3_Host.ops_u.net == c3y ) ? add_u.sin_addr.s_addr  : htonl(0x7f000001);
+  /* add_u.sin_family = AF_INET; */
+
+  if ( u3_Host.ops_u.net && (add_u.sin_addr.s_addr == 0 || add_u.sin_addr.s_addr == 0xffffffff) ) {
+    return;
+  }
+
+#ifdef MESA_DEBUG
+  /* c3_c* sip_c = inet_ntoa(add_u.sin_addr); */
+  // u3l_log("mesa: sending packet to %s:%u", sip_c, por_s);
+#endif
+
+
+  send_helper* snd_u = c3_malloc(sizeof(*snd_u));
+  snd_u->fra_d = fra_d;
+  snd_u->req_u = req_u;
+
+  c3_i     sas_i = uv_udp_send((uv_udp_send_t*)snd_u,
+                               &u3_Host.wax_u,
+                               &buf_u, 1,
+                               (const struct sockaddr*)&add_u,
+                               _mesa_send_cb3);
+
+  if ( sas_i ) {
+    u3l_log("ames: send fail_sync: %s", uv_strerror(sas_i));
+    /*if ( c3y == sam_u->fig_u.net_o ) {
+      //sam_u->fig_u.net_o = c3n;
+    }*/
+  }
 }
 
 static void _mesa_send_buf(u3_mesa* sam_u, sockaddr_in add_u, c3_y* buf_y, c3_w len_w)
@@ -998,10 +1072,10 @@ typedef struct _u3_mesa_request_data {
 } u3_mesa_request_data;
 
 typedef struct _u3_mesa_resend_data {
+  arena                are_u;
   uv_timer_t           tim_u;
   u3_mesa_request_data dat_u;
   c3_y                 ret_y;  //  number of remaining retries
-  arena                are_u;
 } u3_mesa_resend_data;
 
 
@@ -1070,7 +1144,6 @@ _mesa_send_modal(u3_peer* per_u, c3_y* buf_y, c3_w len_w)
   }
 }
 
-//  RETAIN on dat_u->las
 static void
 _mesa_send_request(u3_mesa_request_data* dat_u)
 {
@@ -1089,6 +1162,36 @@ _mesa_send_request(u3_mesa_request_data* dat_u)
   }
 }
 
+static uv_buf_t
+_mesa_peek_buf(c3_c* pek_c, c3_d fra_d, c3_w pek_w)
+// 43
+{
+  if (fra_d <= 0xff) {
+    return uv_buf_init(pek_c+(fra_d*pek_w), pek_w);
+  }
+  if (fra_d <= 0xffff) {
+    return uv_buf_init(
+      pek_c + (0x100 * pek_w) + ((fra_d - 0x100) * (pek_w + 1)),
+      pek_w + 1
+    );
+  }
+  if (fra_d <= 0xffffff) {
+    return uv_buf_init(
+      pek_c + (0x100 * pek_w) +
+      ((fra_d - 0x100) * (pek_w + 1)) +
+      ((fra_d - 0x10000) * (pek_w + 3)),
+      pek_w + 3
+    );
+  }
+  return uv_buf_init(
+    pek_c + (0xff * pek_w) +
+    ((fra_d - 0x100) * (pek_w + 1)) +
+    ((fra_d - 0x10000) * (pek_w + 3)) +
+    ((fra_d - 0x1000000ULL) * (pek_w + 7)),
+    pek_w + 7
+  );
+}
+
 static void
 _try_resend(u3_pend_req* req_u, c3_d nex_d)
 {
@@ -1097,30 +1200,52 @@ _try_resend(u3_pend_req* req_u, c3_d nex_d)
   u3_mesa_pact *pac_u = &req_u->pic_u->pac_u;
 
   c3_y buf_y[PACT_SIZE];
-  c3_w muna = 0;
+  arena scr_u = req_u->are_u;
+  uv_buf_t* bfs_u = new(&scr_u, uv_buf_t, 1);
+  c3_w i_w = 0;
   for ( c3_d i_d = req_u->lef_d; i_d < nex_d; i_d++ ) {
     //  TODO: make fast recovery different from slow
     //  TODO: track skip count but not dupes, since dupes are meaningless
     if ( (c3n == bitset_has(&req_u->was_u, i_d)) &&
         (now_d - req_u->wat_u[i_d].sen_d > req_u->gag_u->rto_w) ) {
+      // u3l_log("now_d %"PRIu64, now_d);
+      // u3l_log("sen_d %"PRIu64, req_u->wat_u[i_d].sen_d);
+      // u3l_log("rto_w %u", req_u->gag_u->rto_w);
       los_o = c3y;
-      pac_u->pek_u.nam_u.fra_d = i_d;
       /* u3l_log("resend fra_w: %llu", i_d); */
 
-      c3_w len_w = mesa_etch_pact_to_buf(buf_y, PACT_SIZE, pac_u);
-      _mesa_send_modal(req_u->per_u, buf_y, len_w);
-      _mesa_req_pact_resent(req_u, &pac_u->pek_u.nam_u);
-      muna++;
+      uv_buf_t buf_u = _mesa_peek_buf(req_u->pek_c, i_d, req_u->pek_w);
+      if (buf_u.base < req_u->pek_c) {
+          u3l_log("peek overflow, dying, fragment %"PRIu64, i_d);
+          abort();
+      }
+      new(&scr_u, uv_buf_t, 1);
+      bfs_u[i_w] = buf_u;
+      /* c3_w len_w = mesa_etch_pact_to_buf(buf_y, PACT_SIZE, pac_u); */
+      _mesa_send_buf3(req_u->per_u->dan_u, buf_u, req_u, i_d);
+      // _mesa_send_modal(req_u->per_u, (c3_y*)buf_u.base, buf_u.len);
+      _mesa_req_pact_resent(req_u, &pac_u->pek_u.nam_u, now_d);
+      i_w++;
     }
   }
+  /* c3_w* int_u = new(&scr_u, c3_w, i_w); */
+  /* struct sockaddr** ads_u = new(&scr_u, struct sockaddr*, i_w); */
+  /* uv_buf_t** bus_u = new(&scr_u, uv_buf_t*, i_w); */
+  /* for (c3_w j_w = 0; j_w < i_w; j_w++) { */
+  /*   ads_u[j_w] = (struct sockaddr*)&req_u->per_u->dan_u; */
+  /*   bus_u[j_w] = &bfs_u[j_w]; */
+  /*   int_u[j_w] = 1; */
+  /* } */
 
   if ( c3y == los_o ) {
+    /* _mesa_send_buf2(req_u->per_u->sam_u, ads_u, bus_u, int_u, i_w); */
+    /* _mesa_send_buf2(req_u->per_u->sam_u, req_u->per_u->dan_u, bfs_u, i_w); */
     req_u->gag_u->sst_w = c3_max(1, req_u->gag_u->wnd_w / 2);
     req_u->gag_u->wnd_w = req_u->gag_u->sst_w;
     req_u->gag_u->rto_w = _clamp_rto(req_u->gag_u->rto_w * 2);
     /* req_u->out_d = 0; */
     u3l_log("loss");
-    u3l_log("resent %u", muna);
+    u3l_log("resent %u", i_w);
     u3l_log("counter %u hav_d %"PRIu64 " nex_d %"PRIu64 " ack_d %"PRIu64 " lef_d %"PRIu64 " old_d %"PRIu64, req_u->los_u->counter, req_u->hav_d, req_u->nex_d, req_u->ack_d, req_u->lef_d, req_u->old_d);
     _log_gage(req_u->gag_u);
   }
@@ -1459,12 +1584,12 @@ _mesa_add_our_to_pit(u3_mesa* sam_u, u3_mesa_name* nam_u)
 static void
 _mesa_resend_timer_cb(uv_timer_t* tim_u)
 {
-  u3_mesa_resend_data* res_u = (u3_mesa_resend_data*)tim_u;
+  u3_mesa_resend_data* res_u = tim_u->data;
   u3_mesa_request_data* dat_u = &res_u->dat_u;
   res_u->ret_y--;
 
-  u3_pit_entry* pit = _mesa_get_pit(dat_u->sam_u, dat_u->nam_u);
-  if ( NULL == pit ) {
+  u3_pend_req* pit_u = _mesa_get_request(dat_u->sam_u, dat_u->nam_u);
+  if ( (u3_pend_req*)CTAG_WAIT != pit_u ) {
     #ifdef MESA_DEBUG
       u3l_log("mesa: resend PIT entry gone %u", res_u->ret_y);
     #endif
@@ -1483,6 +1608,7 @@ _mesa_resend_timer_cb(uv_timer_t* tim_u)
     uv_timer_start(&res_u->tim_u, _mesa_resend_timer_cb, 1000, 0);
   }
   else {
+    _mesa_del_request(res_u->dat_u.sam_u, res_u->dat_u.nam_u);
     _mesa_free_resend_data(res_u);
   }
 }
@@ -1556,8 +1682,10 @@ _mesa_ef_send(u3_mesa* sam_u, u3_noun las, u3_noun pac)
       res_u->ret_y = 4;
       uv_timer_init(u3L, &res_u->tim_u);
     }
-    _mesa_add_our_to_pit(sam_u, nam_u);
+    _mesa_put_request(sam_u, nam_u, (u3_pend_req*)CTAG_WAIT);
+    /* _mesa_add_our_to_pit(sam_u, nam_u); */
     _mesa_send_request(dat_u);
+    res_u->tim_u.data = res_u;
     uv_timer_start(&res_u->tim_u, _mesa_resend_timer_cb, 1000, 0);
   }
 
@@ -1711,7 +1839,6 @@ _init_peer(u3_mesa* sam_u, u3_peer* per_u)
   _init_lane_state(&per_u->dir_u);
   per_u->imp_y = 0;
   _init_lane_state(&per_u->ind_u);
-  vt_init(&per_u->req_u);
 }
 
 static u3_noun
@@ -1962,6 +2089,7 @@ _mesa_page_scry_jumbo_cb(void* vod_p, u3_noun res)
     }
 
     u3r_bytes(0, tip_w, lin_u->tip_y, pof);
+    c3_free(jumbo_y);
 
   }
 
@@ -2066,6 +2194,7 @@ _forward_lanes_cb(void* vod_p, u3_noun nun)
 static void
 _meet_peer(u3_mesa* sam_u, u3_peer* per_u, u3_ship her_u)
 {
+  u3l_log("meet_peer");
   u3_noun her = u3_ship_to_noun(her_u);
   u3_noun gan = u3nc(u3_nul, u3_nul);
 
@@ -2106,19 +2235,43 @@ _mesa_request_next_fragments(u3_mesa* sam_u,
                              u3_pend_req* req_u,
                              sockaddr_in lan_u)
 {
+
+  lan_u.sin_addr.s_addr = ( u3_Host.ops_u.net == c3y ) ? lan_u.sin_addr.s_addr : htonl(0x7f000001);
+
   c3_w win_w = _mesa_req_get_cwnd(req_u);
   u3_mesa_pict* nex_u = req_u->pic_u;
   c3_w nex_d = req_u->nex_d;
-  for ( c3_w i = 0; i < win_w; i++ ) {
+  arena scr_u = req_u->are_u;
+  uv_buf_t* bfs_u = new(&scr_u, uv_buf_t, win_w);
+  uv_buf_t** bus_u = new(&scr_u, uv_buf_t*, win_w);
+  struct sockaddr** ads_u = new(&scr_u, struct sockaddr*, win_w);
+  /* memcpy(ads_u, &&lan_u, win_w*sizeof(struct sockaddr*)); */
+  c3_w* int_u = new(&scr_u, c3_w, win_w);
+  c3_w i;
+  c3_d now_d = _get_now_micros();
+  for ( i = 0; i < win_w; i++ ) {
     c3_w fra_w = nex_d + i;
     if ( fra_w >= req_u->tof_d ) {
       break;
     }
     // u3l_log("next fra_w: %u", fra_w);
-    nex_u->pac_u.pek_u.nam_u.fra_d = nex_d + i;
-    _mesa_add_our_to_pit(sam_u, &nex_u->pac_u.pek_u.nam_u);
-    _mesa_send(nex_u, lan_u);
-    _mesa_req_pact_sent(req_u, &nex_u->pac_u.pek_u.nam_u);
+    nex_u->pac_u.pek_u.nam_u.fra_d = fra_w;
+    uv_buf_t buf_u = _mesa_peek_buf(req_u->pek_c, nex_d+i, req_u->pek_w);
+    if (buf_u.base < req_u->pek_c) {
+        u3l_log("peek overflow, dying, fragment %u", nex_d+i);
+        abort();
+    }
+    /* _mesa_add_our_to_pit(sam_u, &nex_u->pac_u.pek_u.nam_u); */
+    mesa_etch_pact_to_buf((c3_y*)buf_u.base, buf_u.len, &nex_u->pac_u);
+    bfs_u[i] = buf_u;
+    bus_u[i] = &bfs_u[i];
+    ads_u[i] = (struct sockaddr*)&lan_u;
+    int_u[i] = 1;
+    _mesa_req_pact_sent(req_u, fra_w, now_d);
+
+    _mesa_send_buf3(req_u->per_u->dan_u, buf_u, req_u, fra_w);
+    // _mesa_send_modal(req_u->per_u, (c3_y*)buf_u.base, buf_u.len);
+    /* _mesa_send(nex_u, lan_u); */
   }
 }
 
@@ -2145,7 +2298,7 @@ _mesa_veri_scry_cb(void* vod_p, u3_noun nun)
 }
 
 static void
-_mesa_req_pact_init(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u)
+_mesa_req_pact_init(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u, u3_peer* per_u)
 {
   sam_u->tim_d = _get_now_micros();
   u3_mesa_pact* pac_u = &pic_u->pac_u;
@@ -2161,10 +2314,18 @@ _mesa_req_pact_init(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u)
   }
 
   _log_gage(gag_u);
+  u3_mesa_pact exa_u;
+  exa_u.hed_u.typ_y = PACT_PEEK;
+  exa_u.pek_u.nam_u = *nam_u;
+  exa_u.pek_u.nam_u.fra_d = 0;
+  exa_u.pek_u.nam_u.nit_o = c3n;
+  exa_u.pek_u.nam_u.aut_o = c3n;
+  c3_w pek_w = mesa_size_pact(&exa_u);
   c3_d tof_d = mesa_num_leaves(dat_u->tob_d);
   c3_w pof_w = lss_proof_size(tof_d);
   c3_w pairs_w = c3_bits_word(pof_w);
-  arena are_u = arena_create(sizeof(u3_pend_req) + sizeof(u3_mesa_pict) + dat_u->tob_d + (tof_d * sizeof(lss_pair)) + (sizeof(u3_pact_stat) * tof_d + 2) + (pof_w * sizeof(lss_hash)) + ((dat_u->tob_d >> 3) + 1) + sizeof(lss_verifier) + (pairs_w * sizeof(lss_pair)));
+  c3_d pek_d = dat_u->tob_d;
+  arena are_u = arena_create(5*dat_u->tob_d);
   u3_pend_req* req_u = new(&are_u, u3_pend_req, 1);
   req_u->are_u = are_u;
   req_u->pic_u = new(&req_u->are_u, u3_mesa_pict, 1);
@@ -2210,7 +2371,13 @@ _mesa_req_pact_init(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u)
   req_u->los_u = new(&req_u->are_u, lss_verifier, 1);
   lss_verifier_init(req_u->los_u, 0, req_u->tof_d, pof_u, &req_u->are_u);
 
-  req_u = _mesa_put_request(sam_u, &req_u->pic_u->pac_u.pek_u.nam_u, req_u);
+  req_u->pek_w = pek_w;
+  req_u->pek_d = pek_d;
+  req_u->pek_c = new(&req_u->are_u, c3_c, pek_d);
+
+  req_u->per_u = per_u;
+
+  _mesa_put_request(sam_u, &req_u->pic_u->pac_u.pek_u.nam_u, req_u);
   _update_resend_timer(req_u);
 
   // scry to verify auth
@@ -2276,6 +2443,18 @@ _mesa_add_hop(c3_y hop_y, u3_mesa_head* hed_u, u3_mesa_page_pact* pag_u, sockadd
 
 }
 
+static c3_d avg_time() {
+  c3_d sum = 0;
+  c3_w i;
+  for (i = 0; tim_y[i] != 0; i++) {
+    if (tim_y[i] > 1000) {
+      u3l_log("dingding fra %u time %"PRIu64, i, tim_y[i]);
+    }
+    sum += tim_y[i];
+  }
+  return sum / i;
+}
+
 static void
 _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
 {
@@ -2288,8 +2467,6 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
   u3_mesa* sam_u = pic_u->sam_u;
   u3_mesa_pact* pac_u = &pic_u->pac_u;
   u3_mesa_name* nam_u = &pac_u->pag_u.nam_u;
-  /* u3l_log("heard fra %llu", pac_u->pag_u.nam_u.fra_d); */
-
 
   c3_o our_o = u3_ships_equal(nam_u->her_u, sam_u->pir_u->who_d);
 
@@ -2317,16 +2494,52 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
 
   _mesa_put_peer(sam_u, nam_u->her_u, per_u);
 
-  u3_pit_entry* pin_u = _mesa_get_pit(sam_u, nam_u);
-
-  if ( NULL == pin_u ) {
-    #ifdef MESA_DEBUG
-      /* u3l_log(" no PIT entry"); */
-      /* log_name(nam_u); */
-    #endif
+  c3_d lev_d = mesa_num_leaves(pac_u->pag_u.dat_u.tob_d);
+  u3_pend_req* req_u = _mesa_get_request(sam_u, nam_u);
+  if ( !req_u ) {
     return;
   }
-  if ( c3n == _mesa_is_lane_zero(pin_u->adr_u->sdr_u) ) {
+  if ( ( (u3_pend_req*)CTAG_WAIT == req_u ) && (0 == nam_u->fra_d) ) {
+    // process incoming response to ourselves
+    // if single-leaf message, inject directly into Arvo
+    c3_d lev_d = mesa_num_leaves(pac_u->pag_u.dat_u.tob_d);
+    if ( 1 == lev_d ) {
+      u3_noun cad;
+      {
+        u3_noun lan = u3_mesa_encode_lane(lan_u);
+
+        //  XX should just preserve input buffer
+        u3i_slab sab_u;
+        u3i_slab_init(&sab_u, 3, PACT_SIZE);
+        mesa_etch_pact_to_buf(sab_u.buf_y, PACT_SIZE, pac_u);
+        cad = u3nt(c3__heer, lan, u3i_slab_mint(&sab_u));
+      }
+
+      u3_noun wir = u3nc(c3__ames, u3_nul);
+
+      u3l_log("one fragment inject");
+      u3_ovum* ovo = u3_ovum_init(0, c3__ames, wir, cad);
+      ovo = u3_auto_plan(&sam_u->car_u, ovo);
+
+      // early deletion, to avoid injecting retries,
+      //    (in case of failure, the retry timer will add it again to the PIT)
+      //
+      _mesa_del_request(sam_u, nam_u);
+      u3_auto_peer(ovo, 0, 0, _mesa_page_bail_cb);
+      return;
+    }
+
+
+    c3_d now_d = _get_now_micros();
+    _mesa_req_pact_init(sam_u, pic_u, lan_u, per_u);
+    u3l_log(" _mesa_req_pact_init took %"PRIu64, _get_now_micros() - now_d);
+    log_name(nam_u);
+    return;
+  }
+
+  u3_pit_entry* pin_u = _mesa_get_pit(sam_u, nam_u);
+
+  if ( NULL != pin_u ) {
     #ifdef MESA_DEBUG
       u3l_log(" forwarding");
     #endif
@@ -2341,50 +2554,8 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
 
     _mesa_send_pact(sam_u, pin_u->adr_u, per_u, pac_u);
     _mesa_del_pit(sam_u, nam_u);
-    return;
   }
 
-  // process incoming response to ourselves
-
-  // if single-leaf message, inject directly into Arvo
-  c3_d lev_d = mesa_num_leaves(pac_u->pag_u.dat_u.tob_d);
-  if ( 1 == lev_d ) {
-    u3_noun cad;
-    {
-      u3_noun lan = u3_mesa_encode_lane(lan_u);
-
-      //  XX should just preserve input buffer
-      u3i_slab sab_u;
-      u3i_slab_init(&sab_u, 3, PACT_SIZE);
-      mesa_etch_pact_to_buf(sab_u.buf_y, PACT_SIZE, pac_u);
-      cad = u3nt(c3__heer, lan, u3i_slab_mint(&sab_u));
-    }
-
-    u3_noun wir = u3nc(c3__ames, u3_nul);
-
-    u3l_log("one fragment inject");
-    u3_ovum* ovo = u3_ovum_init(0, c3__ames, wir, cad);
-             ovo = u3_auto_plan(&sam_u->car_u, ovo);
-
-    // early deletion, to avoid injecting retries,
-    //    (in case of failure, the retry timer will add it again to the PIT)
-    //
-    _mesa_del_pit(sam_u, nam_u);
-    u3_auto_peer(ovo, 0, 0, _mesa_page_bail_cb);
-    return;
-  }
-
-  u3_pend_req* req_u = _mesa_get_request(sam_u, nam_u);
-  if ( !req_u ) {
-    if ( 0 == nam_u->fra_d ) {
-      _mesa_req_pact_init(sam_u, pic_u, lan_u);
-    }
-    u3l_log(" _mesa_req_pact_init");
-    log_name(nam_u);
-
-    _mesa_del_pit(sam_u, nam_u);
-    return;
-  }
 
   if ( c3y == nam_u->nit_o ) {
     u3l_log("dupe init");
@@ -2410,7 +2581,6 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
   c3_y boq_y = 31;
   // c3_o done_with_jumbo_frame = __(0 == req_u->hav_d % boq_y);
   c3_o done_with_jumbo_frame = __(req_u->hav_d == req_u->tof_d); // TODO: fix for non-message-sized jumbo frames
-  _mesa_del_pit(sam_u, nam_u);
   if ( c3y == done_with_jumbo_frame ) {
     u3_noun cad;
 
@@ -2422,6 +2592,8 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
     u3l_log("%" PRIu64 " kilobytes took %f ms",
             req_u->tof_d,
             (now_d - sam_u->tim_d)/1000.0);
+    u3l_log("page handling took %"PRIu64, avg_time());
+    done = c3y;
 
     {
       // construct jumbo frame
@@ -2515,7 +2687,7 @@ _mesa_hear_peek(u3_mesa_pict* pic_u, sockaddr_in lan_u)
 
   pac_u->pek_u.nam_u.fra_d = bat_d;
 
-  // u3l_log("hear peek fra %llu", fra_d);
+  /* u3l_log("hear peek fra %llu", fra_d); */
 
   // if we have the page, send it
   u3_mesa_line* lin_u = _mesa_get_jumbo_cache(sam_u, &pac_u->pek_u.nam_u);
@@ -2651,8 +2823,11 @@ _mesa_hear(u3_mesa* sam_u,
            c3_w     len_w,
            c3_y*    hun_y)
 {
+  c3_d now_d = _get_now_micros();
   if ( c3n == mesa_is_new_pact(hun_y, len_w) ) {
-    _ames_hear(u3_Host.sam_u, adr_u, len_w, hun_y);
+    c3_y* han_y = c3_malloc(len_w);
+    memcpy(han_y, hun_y, len_w);
+    _ames_hear(u3_Host.sam_u, adr_u, len_w, han_y);
     return;
   }
 
@@ -2661,7 +2836,6 @@ _mesa_hear(u3_mesa* sam_u,
   c3_c* err_c = mesa_sift_pact_from_buf(&pic_u->pac_u, hun_y, len_w);
   if ( err_c ) {
     u3l_log("mesa: hear: sift failed: %s", err_c);
-    arena_free(&sam_u->are_u);
     return;
   }
 
@@ -2678,7 +2852,18 @@ _mesa_hear(u3_mesa* sam_u,
       _mesa_hear_poke(pic_u, sdr_u);
     } break;
   }
-  arena_free(&sam_u->are_u);
+  if (done == c3n) {
+    if (tidx < 200000) {
+      tim_y[tidx] = _get_now_micros() - now_d;
+      tidx++;
+    } else {
+      u3l_log("peek handling took %"PRIu64, avg_time());
+      tidx = 0;
+    }
+  } else {
+    tidx = 0;
+    done = c3n;
+  }
 }
 
 static void _mesa_recv_cb(uv_udp_t*        wax_u,
@@ -2692,16 +2877,13 @@ static void _mesa_recv_cb(uv_udp_t*        wax_u,
     if ( u3C.wag_w & u3o_verbose ) {
       u3l_log("mesa: recv: fail: %s", uv_strerror(nrd_i));
     }
-    arena_free(&sam_u->are_u);
   }
   else if ( 0 == nrd_i ) {
-    arena_free(&sam_u->are_u);
   }
   else if ( flg_i & UV_UDP_PARTIAL ) {
     if ( u3C.wag_w & u3o_verbose ) {
       u3l_log("mesa: recv: fail: message truncated");
     }
-    arena_free(&sam_u->are_u);
   }
   else {
     _mesa_hear(wax_u->data, adr_u, (c3_w)nrd_i, (c3_y*)buf_u->base);
@@ -2784,6 +2966,16 @@ _mesa_io_talk(u3_auto* car_u)
   u3_Host.wax_u.data = sam_u;
   uv_udp_recv_start(&u3_Host.wax_u, _mesa_alloc, _mesa_recv_cb);
 
+  c3_i rec_i = 2 * 1024 * 1024;
+  c3_i lel_i = 0;
+  c3_i err_i = uv_recv_buffer_size((uv_handle_t*)&u3_Host.wax_u, &rec_i);
+  err_i = uv_recv_buffer_size((uv_handle_t*)&u3_Host.wax_u, &lel_i);
+  u3l_log("ames: recv buffer size %i %i %s", err_i, lel_i, uv_strerror(err_i));
+
+  err_i = uv_send_buffer_size((uv_handle_t*)&u3_Host.wax_u, &rec_i);
+  err_i = uv_send_buffer_size((uv_handle_t*)&u3_Host.wax_u, &lel_i);
+  u3l_log("ames: send buffer size %i %i %s", err_i, lel_i, uv_strerror(err_i));
+
   sam_u->car_u.liv_o = c3y;
   //u3z(rac); u3z(who);
 }
@@ -2799,13 +2991,19 @@ u3_mesa_io_init(u3_pier* pir_u)
   sam_u->par_u    = par_u;
   sam_u->pir_u    = pir_u;
 
+  arena are_u;
+  are_u.dat = (char*)are_y;
+  are_u.beg = (char*)are_y;
+  are_u.end = (char*)(are_y + 524288);
+  sam_u->are_u = are_u;
 
   vt_init(&sam_u->pit_u);
   vt_init(&sam_u->per_u);
   vt_init(&sam_u->gag_u);
   vt_init(&sam_u->jum_u);
+  vt_init(&sam_u->req_u);
 
-  u3_assert( !uv_udp_init(u3L, &sam_u->wax_u) );
+  u3_assert( !uv_udp_init_ex(u3L, &sam_u->wax_u, UV_UDP_RECVMMSG) );
   sam_u->wax_u.data = sam_u;
 
   sam_u->sil_u = u3s_cue_xeno_init();
@@ -2851,4 +3049,3 @@ u3_mesa_io_init(u3_pier* pir_u)
 
   return car_u;
 }
-

--- a/pkg/vere/io/mesa/bitset.c
+++ b/pkg/vere/io/mesa/bitset.c
@@ -3,16 +3,10 @@
 
 #include "vere.h"
 
-void bitset_init(u3_bitset* bit_u, c3_w len_w)
+void bitset_init(u3_bitset* bit_u, c3_w len_w, arena* are_u)
 {
   bit_u->len_w = len_w;
-  bit_u->buf_y = c3_calloc((len_w >> 3) + 1);
-}
-
-void
-bitset_free(u3_bitset* bit_u)
-{
-  c3_free(bit_u->buf_y);
+  bit_u->buf_y = new(are_u, c3_y, (len_w >> 3) + 1);
 }
 
 static c3_y

--- a/pkg/vere/io/mesa/bitset.c
+++ b/pkg/vere/io/mesa/bitset.c
@@ -7,6 +7,7 @@ void bitset_init(u3_bitset* bit_u, c3_w len_w, arena* are_u)
 {
   bit_u->len_w = len_w;
   bit_u->buf_y = new(are_u, c3_y, (len_w >> 3) + 1);
+  memset(bit_u->buf_y, 0, (len_w >> 3) + 1);
 }
 
 static c3_y
@@ -83,7 +84,7 @@ c3_w main()
 {
   u3_bitset bit_u;
   bitset_init(&bit_u, 500);
-  
+
   bitset_put(&bit_u, 5);
   bitset_put(&bit_u, 50);
   bitset_put(&bit_u, 100);
@@ -121,5 +122,3 @@ c3_w main()
 }
 
 #endif
-
-

--- a/pkg/vere/io/mesa/bitset.h
+++ b/pkg/vere/io/mesa/bitset.h
@@ -2,13 +2,14 @@
 #define VERE_BITSET_H
 
 #include "c3/c3.h"
+#include "arena.h"
 
 typedef struct _u3_bitset {
   c3_w  len_w;
   c3_y* buf_y;
 } u3_bitset;
 
-void bitset_init(u3_bitset* bit_u, c3_w len_w);
+void bitset_init(u3_bitset* bit_u, c3_w len_w, arena* are_u);
 
 void bitset_free(u3_bitset* bit_u);
 

--- a/pkg/vere/io/mesa/mesa.h
+++ b/pkg/vere/io/mesa/mesa.h
@@ -32,6 +32,11 @@ typedef enum _u3_mesa_hop_type {
   HOP_MANY  = 3
 } u3_mesa_hop_type;
 
+typedef struct _u3_str {
+  c3_c* str_c;
+  c3_w  len_w;
+} u3_str;
+
 typedef struct _u3_mesa_name_meta {
   c3_y         ran_y;  // rank (2 bits)
   c3_y         rif_y;  // rift-len (2 bits)
@@ -50,6 +55,7 @@ typedef struct _u3_mesa_name {
   c3_d               fra_d;
   c3_s               pat_s;
   c3_c*              pat_c;
+  u3_str             str_u;
 } u3_mesa_name;
 
 typedef struct _u3_mesa_data_meta {
@@ -142,6 +148,14 @@ typedef struct _u3_mesa_pact {
   };
 } u3_mesa_pact;
 
+typedef struct _u3_etcher {
+  c3_y* buf_y;
+  c3_w  len_w;
+  c3_w  cap_w;
+  c3_d  bit_d; // for _etch_bits
+  c3_y  off_y; // for _etch_bits
+} u3_etcher;
+
 c3_d mesa_num_leaves(c3_d tot_d);
 c3_w mesa_size_pact(u3_mesa_pact* pac_u);
 c3_o mesa_is_new_pact(c3_y* buf_y, c3_w len_w);
@@ -149,6 +163,8 @@ c3_o mesa_is_new_pact(c3_y* buf_y, c3_w len_w);
 void mesa_free_pact(u3_mesa_pact* pac_u);
 
 c3_w mesa_etch_pact_to_buf(c3_y* buf_y, c3_w cap_w, u3_mesa_pact *pac_u);
+void etcher_init(u3_etcher* ech_u, c3_y* buf_y, c3_w cap_w);
+void _mesa_etch_name(u3_etcher *ech_u, u3_mesa_name* nam_u);
 c3_c* mesa_sift_pact_from_buf(u3_mesa_pact *pac_u, c3_y* buf_y, c3_w len_w);
 
 void inc_hopcount(u3_mesa_head*);

--- a/pkg/vere/io/mesa/pact.c
+++ b/pkg/vere/io/mesa/pact.c
@@ -499,8 +499,8 @@ _sift_var_chub(u3_sifter* sif_u, c3_w len_w)
     return 0;
   }
   c3_d val_d = 0;
-  for ( int i = 0; i < len_w; i++ ) {
-    val_d |= (res_y[i] << (8*i));
+  for ( c3_d i = 0; i < len_w; i++ ) {
+    val_d |= ((c3_d)res_y[i] << (8*i));
   }
   return val_d;
 }

--- a/pkg/vere/io/mesa/pact.c
+++ b/pkg/vere/io/mesa/pact.c
@@ -167,7 +167,7 @@ log_name(u3_mesa_name* nam_u)
     u3z(her);
   }
 
-  u3l_log("%s: /%s", her_c, nam_u->pat_c);
+  u3l_log("%s: /%.*s", her_c, nam_u->pat_s, nam_u->pat_c);
   u3l_log("  rift: %u  bloq: %u  auth/data: %s init: %s frag: %"PRIu64,
           nam_u->rif_w,
           nam_u->boq_y,
@@ -307,45 +307,8 @@ _mesa_bytes_of_chub_tag(c3_y tot_y)
   return 1 << tot_y;
 }
 
-/* lifecycle
-*/
-
-/* mesa_free_pact(): free contents of packet.
-*    Does *not* free pac_u itself
-*/
-void mesa_free_pact(u3_mesa_pact* pac_u)
-{
-  c3_free(pac_u->pek_u.nam_u.pat_c);
-  switch ( pac_u->hed_u.typ_y ) {
-    default: {
-      break;
-    };
-    case PACT_PEEK: {
-      break;
-    };
-    case PACT_PAGE: {
-      c3_free(pac_u->pag_u.dat_u.fra_y);
-      break;
-    };
-    case PACT_POKE: {
-      /* c3_free(pac_u->pok_u.nam_u.pat_c); */
-      c3_free(pac_u->pok_u.pay_u.pat_c);
-      c3_free(pac_u->pok_u.dat_u.fra_y);
-      break;
-    };
-  }
-}
-
 /* serialisation
 */
-
-typedef struct _u3_etcher {
-  c3_y* buf_y;
-  c3_w  len_w;
-  c3_w  cap_w;
-  c3_d  bit_d; // for _etch_bits
-  c3_y  off_y; // for _etch_bits
-} u3_etcher;
 
 typedef struct _u3_sifter {
   c3_y* buf_y;
@@ -355,7 +318,7 @@ typedef struct _u3_sifter {
   c3_c* err_c;
 } u3_sifter;
 
-static void
+void
 etcher_init(u3_etcher* ech_u, c3_y* buf_y, c3_w cap_w)
 {
   ech_u->buf_y = buf_y;
@@ -630,7 +593,7 @@ mesa_sift_head(u3_sifter* sif_u, u3_mesa_head* hed_u)
   }
 }
 
-static void
+void
 _mesa_etch_name(u3_etcher *ech_u, u3_mesa_name* nam_u)
 {
   u3_mesa_name_meta met_u = {0};
@@ -672,6 +635,9 @@ _mesa_etch_name(u3_etcher *ech_u, u3_mesa_name* nam_u)
 static void
 _mesa_sift_name(u3_sifter* sif_u, u3_mesa_name* nam_u)
 {
+  nam_u->str_u.str_c = (c3_c*)sif_u->buf_y;
+  c3_w rem_w = sif_u->rem_w;
+
   u3_mesa_name_meta met_u = {0};
   met_u.ran_y = _sift_bits(sif_u, 2);
   met_u.rif_y = _sift_bits(sif_u, 2);
@@ -698,9 +664,16 @@ _mesa_sift_name(u3_sifter* sif_u, u3_mesa_name* nam_u)
 
   nam_u->pat_s = _sift_short(sif_u);
 
-  nam_u->pat_c = c3_calloc(nam_u->pat_s + 1);
-  _sift_bytes(sif_u, (c3_y*)nam_u->pat_c, nam_u->pat_s);
-  nam_u->pat_c[nam_u->pat_s] = 0;
+  nam_u->pat_c = (c3_c*)sif_u->buf_y;
+  /* nam_u->pat_c = c3_calloc(nam_u->pat_s + 1); */
+  /* _sift_bytes(sif_u, (c3_y*)nam_u->pat_c, nam_u->pat_s); */
+
+  sif_u->buf_y += nam_u->pat_s;
+  sif_u->rem_w -= nam_u->pat_s;
+
+  nam_u->str_u.len_w = rem_w - sif_u->rem_w;
+
+  /* nam_u->pat_c[nam_u->pat_s] = 0; */
 }
 
 static void
@@ -777,7 +750,7 @@ _mesa_sift_data(u3_sifter* sif_u, u3_mesa_data* dat_u)
     nel_y = _sift_byte(sif_u);
   }
   dat_u->len_w = _sift_var_word(sif_u, nel_y);
-  dat_u->fra_y = _sift_bytes_alloc(sif_u, dat_u->len_w);
+  dat_u->fra_y = _sift_next(sif_u, dat_u->len_w);
 }
 
 static void

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -342,8 +342,9 @@
         c3_o       pep_o;                   //  prep for upgrade
         c3_i       xit_i;                   //  exit code for shutdown
         void     (*bot_f)();                //  call when chis is up
-        void*      sam_u;                   //  XX
-        uv_udp_t   wax_u;                   //  XX
+        void*      sam_u;                   //  old ames, "unified driver" hack
+        uv_udp_t   wax_u;                   //  "unified driver" udp send handle
+        c3_w*      imp_u;                   //  "unified driver" galaxy IP:s
       } u3_host;                            //  host == computer == process
 
     /**  Pier system.

--- a/pkg/vere/verstable.h
+++ b/pkg/vere/verstable.h
@@ -1,0 +1,1946 @@
+/*------------------------------------------------- VERSTABLE v2.1.1 ---------------------------------------------------
+
+Verstable is a C99-compatible, open-addressing hash table using quadratic probing and the following additions:
+
+* All keys that hash (i.e. "belong") to the same bucket (their "home bucket") are linked together by an 11-bit integer
+  specifying the quadratic displacement, relative to that bucket, of the next key in the chain.
+
+* If a chain of keys exists for a given bucket, then it always begins at that bucket. To maintain this policy, a 1-bit
+  flag is used to mark whether the key occupying a bucket belongs there. When inserting a new key, if the bucket it
+  belongs to is occupied by a key that does not belong there, then the occupying key is evicted and the new key takes
+  the bucket.
+
+* A 4-bit fragment of each key's hash code is also stored.
+
+* The aforementioned metadata associated with each bucket (the 4-bit hash fragment, the 1-bit flag, and the 11-bit link
+  to the next key in the chain) are stored together in a uint16_t array rather than in the bucket alongside the key and
+  (optionally) the value.
+
+One way to conceptualize this scheme is as a chained hash table in which overflowing keys are stored not in separate
+memory allocations but in otherwise unused buckets. In this regard, it shares similarities with Malte Skarupke's Bytell
+hash table (https://www.youtube.com/watch?v=M2fKMP47slQ) and traditional "coalesced hashing".
+
+Advantages of this scheme include:
+
+* Fast lookups impervious to load factor: If the table contains any key belonging to the lookup key's home bucket, then
+  that bucket contains the first in a traversable chain of all keys belonging to it. Hence, only the home bucket and
+  other buckets containing keys belonging to it are ever probed. Moreover, the stored hash fragments allow skipping most
+  non-matching keys in the chain without accessing the actual buckets array or calling the (potentially expensive) key
+  comparison function.
+
+* Fast insertions: Insertions are faster than they are in other schemes that move keys around (e.g. Robin Hood) because
+  they only move, at most, one existing key.
+
+* Fast, tombstone-free deletions: Deletions, which usually require tombstones in quadratic-probing hash tables, are
+  tombstone-free and only move, at most, one existing key.
+
+* Fast iteration: The separate metadata array allows keys in sparsely populated tables to be found without incurring the
+  frequent cache misses that would result from traversing the buckets array.
+
+Usage example:
+
+  +---------------------------------------------------------+----------------------------------------------------------+
+  | Using the generic macro API (C11 and later):            | Using the prefixed functions API (C99 and later):        |
+  |---------------------------------------------------------+----------------------------------------------------------+
+  | #include <stdio.h>                                      | #include <stdio.h>                                       |
+  |                                                         |                                                          |
+  | // Instantiating a set template.                        | // Instantiating a set template.                         |
+  | #define NAME int_set                                    | #define NAME int_set                                     |
+  | #define KEY_TY int                                      | #define KEY_TY int                                       |
+  | #include "verstable.h"                                  | #define HASH_FN vt_hash_integer                          |
+  |                                                         | #define CMPR_FN vt_cmpr_integer                          |
+  | // Instantiating a map template.                        | #include "verstable.h"                                   |
+  | #define NAME int_int_map                                |                                                          |
+  | #define KEY_TY int                                      | // Instantiating a map template.                         |
+  | #define VAL_TY int                                      | #define NAME int_int_map                                 |
+  | #include "verstable.h"                                  | #define KEY_TY int                                       |
+  |                                                         | #define VAL_TY int                                       |
+  | int main( void )                                        | #define HASH_FN vt_hash_integer                          |
+  | {                                                       | #define CMPR_FN vt_cmpr_integer                          |
+  |   // Set.                                               | #include "verstable.h"                                   |
+  |                                                         |                                                          |
+  |   int_set our_set;                                      | int main( void )                                         |
+  |   vt_init( &our_set );                                  | {                                                        |
+  |                                                         |   // Set.                                                |
+  |   // Inserting keys.                                    |                                                          |
+  |   for( int i = 0; i < 10; ++i )                         |   int_set our_set;                                       |
+  |   {                                                     |   int_set_init( &our_set );                              |
+  |     int_set_itr itr = vt_insert( &our_set, i );         |                                                          |
+  |     if( vt_is_end( itr ) )                              |   // Inserting keys.                                     |
+  |     {                                                   |   for( int i = 0; i < 10; ++i )                          |
+  |       // Out of memory, so abort.                       |   {                                                      |
+  |       vt_cleanup( &our_set );                           |     int_set_itr itr =                                    |
+  |       return 1;                                         |       int_set_insert( &our_set, i );                     |
+  |     }                                                   |     if( int_set_is_end( itr ) )                          |
+  |   }                                                     |     {                                                    |
+  |                                                         |       // Out of memory, so abort.                        |
+  |   // Erasing keys.                                      |       int_set_cleanup( &our_set );                       |
+  |   for( int i = 0; i < 10; i += 3 )                      |       return 1;                                          |
+  |     vt_erase( &our_set, i );                            |     }                                                    |
+  |                                                         |   }                                                      |
+  |   // Retrieving keys.                                   |                                                          |
+  |   for( int i = 0; i < 10; ++i )                         |   // Erasing keys.                                       |
+  |   {                                                     |   for( int i = 0; i < 10; i += 3 )                       |
+  |     int_set_itr itr = vt_get( &our_set, i );            |     int_set_erase( &our_set, i );                        |
+  |     if( !vt_is_end( itr ) )                             |                                                          |
+  |       printf( "%d ", itr.data->key );                   |   // Retrieving keys.                                    |
+  |   }                                                     |   for( int i = 0; i < 10; ++i )                          |
+  |   // Printed: 1 2 4 5 7 8                               |   {                                                      |
+  |                                                         |     int_set_itr itr = int_set_get( &our_set, i );        |
+  |   // Iteration.                                         |     if( !int_set_is_end( itr ) )                         |
+  |   for(                                                  |       printf( "%d ", itr.data->key );                    |
+  |     int_set_itr itr = vt_first( &our_set );             |   }                                                      |
+  |     !vt_is_end( itr );                                  |   // Printed: 1 2 4 5 7 8                                |
+  |     itr = vt_next( itr )                                |                                                          |
+  |   )                                                     |   // Iteration.                                          |
+  |     printf( "%d ", itr.data->key );                     |   for(                                                   |
+  |   // Printed: 2 4 7 1 5 8                               |     int_set_itr itr =                                    |
+  |                                                         |       int_set_first( &our_set );                         |
+  |   vt_cleanup( &our_set );                               |     !int_set_is_end( itr );                              |
+  |                                                         |     itr = int_set_next( itr )                            |
+  |   // Map.                                               |   )                                                      |
+  |                                                         |     printf( "%d ", itr.data->key );                      |
+  |   int_int_map our_map;                                  |   // Printed: 2 4 7 1 5 8                                |
+  |   vt_init( &our_map );                                  |                                                          |
+  |                                                         |   int_set_cleanup( &our_set );                           |
+  |   // Inserting keys and values.                         |                                                          |
+  |   for( int i = 0; i < 10; ++i )                         |   // Map.                                                |
+  |   {                                                     |                                                          |
+  |     int_int_map_itr itr =                               |   int_int_map our_map;                                   |
+  |       vt_insert( &our_map, i, i + 1 );                  |   int_int_map_init( &our_map );                          |
+  |     if( vt_is_end( itr ) )                              |                                                          |
+  |     {                                                   |   // Inserting keys and values.                          |
+  |       // Out of memory, so abort.                       |   for( int i = 0; i < 10; ++i )                          |
+  |       vt_cleanup( &our_map );                           |   {                                                      |
+  |       return 1;                                         |     int_int_map_itr itr =                                |
+  |     }                                                   |       int_int_map_insert( &our_map, i, i + 1 );          |
+  |   }                                                     |     if( int_int_map_is_end( itr ) )                      |
+  |                                                         |     {                                                    |
+  |   // Erasing keys and values.                           |       // Out of memory, so abort.                        |
+  |   for( int i = 0; i < 10; i += 3 )                      |       int_int_map_cleanup( &our_map );                   |
+  |     vt_erase( &our_map, i );                            |       return 1;                                          |
+  |                                                         |     }                                                    |
+  |   // Retrieving keys and values.                        |   }                                                      |
+  |   for( int i = 0; i < 10; ++i )                         |                                                          |
+  |   {                                                     |   // Erasing keys and values.                            |
+  |     int_int_map_itr itr = vt_get( &our_map, i );        |   for( int i = 0; i < 10; i += 3 )                       |
+  |     if( !vt_is_end( itr ) )                             |     int_int_map_erase( &our_map, i );                    |
+  |       printf(                                           |                                                          |
+  |         "%d:%d ",                                       |   // Retrieving keys and values.                         |
+  |         itr.data->key,                                  |   for( int i = 0; i < 10; ++i )                          |
+  |         itr.data->val                                   |   {                                                      |
+  |       );                                                |     int_int_map_itr itr =                                |
+  |   }                                                     |       int_int_map_get( &our_map, i );                    |
+  |   // Printed: 1:2 2:3 4:5 5:6 7:8 8:9                   |     if( !int_int_map_is_end( itr ) )                     |
+  |                                                         |       printf(                                            |
+  |   // Iteration.                                         |         "%d:%d ",                                        |
+  |   for(                                                  |         itr.data->key,                                   |
+  |     int_int_map_itr itr = vt_first( &our_map );         |         itr.data->val                                    |
+  |     !vt_is_end( itr );                                  |     );                                                   |
+  |     itr = vt_next( itr )                                |   }                                                      |
+  |   )                                                     |   // Printed: 1:2 2:3 4:5 5:6 7:8 8:9                    |
+  |     printf(                                             |                                                          |
+  |       "%d:%d ",                                         |   // Iteration.                                          |
+  |       itr.data->key,                                    |   for(                                                   |
+  |       itr.data->val                                     |     int_int_map_itr itr =                                |
+  |     );                                                  |       int_int_map_first( &our_map );                     |
+  |   // Printed: 2:3 4:5 7:8 1:2 5:6 8:9                   |     !int_int_map_is_end( itr );                          |
+  |                                                         |     itr = int_int_map_next( itr )                        |
+  |   vt_cleanup( &our_map );                               |   )                                                      |
+  | }                                                       |     printf(                                              |
+  |                                                         |       "%d:%d ",                                          |
+  |                                                         |       itr.data->key,                                     |
+  |                                                         |       itr.data->val                                      |
+  |                                                         |     );                                                   |
+  |                                                         |   // Printed: 2:3 4:5 7:8 1:2 5:6 8:9                    |
+  |                                                         |                                                          |
+  |                                                         |   int_int_map_cleanup( &our_map );                       |
+  |                                                         | }                                                        |
+  |                                                         |                                                          |
+  +---------------------------------------------------------+----------------------------------------------------------+
+
+API:
+
+  Instantiating a hash table template:
+
+    Create a new hash table type in the following manner:
+
+      #define NAME   <your chosen type name>
+      #define KEY_TY <type>
+      #include "verstable.h"
+
+    The NAME macro specifies the name of hash table type that the library will declare, the prefix for the functions
+    associated with it, and the prefix for the associated iterator type.
+
+    The KEY_TY macro specifies the key type.
+
+    In C99, it is also always necessary to define HASH_FN and CMPR_FN (see below) before including the header.
+
+    The following macros may also be defined before including the header:
+
+      #define VAL_TY <type>
+
+        The type of the value associated with each key.
+        If this macro is defined, the hash table acts as a map associating keys with values.
+        Otherwise, it acts as a set containing only keys.
+
+      #define HASH_FN <function name>
+
+        The name of the existing function used to hash each key.
+        The function should have the signature uint64_t ( KEY_TY key ) and return a 64-bit hash code.
+        For best performance, the hash function should provide a high level of entropy across all bits.
+        There are two default hash functions: vt_hash_integer for all integer types up to 64 bits in size, and
+        vt_hash_string for NULL-terminated strings (i.e. char *).
+        When KEY_TY is one of such types and the compiler is in C11 mode or later, HASH_FN may be left undefined, in
+        which case the appropriate default function is inferred from KEY_TY.
+        Otherwise, HASH_FN must be defined.
+
+      #define CMPR_FN <function name>
+
+        The name of the existing function used to compare two keys.
+        The function should have the signature bool ( KEY_TY key_1, KEY_TY key_2 ) and return true if the two keys are
+        equal.
+        There are two default comparison functions: vt_cmpr_integer for all integer types up to 64 bits in size, and
+        vt_cmpr_string for NULL-terminated strings (i.e. char *).
+        As with the default hash functions, in C11 or later the appropriate default comparison function is inferred if
+        KEY_TY is one of such types and CMPR_FN is left undefined.
+        Otherwise, CMPR_FN must be defined.
+
+      #define MAX_LOAD <floating point value>
+
+        The floating-point load factor at which the hash table automatically doubles the size of its internal buckets
+        array.
+        The default is 0.9, i.e. 90%.
+
+      #define KEY_DTOR_FN <function name>
+
+        The name of the existing destructor function, with the signature void ( KEY_TY key ), called on a key when it is
+        erased from the table or replaced by a newly inserted key.
+        The API functions that may call the key destructor are NAME_insert, NAME_erase, NAME_erase_itr, NAME_clear,
+        and NAME_cleanup.
+
+      #define VAL_DTOR_FN <function name>
+
+        The name of the existing destructor function, with the signature void ( VAL_TY val ), called on a value when it
+        is erased from the table or replaced by a newly inserted value.
+        The API functions that may call the value destructor are NAME_insert, NAME_erase, NAME_erase_itr, NAME_clear,
+        and NAME_cleanup.
+
+      #define CTX_TY <type>
+
+        The type of the hash table type's ctx (context) member.
+        This member only exists if CTX_TY was defined.
+        It is intended to be used in conjunction with MALLOC_FN and FREE_FN (see below).
+
+      #define MALLOC_FN <function name>
+
+        The name of the existing function used to allocate memory.
+        If CTX_TY was defined, the signature should be void *( size_t size, CTX_TY *ctx ), where size is the number of
+        bytes to allocate and ctx points to the table's ctx member.
+        Otherwise, the signature should be void *( size_t size ).
+        The default wraps stdlib.h's malloc.
+
+      #define FREE_FN <function name>
+
+        The name of the existing function used to free memory.
+        If CTX_TY was defined, the signature should be void ( void *ptr, size_t size, CTX_TY *ctx ), where ptr points to
+        the memory to free, size is the number of bytes that were allocated, and ctx points to the table's ctx member.
+        Otherwise, the signature should be void ( void *ptr, size_t size ).
+        The default wraps stdlib.h's free.
+
+      #define HEADER_MODE
+      #define IMPLEMENTATION_MODE
+
+        By default, all hash table functions are defined as static inline functions, the intent being that a given hash
+        table template should be instantiated once per translation unit; for best performance, this is the recommended
+        way to use the library.
+        However, it is also possible separate the struct definitions and function declarations from the function
+        definitions such that one implementation can be shared across all translation units (as in a traditional header
+        and source file pair).
+        In that case, instantiate a template wherever it is needed by defining HEADER_MODE, along with only NAME,
+        KEY_TY, and (optionally) VAL_TY, CTX_TY, and header guards, and including the library, e.g.:
+
+          #ifndef INT_INT_MAP_H
+          #define INT_INT_MAP_H
+          #define NAME   int_int_map
+          #define KEY_TY int
+          #define VAL_TY int
+          #define HEADER_MODE
+          #include "verstable.h"
+          #endif
+
+        In one source file, define IMPLEMENTATION_MODE, along with NAME, KEY_TY, and any of the aforementioned optional
+        macros, and include the library, e.g.:
+
+          #define NAME     int_int_map
+          #define KEY_TY   int
+          #define VAL_TY   int
+          #define HASH_FN  vt_hash_integer // C99.
+          #define CMPR_FN  vt_cmpr_integer // C99.
+          #define MAX_LOAD 0.8
+          #define IMPLEMENTATION_MODE
+          #include "verstable.h"
+
+    Including the library automatically undefines all the aforementioned macros after they have been used to instantiate
+    the template.
+
+  Functions:
+
+    The functions associated with a hash table type are all prefixed with the name the user supplied via the NAME macro.
+    In C11 and later, the generic "vt_"-prefixed macros may be used to automatically select the correct version of the
+    specified function based on the arguments.
+
+    void NAME_init( NAME *table )
+    void NAME_init( NAME *table, CTX_TY ctx )
+    // C11 generic macro: vt_init.
+
+      Initializes the table for use.
+      If CTX_TY was defined, ctx sets the table's ctx member.
+
+    bool NAME_init_clone( NAME *table, NAME *source )
+    bool NAME_init_clone( NAME *table, NAME *source, CTX_TY ctx )
+    // C11 generic macro: vt_init_clone.
+
+      Initializes the table as a shallow copy of the specified source table.
+      If CTX_TY was defined, ctx sets the table's ctx member.
+      Returns false in the case of memory allocation failure.
+
+    size_t NAME_size( NAME *table ) // C11 generic macro: vt_size.
+
+      Returns the number of keys currently in the table.
+
+    size_t NAME_bucket_count( NAME *table ) // C11 generic macro: vt_bucket_count.
+
+      Returns the table's current bucket count.
+
+    NAME_itr NAME_insert( NAME *table, KEY_TY key )
+    NAME_itr NAME_insert( NAME *table, KEY_TY key, VAL_TY val )
+    // C11 generic macro: vt_insert.
+
+      Inserts the specified key (and value, if VAL_TY was defined) into the hash table.
+      If the same key already exists, then the new key (and value) replaces the existing key (and value).
+      Returns an iterator to the new key, or an end iterator in the case of memory allocation failure.
+
+    NAME_itr NAME_get_or_insert( NAME *table, KEY_TY key )
+    NAME_itr NAME_get_or_insert( NAME *table, KEY_TY key, VAL_TY val )
+    // C11 generic macro: vt_get_or_insert.
+
+      Inserts the specified key (and value, if VAL_TY was defined) if it does not already exist in the table.
+      Returns an iterator to the new key if it was inserted, or an iterator to the existing key, or an end iterator if
+      the key did not exist but the new key could not be inserted because of memory allocation failure.
+      Determine whether the key was inserted by comparing the table's size before and after the call.
+
+    NAME_itr NAME_get( NAME *table, KEY_TY key ) // C11 generic macro: vt_get.
+
+      Returns a iterator to the specified key, or an end iterator if no such key exists.
+
+    bool NAME_erase( NAME *table, KEY_TY key ) // C11 generic macro: vt_erase.
+
+      Erases the specified key (and associated value, if VAL_TY was defined), if it exists.
+      Returns true if a key was erased.
+
+    NAME_itr NAME_erase_itr( NAME *table, NAME_itr itr ) // C11 generic macro: vt_erase_itr.
+
+      Erases the key (and associated value, if VAL_TY was defined) pointed to by the specified iterator.
+      Returns an iterator to the next key in the table, or an end iterator if the erased key was the last one.
+
+    bool NAME_reserve( NAME *table, size_t size ) // C11 generic macro: vt_reserve.
+
+      Ensures that the bucket count is large enough to support the specified key count (i.e. size) without rehashing.
+      Returns false if unsuccessful due to memory allocation failure.
+
+    bool NAME_shrink( NAME *table ) // C11 generic macro: vt_shrink.
+
+      Shrinks the bucket count to best accommodate the current size.
+      Returns false if unsuccessful due to memory allocation failure.
+
+    NAME_itr NAME_first( NAME *table ) // C11 generic macro: vt_first.
+
+      Returns an iterator to the first key in the table, or an end iterator if the table is empty.
+
+    bool NAME_is_end( NAME *table, NAME_itr itr ) // C11 generic macro: vt_is_end.
+
+      Returns true if the iterator is an end iterator.
+
+    NAME_itr NAME_next( NAME_itr itr ) // C11 generic macro: vt_next.
+
+      Returns an iterator to the key after the one pointed to by the specified iterator, or an end iterator if the
+      specified iterator points to the last key in the table.
+
+    void NAME_clear( NAME *table ) // C11 generic macro: vt_clear.
+
+      Erases all keys (and values, if VAL_TY was defined) in the table.
+
+    void NAME_cleanup( NAME *table ) // C11 generic macro: vt_cleanup.
+
+      Erases all keys (and values, if VAL_TY was defined) in the table, frees all memory associated with it, and
+      initializes it for reuse.
+
+  Iterators:
+
+    Access the key (and value, if VAL_TY was defined) that an iterator points to using the NAME_itr struct's data
+    member:
+
+      itr.data->key
+      itr.data->val
+
+    Functions that may insert new keys (NAME_insert and NAME_get_or_insert), erase keys (NAME_erase and NAME_erase_itr),
+    or reallocate the internal bucket array (NAME_reserve and NAME_shrink) invalidate all exiting iterators.
+    To delete keys during iteration and resume iterating, use the return value of NAME_erase_itr.
+
+Version history:
+
+  18/06/2024 2.1.1: Fixed a bug affecting iteration on big-endian platforms under MSVC.
+  27/05/2024 2.1.0: Replaced the Murmur3 mixer with the fast-hash mixer as the default integer hash function.
+                    Fixed a bug that could theoretically cause a crash on rehash (triggerable in testing using
+                    NAME_shrink with a maximum load factor significantly higher than 1.0).
+  06/02/2024 2.0.0: Improved custom allocator support by introducing the CTX_TY option and allowing user-supplied free
+                    functions to receive the allocation size.
+                    Improved documentation.
+                    Introduced various optimizations, including storing the buckets-array size mask instead of the
+                    bucket count, eliminating empty-table checks, combining the buckets memory and metadata memory into
+                    one allocation, and adding branch prediction macros.
+                    Fixed a bug that caused a key to be used after destruction during erasure.
+  12/12/2023 1.0.0: Initial release.
+
+License (MIT):
+
+  Copyright (c) 2023-2024 Jackson L. Allan
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+  documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+  persons to whom the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+  Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*--------------------------------------------------------------------------------------------------------------------*/
+/*                                               Common header section                                                */
+/*--------------------------------------------------------------------------------------------------------------------*/
+
+#ifndef VERSTABLE_H
+#define VERSTABLE_H
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+// Two-way concatenation macro.
+#define VT_CAT_( a, b ) a##b
+#define VT_CAT( a, b ) VT_CAT_( a, b )
+
+// Branch optimization macros.
+#ifdef __GNUC__
+#define VT_LIKELY( expression )   __builtin_expect( (bool)( expression ), true )
+#define VT_UNLIKELY( expression ) __builtin_expect( (bool)( expression ), false )
+#else
+#define VT_LIKELY( expression )   ( expression )
+#define VT_UNLIKELY( expression ) ( expression )
+#endif
+
+// Masks for manipulating and extracting data from a bucket's uint16_t metadatum.
+#define VT_EMPTY               0x0000
+#define VT_HASH_FRAG_MASK      0xF000 // 0b1111000000000000.
+#define VT_IN_HOME_BUCKET_MASK 0x0800 // 0b0000100000000000.
+#define VT_DISPLACEMENT_MASK   0x07FF // 0b0000011111111111, also denotes the displacement limit. Set to VT_LOAD to 1.0
+                                      // to test proper handling of encroachment on the displacement limit during
+                                      // inserts.
+
+// Extracts a hash fragment from a uint64_t hash code.
+// We take the highest four bits so that keys that map (via modulo) to the same bucket have distinct hash fragments.
+static inline uint16_t vt_hashfrag( uint64_t hash )
+{
+  return ( hash >> 48 ) & VT_HASH_FRAG_MASK;
+}
+
+// Standard quadratic probing formula that guarantees that all buckets are visited when the bucket count is a power of
+// two (at least in theory, because the displacement limit could terminate the search early when the bucket count is
+// high).
+static inline size_t vt_quadratic( uint16_t displacement )
+{
+  return ( (size_t)displacement * displacement + displacement ) / 2;
+}
+
+#define VT_MIN_NONZERO_BUCKET_COUNT 8 // Must be a power of two.
+
+// Function to find the left-most non-zero uint16_t in a uint64_t.
+// This function is used when we scan four buckets at a time while iterating and relies on compiler intrinsics wherever
+// possible.
+
+#if defined( __GNUC__ ) && ULLONG_MAX == 0xFFFFFFFFFFFFFFFF
+
+static inline int vt_first_nonzero_uint16( uint64_t val )
+{
+  const uint16_t endian_checker = 0x0001;
+  if( *(const char *)&endian_checker ) // Little-endian (the compiler will optimize away the check at -O1 and above).
+    return __builtin_ctzll( val ) / 16;
+  
+  return __builtin_clzll( val ) / 16;
+}
+
+#elif defined( _MSC_VER ) && ( defined( _M_X64 ) || defined( _M_ARM64 ) )
+
+#include <intrin.h>
+#pragma intrinsic(_BitScanForward64)
+#pragma intrinsic(_BitScanReverse64)
+
+static inline int vt_first_nonzero_uint16( uint64_t val )
+{
+  unsigned long result;
+
+  const uint16_t endian_checker = 0x0001;
+  if( *(const char *)&endian_checker )
+    _BitScanForward64( &result, val );
+  else
+  {
+    _BitScanReverse64( &result, val );
+    result = 63 - result;
+  }
+
+  return result / 16;
+}
+
+#else
+
+static inline int vt_first_nonzero_uint16( uint64_t val )
+{
+  int result = 0;
+
+  uint32_t half;
+  memcpy( &half, &val, sizeof( uint32_t ) );
+  if( !half )
+    result += 2;
+  
+  uint16_t quarter;
+  memcpy( &quarter, (char *)&val + result * sizeof( uint16_t ), sizeof( uint16_t ) );
+  if( !quarter )
+    result += 1;
+  
+  return result;
+}
+
+#endif
+
+// When the bucket count is zero, setting the metadata pointer to point to a VT_EMPTY placeholder, rather than NULL,
+// allows us to avoid checking for a zero bucket count during insertion and lookup.
+static const uint16_t vt_empty_placeholder_metadatum = VT_EMPTY;
+
+// Default hash and comparison functions.
+
+// Fast-hash, as described by https://jonkagstrom.com/bit-mixer-construction and
+// https://code.google.com/archive/p/fast-hash.
+// In testing, this hash function provided slightly better performance than the Murmur3 mixer.
+static inline uint64_t vt_hash_integer( uint64_t key )
+{
+  key ^= key >> 23;
+  key *= 0x2127599bf4325c37ull;
+  key ^= key >> 47;
+  return key;
+}
+
+// FNV-1a.
+static inline uint64_t vt_hash_string( char *key )
+{
+  uint64_t hash = 0xcbf29ce484222325ull;
+  while( *key )
+    hash = ( (unsigned char)*key++ ^ hash ) * 0x100000001b3ull;
+
+  return hash;
+}
+
+static inline bool vt_cmpr_integer( uint64_t key_1, uint64_t key_2 )
+{
+  return key_1 == key_2;
+}
+
+static inline bool vt_cmpr_string( char *key_1, char *key_2 )
+{
+  return strcmp( key_1, key_2 ) == 0;
+}
+
+// Default allocation and free functions.
+
+static inline void *vt_malloc( size_t size )
+{
+  return malloc( size );
+}
+
+static inline void vt_free( void *ptr, size_t size )
+{
+  (void)size;
+  free( ptr );
+}
+
+static inline void *vt_malloc_with_ctx( size_t size, void *ctx )
+{
+  (void)ctx;
+  return malloc( size );
+}
+
+static inline void vt_free_with_ctx( void *ptr, size_t size, void *ctx )
+{
+  (void)size;
+  (void)ctx;
+  free( ptr );
+}
+
+// The rest of the common header section pertains to the C11 generic macro API.
+// This interface is based on the extendible-_Generic mechanism documented in detail at
+// https://github.com/JacksonAllan/CC/blob/main/articles/Better_C_Generics_Part_1_The_Extendible_Generic.md.
+// In summary, instantiating a template also defines wrappers for the template's types and functions with names in the
+// pattern of vt_table_NNNN and vt_init_NNNN, where NNNN is an automatically generated integer unique to the template
+// instance in the current translation unit.
+// These wrappers plug in to _Generic-based API macros, which use preprocessor magic to automatically generate _Generic
+// slots for every existing template instance.
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined( VT_NO_C11_GENERIC_API )
+
+// Octal counter that supports up to 511 hash table templates.
+#define VT_TEMPLATE_COUNT_D1 0 // Digit 1, i.e. least significant digit.
+#define VT_TEMPLATE_COUNT_D2 0
+#define VT_TEMPLATE_COUNT_D3 0
+
+// Four-way concatenation macro.
+#define VT_CAT_4_( a, b, c, d ) a##b##c##d
+#define VT_CAT_4( a, b, c, d )  VT_CAT_4_( a, b, c, d )
+
+// Provides the current value of the counter as a three-digit octal number preceded by 0.
+#define VT_TEMPLATE_COUNT VT_CAT_4( 0, VT_TEMPLATE_COUNT_D3, VT_TEMPLATE_COUNT_D2, VT_TEMPLATE_COUNT_D1 )
+
+// _Generic-slot generation macros.
+
+#define VT_GENERIC_SLOT( ty, fn, n ) , VT_CAT( ty, n ): VT_CAT( fn, n )
+#define VT_R1_0( ty, fn, d3, d2 )
+#define VT_R1_1( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 0 ) )
+#define VT_R1_2( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 1 ) ) VT_R1_1( ty, fn, d3, d2 )
+#define VT_R1_3( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 2 ) ) VT_R1_2( ty, fn, d3, d2 )
+#define VT_R1_4( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 3 ) ) VT_R1_3( ty, fn, d3, d2 )
+#define VT_R1_5( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 4 ) ) VT_R1_4( ty, fn, d3, d2 )
+#define VT_R1_6( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 5 ) ) VT_R1_5( ty, fn, d3, d2 )
+#define VT_R1_7( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 6 ) ) VT_R1_6( ty, fn, d3, d2 )
+#define VT_R1_8( ty, fn, d3, d2 ) VT_GENERIC_SLOT( ty, fn, VT_CAT_4( 0, d3, d2, 7 ) ) VT_R1_7( ty, fn, d3, d2 )
+#define VT_R2_0( ty, fn, d3 )
+#define VT_R2_1( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 0 )
+#define VT_R2_2( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 1 ) VT_R2_1( ty, fn, d3 )
+#define VT_R2_3( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 2 ) VT_R2_2( ty, fn, d3 )
+#define VT_R2_4( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 3 ) VT_R2_3( ty, fn, d3 )
+#define VT_R2_5( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 4 ) VT_R2_4( ty, fn, d3 )
+#define VT_R2_6( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 5 ) VT_R2_5( ty, fn, d3 )
+#define VT_R2_7( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 6 ) VT_R2_6( ty, fn, d3 )
+#define VT_R2_8( ty, fn, d3 ) VT_R1_8( ty, fn, d3, 7 ) VT_R2_7( ty, fn, d3 )
+#define VT_R3_0( ty, fn )
+#define VT_R3_1( ty, fn ) VT_R2_8( ty, fn, 0 )
+#define VT_R3_2( ty, fn ) VT_R2_8( ty, fn, 1 ) VT_R3_1( ty, fn )
+#define VT_R3_3( ty, fn ) VT_R2_8( ty, fn, 2 ) VT_R3_2( ty, fn )
+#define VT_R3_4( ty, fn ) VT_R2_8( ty, fn, 3 ) VT_R3_3( ty, fn )
+#define VT_R3_5( ty, fn ) VT_R2_8( ty, fn, 4 ) VT_R3_4( ty, fn )
+#define VT_R3_6( ty, fn ) VT_R2_8( ty, fn, 5 ) VT_R3_5( ty, fn )
+#define VT_R3_7( ty, fn ) VT_R2_8( ty, fn, 6 ) VT_R3_6( ty, fn )
+
+#define VT_GENERIC_SLOTS( ty, fn )                                                           \
+VT_CAT( VT_R1_, VT_TEMPLATE_COUNT_D1 )( ty, fn, VT_TEMPLATE_COUNT_D3, VT_TEMPLATE_COUNT_D2 ) \
+VT_CAT( VT_R2_, VT_TEMPLATE_COUNT_D2 )( ty, fn, VT_TEMPLATE_COUNT_D3 )                       \
+VT_CAT( VT_R3_, VT_TEMPLATE_COUNT_D3 )( ty, fn )                                             \
+
+// Actual generic API macros.
+
+// vt_init must be handled as a special case because it could take one or two arguments, depending on whether CTX_TY
+// was defined.
+#define VT_ARG_3( _1, _2, _3, ... ) _3
+#define vt_init( ... ) VT_ARG_3( __VA_ARGS__, vt_init_with_ctx, vt_init_without_ctx, )( __VA_ARGS__ )
+#define vt_init_without_ctx( table ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_init_ ) )( table )
+#define vt_init_with_ctx( table, ... ) _Generic( *( table ) \
+  VT_GENERIC_SLOTS( vt_table_, vt_init_ )                   \
+)( table, __VA_ARGS__ )                                     \
+
+#define vt_init_clone( table, ... ) _Generic( *( table ) \
+  VT_GENERIC_SLOTS( vt_table_, vt_init_clone_ )          \
+)( table, __VA_ARGS__ )                                  \
+
+#define vt_size( table )_Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_size_ ) )( table )
+
+#define vt_bucket_count( table ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_bucket_count_ ) )( table )
+
+#define vt_is_end( itr ) _Generic( itr VT_GENERIC_SLOTS( vt_table_itr_, vt_is_end_ ) )( itr )
+
+#define vt_insert( table, ... ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_insert_ ) )( table, __VA_ARGS__ )
+
+#define vt_get_or_insert( table, ... ) _Generic( *( table ) \
+  VT_GENERIC_SLOTS( vt_table_, vt_get_or_insert_ )          \
+)( table, __VA_ARGS__ )                                     \
+
+#define vt_get( table, ... ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_get_ ) )( table, __VA_ARGS__ )
+
+#define vt_erase( table, ... ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_erase_ ) )( table, __VA_ARGS__ )
+
+#define vt_next( itr ) _Generic( itr VT_GENERIC_SLOTS( vt_table_itr_, vt_next_ ) )( itr )
+
+#define vt_erase_itr( table, ... ) _Generic( *( table ) \
+  VT_GENERIC_SLOTS( vt_table_, vt_erase_itr_ )          \
+)( table, __VA_ARGS__ )                                 \
+
+#define vt_reserve( table, ... ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_reserve_ ) )( table, __VA_ARGS__ )
+
+#define vt_shrink( table ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_shrink_ ) )( table )
+
+#define vt_first( table ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_first_ ) )( table )
+
+#define vt_clear( table ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_clear_ ) )( table )
+
+#define vt_cleanup( table ) _Generic( *( table ) VT_GENERIC_SLOTS( vt_table_, vt_cleanup_ ) )( table )
+
+#endif
+
+#endif
+
+/*--------------------------------------------------------------------------------------------------------------------*/
+/*                                                  Prefixed structs                                                  */
+/*--------------------------------------------------------------------------------------------------------------------*/
+
+#ifndef IMPLEMENTATION_MODE
+
+typedef struct
+{
+  KEY_TY key;
+  #ifdef VAL_TY
+  VAL_TY val;
+  #endif
+} VT_CAT( NAME, _bucket );
+
+typedef struct
+{
+  VT_CAT( NAME, _bucket ) *data;
+  uint16_t *metadatum;
+  uint16_t *metadata_end; // Iterators carry an internal end pointer so that NAME_is_end does not need the table to be
+                          // passed in as an argument.
+                          // This also allows for the zero-bucket-count check to occur once in NAME_first, rather than
+                          // repeatedly in NAME_is_end.
+  size_t home_bucket; // SIZE_MAX if home bucket is unknown.
+} VT_CAT( NAME, _itr );
+
+typedef struct
+{
+  size_t key_count;
+  size_t buckets_mask; // Rather than storing the bucket count directly, we store the bit mask used to reduce a hash
+                       // code or displacement-derived bucket index to the buckets array, i.e. the bucket count minus
+                       // one.
+                       // Consequently, a zero bucket count (i.e. when .metadata points to the placeholder) constitutes
+                       // a special case, represented by all bits unset (i.e. zero).
+  VT_CAT( NAME, _bucket ) *buckets;
+  uint16_t *metadata; // As described above, each metadatum consists of a 4-bit hash-code fragment (X), a 1-bit flag
+                      // indicating whether the key in this bucket begins a chain associated with the bucket (Y), and
+                      // an 11-bit value indicating the quadratic displacement of the next key in the chain (Z):
+                      // XXXXYZZZZZZZZZZZ.
+  #ifdef CTX_TY
+  CTX_TY ctx;
+  #endif
+} NAME;
+
+#endif
+
+/*--------------------------------------------------------------------------------------------------------------------*/
+/*                                                Function prototypes                                                 */
+/*--------------------------------------------------------------------------------------------------------------------*/
+
+#if defined( HEADER_MODE ) || defined( IMPLEMENTATION_MODE )
+#define VT_API_FN_QUALIFIERS
+#else
+#define VT_API_FN_QUALIFIERS static inline
+#endif
+
+#ifndef IMPLEMENTATION_MODE
+
+VT_API_FN_QUALIFIERS void VT_CAT( NAME, _init )(
+  NAME *
+  #ifdef CTX_TY
+  , CTX_TY
+  #endif
+);
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _init_clone )(
+  NAME *,
+  NAME *
+  #ifdef CTX_TY
+  , CTX_TY
+  #endif
+);
+
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _size )( NAME * );
+
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _bucket_count )( NAME * );
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _is_end )( VT_CAT( NAME, _itr ) );
+
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _insert )(
+  NAME *,
+  KEY_TY
+  #ifdef VAL_TY
+  , VAL_TY
+  #endif
+);
+
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _get_or_insert )(
+  NAME *,
+  KEY_TY
+  #ifdef VAL_TY
+  , VAL_TY
+  #endif
+);
+
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _get )(
+  NAME *table,
+  KEY_TY key
+);
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _erase )( NAME *, KEY_TY );
+
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _next )( VT_CAT( NAME, _itr ) );
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _reserve )( NAME *, size_t );
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _shrink )( NAME * );
+
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _first )( NAME * );
+
+VT_API_FN_QUALIFIERS void VT_CAT( NAME, _clear )( NAME * );
+
+VT_API_FN_QUALIFIERS void VT_CAT( NAME, _cleanup )( NAME * );
+
+// Not an API function, but must be prototyped anyway because it is called by the inline NAME_erase_itr below.
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _erase_itr_raw ) ( NAME *, VT_CAT( NAME, _itr ) );
+
+// Erases the key pointed to by itr and returns an iterator to the next key in the table.
+// This function must be inlined to ensure that the compiler optimizes away the NAME_fast_forward call if the returned
+// iterator is discarded.
+#ifdef __GNUC__
+static inline __attribute__((always_inline))
+#elif defined( _MSC_VER )
+static __forceinline
+#else
+static inline
+#endif
+VT_CAT( NAME, _itr ) VT_CAT( NAME, _erase_itr )( NAME *table, VT_CAT( NAME, _itr ) itr )
+{
+  if( VT_CAT( NAME, _erase_itr_raw )( table, itr ) )
+    return VT_CAT( NAME, _next )( itr );
+
+  return itr;
+}
+
+#endif
+
+/*--------------------------------------------------------------------------------------------------------------------*/
+/*                                              Function implementations                                              */
+/*--------------------------------------------------------------------------------------------------------------------*/
+
+#ifndef HEADER_MODE
+
+// Default settings.
+
+#ifndef MAX_LOAD
+#define MAX_LOAD 0.9
+#endif
+
+#if !defined( MALLOC ) || !defined( FREE )
+#include <stdlib.h>
+#endif
+
+#ifndef MALLOC_FN
+#ifdef CTX_TY
+#define MALLOC_FN vt_malloc_with_ctx
+#else
+#define MALLOC_FN vt_malloc
+#endif
+#endif
+
+#ifndef FREE_FN
+#ifdef CTX_TY
+#define FREE_FN vt_free_with_ctx
+#else
+#define FREE_FN vt_free
+#endif
+#endif
+
+#ifndef HASH_FN
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#ifdef _MSC_VER // In MSVC, the compound literal in the _Generic triggers a warning about unused local variables at /W4.
+#define HASH_FN                                                               \
+_Pragma( "warning( push )" )                                                  \
+_Pragma( "warning( disable: 4189 )" )                                         \
+_Generic( ( KEY_TY ){ 0 }, char *: vt_hash_string, default: vt_hash_integer ) \
+_Pragma( "warning( pop )" )
+#else
+#define HASH_FN _Generic( ( KEY_TY ){ 0 }, char *: vt_hash_string, default: vt_hash_integer )
+#endif
+#else
+#error Hash function inference is only available in C11 and later. In C99, you need to define HASH_FN manually to \
+vt_hash_integer, vt_hash_string, or your own custom function with the signature uint64_t ( KEY_TY ).
+#endif
+#endif
+
+#ifndef CMPR_FN
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#ifdef _MSC_VER
+#define CMPR_FN                                                               \
+_Pragma( "warning( push )" )                                                  \
+_Pragma( "warning( disable: 4189 )" )                                         \
+_Generic( ( KEY_TY ){ 0 }, char *: vt_cmpr_string, default: vt_cmpr_integer ) \
+_Pragma( "warning( pop )" )
+#else
+#define CMPR_FN _Generic( ( KEY_TY ){ 0 }, char *: vt_cmpr_string, default: vt_cmpr_integer )
+#endif
+#else
+#error Comparison function inference is only available in C11 and later. In C99, you need to define CMPR_FN manually \
+to vt_cmpr_integer, vt_cmpr_string, or your own custom function with the signature bool ( KEY_TY, KEY_TY ).
+#endif
+#endif
+
+VT_API_FN_QUALIFIERS void VT_CAT( NAME, _init )(
+  NAME *table
+  #ifdef CTX_TY
+  , CTX_TY ctx
+  #endif
+)
+{
+  table->key_count = 0;
+  table->buckets_mask = 0x0000000000000000ull;
+  table->buckets = NULL;
+  table->metadata = (uint16_t *)&vt_empty_placeholder_metadatum;
+  #ifdef CTX_TY
+  table->ctx = ctx;
+  #endif
+}
+
+// For efficiency, especially in the case of a small table, the buckets array and metadata share the same dynamic memory
+// allocation:
+//   +-----------------------------+-----+----------------+--------+
+//   |           Buckets           | Pad |    Metadata    | Excess |
+//   +-----------------------------+-----+----------------+--------+
+// Any allocated metadata array requires four excess elements to ensure that iteration functions, which read four
+// metadata at a time, never read beyond the end of it.
+// This function returns the offset of the beginning of the metadata, i.e. the size of the buckets array plus the
+// (usually zero) padding.
+// It assumes that the bucket count is not zero.
+static inline size_t VT_CAT( NAME, _metadata_offset )( NAME *table )
+{
+  // Use sizeof, rather than alignof, for C99 compatibility.
+  return ( ( ( table->buckets_mask + 1 ) * sizeof( VT_CAT( NAME, _bucket ) ) + sizeof( uint16_t ) - 1 ) /
+    sizeof( uint16_t ) ) * sizeof( uint16_t );
+}
+
+// Returns the total allocation size, including the buckets array, padding, metadata, and excess metadata.
+// As above, this function assumes that the bucket count is not zero.
+static inline size_t VT_CAT( NAME, _total_alloc_size )( NAME *table )
+{
+  return VT_CAT( NAME, _metadata_offset )( table ) + ( table->buckets_mask + 1 + 4 ) * sizeof( uint16_t );
+}
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _init_clone )(
+  NAME *table,
+  NAME *source
+  #ifdef CTX_TY
+  , CTX_TY ctx
+  #endif
+)
+{
+  table->key_count = source->key_count;
+  table->buckets_mask = source->buckets_mask;
+  #ifdef CTX_TY
+  table->ctx = ctx;
+  #endif
+
+  if( !source->buckets_mask )
+  {
+    table->metadata = (uint16_t *)&vt_empty_placeholder_metadatum;
+    table->buckets = NULL;
+    return true;
+  }
+
+  void *allocation = MALLOC_FN(
+    VT_CAT( NAME, _total_alloc_size )( table )
+    #ifdef CTX_TY
+    , &table->ctx
+    #endif
+  );
+
+  if( VT_UNLIKELY( !allocation ) )
+    return false;
+
+  table->buckets = (VT_CAT( NAME, _bucket ) *)allocation;
+  table->metadata = (uint16_t *)( (unsigned char *)allocation + VT_CAT( NAME, _metadata_offset )( table ) );
+  memcpy( allocation, source->buckets, VT_CAT( NAME, _total_alloc_size )( table ) );
+
+  return true;
+}
+
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _size )( NAME *table )
+{
+  return table->key_count;
+}
+
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _bucket_count )( NAME *table )
+{
+  // If the bucket count is zero, buckets_mask will be zero, not the bucket count minus one.
+  // We account for this special case by adding (bool)buckets_mask rather than one.
+  return table->buckets_mask + (bool)table->buckets_mask;
+}
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _is_end )( VT_CAT( NAME, _itr ) itr )
+{
+  return itr.metadatum == itr.metadata_end;
+}
+
+// Finds the earliest empty bucket in which a key belonging to home_bucket can be placed, assuming that home_bucket
+// is already occupied.
+// The reason to begin the search at home_bucket, rather than the end of the existing chain, is that keys deleted from
+// other chains might have freed up buckets that could fall in this chain before the final key.
+// Returns true if an empty bucket within the range of the displacement limit was found, in which case the final two
+// pointer arguments contain the index of the empty bucket and its quadratic displacement from home_bucket.
+static inline bool VT_CAT( NAME, _find_first_empty )(
+  NAME *table,
+  size_t home_bucket,
+  size_t *empty,
+  uint16_t *displacement
+)
+{
+  *displacement = 1;
+  size_t linear_dispacement = 1;
+
+  while( true )
+  {
+    *empty = ( home_bucket + linear_dispacement ) & table->buckets_mask;
+    if( table->metadata[ *empty ] == VT_EMPTY )
+      return true;
+
+    if( VT_UNLIKELY( ++*displacement == VT_DISPLACEMENT_MASK ) )
+      return false;
+
+    linear_dispacement += *displacement;
+  }
+}
+
+// Finds the key in the chain beginning in home_bucket after which to link a new key with displacement_to_empty
+// quadratic displacement and returns the index of the bucket containing that key.
+// Although the new key could simply be linked to the end of the chain, keeping the chain ordered by displacement
+// theoretically improves cache locality during lookups.
+static inline size_t VT_CAT( NAME, _find_insert_location_in_chain )(
+  NAME *table,
+  size_t home_bucket,
+  uint16_t displacement_to_empty
+)
+{
+  size_t candidate = home_bucket;
+  while( true )
+  {
+    uint16_t displacement = table->metadata[ candidate ] & VT_DISPLACEMENT_MASK;
+
+    if( displacement > displacement_to_empty )
+      return candidate;
+
+    candidate = ( home_bucket + vt_quadratic( displacement ) ) & table->buckets_mask;
+  }
+}
+
+// Frees up a bucket occupied by a key not belonging there so that a new key belonging there can be placed there as the
+// beginning of a new chain.
+// This requires:
+// * Finding the previous key in the chain to which the occupying key belongs by rehashing it and then traversing the
+//   chain.
+// * Disconnecting the key from the chain.
+// * Finding the appropriate empty bucket to which to move the key.
+// * Moving the key (and value) data to the empty bucket.
+// * Re-linking the key to the chain.
+// Returns true if the eviction succeeded, or false if no empty bucket to which to evict the occupying key could be
+// found within the displacement limit.
+static inline bool VT_CAT( NAME, _evict )( NAME *table, size_t bucket )
+{
+  // Find the previous key in chain.
+  size_t home_bucket = HASH_FN( table->buckets[ bucket ].key ) & table->buckets_mask;
+  size_t prev = home_bucket;
+  while( true )
+  {
+    size_t next = ( home_bucket + vt_quadratic( table->metadata[ prev ] & VT_DISPLACEMENT_MASK ) ) &
+      table->buckets_mask;
+
+    if( next == bucket )
+      break;
+
+    prev = next;
+  }
+
+  // Disconnect the key from chain.
+  table->metadata[ prev ] = ( table->metadata[ prev ] & ~VT_DISPLACEMENT_MASK ) | ( table->metadata[ bucket ] &
+    VT_DISPLACEMENT_MASK );
+
+  // Find the empty bucket to which to move the key.
+  size_t empty;
+  uint16_t displacement;
+  if( VT_UNLIKELY( !VT_CAT( NAME, _find_first_empty )( table, home_bucket, &empty, &displacement ) ) )
+    return false;
+
+  // Find the key in the chain after which to link the moved key.
+  prev = VT_CAT( NAME, _find_insert_location_in_chain )( table, home_bucket, displacement );
+
+  // Move the key (and value) data.
+  table->buckets[ empty ] = table->buckets[ bucket ];
+
+  // Re-link the key to the chain from its new bucket.
+  table->metadata[ empty ] = ( table->metadata[ bucket ] & VT_HASH_FRAG_MASK ) | ( table->metadata[ prev ] &
+    VT_DISPLACEMENT_MASK );
+  table->metadata[ prev ] = ( table->metadata[ prev ] & ~VT_DISPLACEMENT_MASK ) | displacement;
+
+  return true;
+}
+
+// Returns an end iterator, i.e. any iterator for which .metadatum == .metadata_end.
+// This function just cleans up the library code in functions that return an end iterator as a failure indicator.
+static inline VT_CAT( NAME, _itr ) VT_CAT( NAME, _end_itr )( void )
+{
+  VT_CAT( NAME, _itr ) itr = { NULL, NULL, NULL, 0 };
+  return itr;
+}
+
+// Inserts a key, optionally replacing the existing key if it already exists.
+// There are two main cases that must be handled:
+// * If the key's home bucket is empty or occupied by a key that does not belong there, then the key is inserted there,
+//   evicting the occupying key if there is one.
+// * Otherwise, the chain of keys beginning at the home bucket is (if unique is false) traversed in search of a matching
+//   key.
+//   If none is found, then the new key is inserted at the earliest available bucket, per quadratic probing from the
+//   home bucket, and then linked to the chain in a manner that maintains its quadratic order.
+// The unique argument tells the function whether to skip searching for the key before inserting it (on rehashing, this
+// step is unnecessary).
+// The replace argument tells the function whether to replace an existing key.
+// If replace is true, the function returns an iterator to the inserted key, or an end iterator if the key was not
+// inserted because of the maximum load factor or displacement limit constraints.
+// If replace is false, then the return value is as described above, except that if the key already exists, the function
+// returns an iterator to the existing key.
+static inline VT_CAT( NAME, _itr ) VT_CAT( NAME, _insert_raw )(
+  NAME *table,
+  KEY_TY key,
+  #ifdef VAL_TY
+  VAL_TY *val,
+  #endif
+  bool unique,
+  bool replace
+)
+{
+  uint64_t hash = HASH_FN( key );
+  uint16_t hashfrag = vt_hashfrag( hash );
+  size_t home_bucket = hash & table->buckets_mask;
+
+  // Case 1: The home bucket is empty or contains a key that doesn't belong there.
+  // This case also implicitly handles the case of a zero bucket count, since home_bucket will be zero and metadata[ 0 ]
+  // will be the empty placeholder.
+  // In that scenario, the zero buckets_mask triggers the below load-factor check.
+  if( !( table->metadata[ home_bucket ] & VT_IN_HOME_BUCKET_MASK ) )
+  {
+    if(
+      // Load-factor check.
+      VT_UNLIKELY( table->key_count + 1 > VT_CAT( NAME, _bucket_count )( table ) * MAX_LOAD ) ||
+      // Vacate the home bucket if it contains a key.
+      ( table->metadata[ home_bucket ] != VT_EMPTY && VT_UNLIKELY( !VT_CAT( NAME, _evict )( table, home_bucket ) ) )
+    )
+      return VT_CAT( NAME, _end_itr )();
+
+    table->buckets[ home_bucket ].key = key;
+    #ifdef VAL_TY
+    table->buckets[ home_bucket ].val = *val;
+    #endif
+    table->metadata[ home_bucket ] = hashfrag | VT_IN_HOME_BUCKET_MASK | VT_DISPLACEMENT_MASK;
+
+    ++table->key_count;
+
+    VT_CAT( NAME, _itr ) itr = {
+      table->buckets + home_bucket,
+      table->metadata + home_bucket,
+      table->metadata + table->buckets_mask + 1, // Iteration stopper (i.e. the first of the four excess metadata).
+      home_bucket
+    };
+    return itr;
+  }
+
+  // Case 2: The home bucket contains the beginning of a chain.
+
+  // Optionally, check the existing chain.
+  if( !unique )
+  {
+    size_t bucket = home_bucket;
+    while( true )
+    {
+      if(
+        ( table->metadata[ bucket ] & VT_HASH_FRAG_MASK ) == hashfrag &&
+        VT_LIKELY( CMPR_FN( table->buckets[ bucket ].key, key ) )
+      )
+      {
+        if( replace )
+        {
+          #ifdef KEY_DTOR_FN
+          KEY_DTOR_FN( table->buckets[ bucket ].key );
+          #endif
+          table->buckets[ bucket ].key = key;
+
+          #ifdef VAL_TY
+          #ifdef VAL_DTOR_FN
+          VAL_DTOR_FN( table->buckets[ bucket ].val );
+          #endif
+          table->buckets[ bucket ].val = *val;
+          #endif
+        }
+
+        VT_CAT( NAME, _itr ) itr = {
+          table->buckets + bucket,
+          table->metadata + bucket,
+          table->metadata + table->buckets_mask + 1,
+          home_bucket
+        };
+        return itr;
+      }
+
+      uint16_t displacement = table->metadata[ bucket ] & VT_DISPLACEMENT_MASK;
+      if( displacement == VT_DISPLACEMENT_MASK )
+        break;
+
+      bucket = ( home_bucket + vt_quadratic( displacement ) ) & table->buckets_mask;
+    }
+  }
+
+  size_t empty;
+  uint16_t displacement;
+  if(
+    VT_UNLIKELY( 
+      // Load-factor check.
+      table->key_count + 1 > VT_CAT( NAME, _bucket_count )( table ) * MAX_LOAD ||
+      // Find the earliest empty bucket, per quadratic probing.
+      !VT_CAT( NAME, _find_first_empty )( table, home_bucket, &empty, &displacement )
+    )
+  )
+    return VT_CAT( NAME, _end_itr )();
+
+  // Insert the new key (and value) in the empty bucket and link it to the chain.
+
+  size_t prev = VT_CAT( NAME, _find_insert_location_in_chain )( table, home_bucket, displacement );
+
+  table->buckets[ empty ].key = key;
+  #ifdef VAL_TY
+  table->buckets[ empty ].val = *val;
+  #endif
+  table->metadata[ empty ] = hashfrag | ( table->metadata[ prev ] & VT_DISPLACEMENT_MASK );
+  table->metadata[ prev ] = ( table->metadata[ prev ] & ~VT_DISPLACEMENT_MASK ) | displacement;
+
+  ++table->key_count;
+
+  VT_CAT( NAME, _itr ) itr = {
+    table->buckets + empty,
+    table->metadata + empty,
+    table->metadata + table->buckets_mask + 1,
+    home_bucket
+  };
+  return itr;
+}
+
+// Resizes the bucket array.
+// This function assumes that bucket_count is a power of two and large enough to accommodate all keys without violating
+// the maximum load factor.
+// Returns false in the case of allocation failure.
+// As this function is called very rarely in _insert and _get_or_insert, ideally it should not be inlined into those
+// functions.
+// In testing, the no-inline approach showed a performance benefit when inserting existing keys (i.e. replacing).
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes" // Silence warning about combining noinline with static inline.
+__attribute__((noinline)) static inline
+#elif defined( _MSC_VER )
+__declspec(noinline) static inline
+#else
+static inline
+#endif
+bool VT_CAT( NAME, _rehash )( NAME *table, size_t bucket_count )
+{
+  // The attempt to resize the bucket array and rehash the keys must occur inside a loop that incrementally doubles the
+  // target bucket count because a failure could theoretically occur at any load factor due to the displacement limit.
+  while( true )
+  {
+    NAME new_table =  {
+      0,
+      bucket_count - 1,
+      NULL,
+      NULL
+      #ifdef CTX_TY
+      , table->ctx
+      #endif
+    };
+
+    void *allocation = MALLOC_FN(
+      VT_CAT( NAME, _total_alloc_size )( &new_table )
+      #ifdef CTX_TY
+      , &new_table.ctx
+      #endif
+    );
+
+    if( VT_UNLIKELY( !allocation ) )
+      return false;
+
+    new_table.buckets = (VT_CAT( NAME, _bucket ) *)allocation;
+    new_table.metadata = (uint16_t *)( (unsigned char *)allocation + VT_CAT( NAME, _metadata_offset )( &new_table ) );
+
+    memset( new_table.metadata, 0x00, ( bucket_count + 4 ) * sizeof( uint16_t ) );
+
+    // Iteration stopper at the end of the actual metadata array (i.e. the first of the four excess metadata).
+    new_table.metadata[ bucket_count ] = 0x01;
+
+    for( size_t bucket = 0; bucket < VT_CAT( NAME, _bucket_count )( table ); ++bucket )
+      if( table->metadata[ bucket ] != VT_EMPTY )
+      {
+        VT_CAT( NAME, _itr ) itr = VT_CAT( NAME, _insert_raw )(
+          &new_table,
+          table->buckets[ bucket ].key,
+          #ifdef VAL_TY
+          &table->buckets[ bucket ].val,
+          #endif
+          true,
+          false
+        );
+
+        if( VT_UNLIKELY( VT_CAT( NAME, _is_end )( itr ) ) )
+          break;
+      }
+
+    // If a key could not be reinserted due to the displacement limit, double the bucket count and retry.
+    if( VT_UNLIKELY( new_table.key_count < table->key_count ) )
+    {
+      FREE_FN(
+        new_table.buckets,
+        VT_CAT( NAME, _total_alloc_size )( &new_table )
+        #ifdef CTX_TY
+        , &new_table.ctx
+        #endif
+      );
+
+      bucket_count *= 2;
+      continue;
+    }
+
+    if( table->buckets_mask )
+      FREE_FN(
+        table->buckets,
+        VT_CAT( NAME, _total_alloc_size )( table )
+        #ifdef CTX_TY
+        , &table->ctx
+        #endif
+      );
+
+    *table = new_table;
+    return true;
+  }
+}
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+// Inserts a key, replacing the existing key if it already exists.
+// This function wraps insert_raw in a loop that handles growing and rehashing the table if a new key cannot be inserted
+// because of the maximum load factor or displacement limit constraints.
+// Returns an iterator to the inserted key, or an end iterator in the case of allocation failure.
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _insert )(
+  NAME *table,
+  KEY_TY key
+  #ifdef VAL_TY
+  , VAL_TY val
+  #endif
+)
+{
+  while( true )
+  {
+    VT_CAT( NAME, _itr ) itr = VT_CAT( NAME, _insert_raw )(
+      table,
+      key,
+      #ifdef VAL_TY
+      &val,
+      #endif
+      false,
+      true
+    );
+
+    if(
+      // Lookup succeeded, in which case itr points to the found key.
+      VT_LIKELY( !VT_CAT( NAME, _is_end )( itr ) ) ||
+      // Lookup failed and rehash also fails, in which case itr is an end iterator.
+      VT_UNLIKELY(
+        !VT_CAT( NAME, _rehash )(
+          table, table->buckets_mask ? VT_CAT( NAME, _bucket_count )( table ) * 2 : VT_MIN_NONZERO_BUCKET_COUNT
+        )
+      )
+    )
+      return itr;
+  }
+}
+
+// Same as NAME_insert, except that if the key already exists, no insertion occurs and the function returns an iterator
+// to the existing key.
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _get_or_insert )(
+  NAME *table,
+  KEY_TY key
+  #ifdef VAL_TY
+  , VAL_TY val
+  #endif
+)
+{
+  while( true )
+  {
+    VT_CAT( NAME, _itr ) itr = VT_CAT( NAME, _insert_raw )(
+      table,
+      key,
+      #ifdef VAL_TY
+      &val,
+      #endif
+      false,
+      false
+    );
+
+    if(
+      // Lookup succeeded, in which case itr points to the found key.
+      VT_LIKELY( !VT_CAT( NAME, _is_end )( itr ) ) ||
+      // Lookup failed and rehash also fails, in which case itr is an end iterator.
+      VT_UNLIKELY(
+        !VT_CAT( NAME, _rehash )(
+          table, table->buckets_mask ? VT_CAT( NAME, _bucket_count )( table ) * 2 : VT_MIN_NONZERO_BUCKET_COUNT
+        )
+      )
+    )
+      return itr;
+  }
+}
+
+// Returns an iterator pointing to the specified key, or an end iterator if the key does not exist.
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _get )( NAME *table, KEY_TY key )
+{
+  uint64_t hash = HASH_FN( key );
+  size_t home_bucket = hash & table->buckets_mask;
+
+  // If the home bucket is empty or contains a key that does not belong there, then our key does not exist.
+  // This check also implicitly handles the case of a zero bucket count, since home_bucket will be zero and
+  // metadata[ 0 ] will be the empty placeholder.
+  if( !( table->metadata[ home_bucket ] & VT_IN_HOME_BUCKET_MASK ) )
+    return VT_CAT( NAME, _end_itr )();
+
+  // Traverse the chain of keys belonging to the home bucket.
+  uint16_t hashfrag = vt_hashfrag( hash );
+  size_t bucket = home_bucket;
+  while( true )
+  {
+    if(
+      ( table->metadata[ bucket ] & VT_HASH_FRAG_MASK ) == hashfrag &&
+      VT_LIKELY( CMPR_FN( table->buckets[ bucket ].key, key ) )
+    )
+    {
+      VT_CAT( NAME, _itr ) itr = {
+        table->buckets + bucket,
+        table->metadata + bucket,
+        table->metadata + table->buckets_mask + 1,
+        home_bucket
+      };
+      return itr;
+    }
+
+    uint16_t displacement = table->metadata[ bucket ] & VT_DISPLACEMENT_MASK;
+    if( displacement == VT_DISPLACEMENT_MASK )
+      return VT_CAT( NAME, _end_itr )();
+
+    bucket = ( home_bucket + vt_quadratic( displacement ) ) & table->buckets_mask;
+  }
+}
+
+// Erases the key pointed to by the specified iterator.
+// The erasure always occurs at the end of the chain to which the key belongs.
+// If the key to be erased is not the last in the chain, it is swapped with the last so that erasure occurs at the end.
+// This helps keep a chain's keys close to their home bucket for the sake of cache locality.
+// Returns true if, in the case of iteration from first to end, NAME_next should now be called on the iterator to find
+// the next key.
+// This return value is necessary because at the iterator location, the erasure could result in an empty bucket, a
+// bucket containing a moved key already visited during the iteration, or a bucket containing a moved key not yet
+// visited.
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _erase_itr_raw )( NAME *table, VT_CAT( NAME, _itr ) itr )
+{
+  --table->key_count;
+  size_t itr_bucket = itr.metadatum - table->metadata;
+
+  // For now, we only call the value's destructor because the key may need to be hashed below to determine the home
+  // bucket.
+  #ifdef VAL_DTOR_FN
+  VAL_DTOR_FN( table->buckets[ itr_bucket ].val );
+  #endif
+
+  // Case 1: The key is the only one in its chain, so just remove it.
+  if(
+    table->metadata[ itr_bucket ] & VT_IN_HOME_BUCKET_MASK &&
+    ( table->metadata[ itr_bucket ] & VT_DISPLACEMENT_MASK ) == VT_DISPLACEMENT_MASK
+  )
+  {
+    #ifdef KEY_DTOR_FN
+    KEY_DTOR_FN( table->buckets[ itr_bucket ].key );
+    #endif
+    table->metadata[ itr_bucket ] = VT_EMPTY;
+    return true;
+  }
+
+  // Case 2 and 3 require that we know the key's home bucket, which the iterator may not have recorded.
+  if( itr.home_bucket == SIZE_MAX )
+  {
+    if( table->metadata[ itr_bucket ] & VT_IN_HOME_BUCKET_MASK )
+      itr.home_bucket = itr_bucket;
+    else
+      itr.home_bucket = HASH_FN( table->buckets[ itr_bucket ].key ) & table->buckets_mask;
+  }
+
+  // The key can now be safely destructed for cases 2 and 3.
+  #ifdef KEY_DTOR_FN
+  KEY_DTOR_FN( table->buckets[ itr_bucket ].key );
+  #endif
+
+  // Case 2: The key is the last in a multi-key chain.
+  // Traverse the chain from the beginning and find the penultimate key.
+  // Then disconnect the key and erase.
+  if( ( table->metadata[ itr_bucket ] & VT_DISPLACEMENT_MASK ) == VT_DISPLACEMENT_MASK )
+  {
+    size_t bucket = itr.home_bucket;
+    while( true )
+    {
+      uint16_t displacement = table->metadata[ bucket ] & VT_DISPLACEMENT_MASK;
+      size_t next = ( itr.home_bucket + vt_quadratic( displacement ) ) & table->buckets_mask;
+      if( next == itr_bucket )
+      {
+        table->metadata[ bucket ] |= VT_DISPLACEMENT_MASK;
+        table->metadata[ itr_bucket ] = VT_EMPTY;
+        return true;
+      }
+
+      bucket = next;
+    }
+  }
+
+  // Case 3: The chain has multiple keys, and the key is not the last one.
+  // Traverse the chain from the key to be erased and find the last and penultimate keys.
+  // Disconnect the last key from the chain, and swap it with the key to erase.
+  size_t bucket = itr_bucket;
+  while( true )
+  {
+    size_t prev = bucket;
+    bucket = ( itr.home_bucket + vt_quadratic( table->metadata[ bucket ] & VT_DISPLACEMENT_MASK ) ) &
+      table->buckets_mask;
+
+    if( ( table->metadata[ bucket ] & VT_DISPLACEMENT_MASK ) == VT_DISPLACEMENT_MASK )
+    {
+      table->buckets[ itr_bucket ] = table->buckets[ bucket ];
+
+      table->metadata[ itr_bucket ] = ( table->metadata[ itr_bucket ] & ~VT_HASH_FRAG_MASK ) | (
+        table->metadata[ bucket ] & VT_HASH_FRAG_MASK );
+
+      table->metadata[ prev ] |= VT_DISPLACEMENT_MASK;
+      table->metadata[ bucket ] = VT_EMPTY;
+
+      // Whether the iterator should be advanced depends on whether the key moved to the iterator bucket came from
+      // before or after that bucket.
+      // In the former case, the iteration would already have hit the moved key, so the iterator should still be
+      // advanced.
+      if( bucket > itr_bucket )
+        return false;
+
+      return true;
+    }
+  }
+}
+
+// Erases the specified key, if it exists.
+// Returns true if a key was erased.
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _erase )( NAME *table, KEY_TY key )
+{
+  VT_CAT( NAME, _itr ) itr = VT_CAT( NAME, _get)( table, key );
+  if( VT_CAT( NAME, _is_end )( itr ) )
+    return false;
+
+  VT_CAT( NAME, _erase_itr_raw )( table, itr );
+  return true;
+}
+
+// Finds the first occupied bucket at or after the bucket pointed to by itr.
+// This function scans four buckets at a time, ideally using intrinsics.
+static inline void VT_CAT( NAME, _fast_forward )( VT_CAT( NAME, _itr ) *itr )
+{
+  while( true )
+  {
+    uint64_t metadata;
+    memcpy( &metadata, itr->metadatum, sizeof( uint64_t ) );
+    if( metadata )
+    {
+      int offset = vt_first_nonzero_uint16( metadata );
+      itr->data += offset;
+      itr->metadatum += offset;
+      itr->home_bucket = SIZE_MAX;
+      return;
+    }
+
+    itr->data += 4;
+    itr->metadatum += 4;
+  }
+}
+
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _next )( VT_CAT( NAME, _itr ) itr )
+{
+  ++itr.data;
+  ++itr.metadatum;
+  VT_CAT( NAME, _fast_forward )( &itr );
+  return itr;
+}
+
+// Returns the minimum bucket count required to accommodate a certain number of keys, which is governed by the maximum
+// load factor.
+static inline size_t VT_CAT( NAME, _min_bucket_count_for_size )( size_t size )
+{
+  if( size == 0 )
+    return 0;
+
+  // Round up to a power of two.
+  size_t bucket_count = VT_MIN_NONZERO_BUCKET_COUNT;
+  while( size > bucket_count * MAX_LOAD )
+    bucket_count *= 2;
+
+  return bucket_count;
+}
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _reserve )( NAME *table, size_t size )
+{
+  size_t bucket_count = VT_CAT( NAME, _min_bucket_count_for_size )( size );
+
+  if( bucket_count <= VT_CAT( NAME, _bucket_count )( table ) )
+    return true;
+
+  return VT_CAT( NAME, _rehash )( table, bucket_count );
+}
+
+VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _shrink )( NAME *table )
+{
+  size_t bucket_count = VT_CAT( NAME, _min_bucket_count_for_size )( table->key_count );
+
+  if( bucket_count == VT_CAT( NAME, _bucket_count )( table ) ) // Shrink unnecessary.
+    return true;
+
+  if( bucket_count == 0 )
+  {
+    FREE_FN(
+      table->buckets,
+      VT_CAT( NAME, _total_alloc_size )( table )
+      #ifdef CTX_TY
+      , &table->ctx
+      #endif
+    );
+
+    table->buckets_mask = 0x0000000000000000ull;
+    table->metadata = (uint16_t *)&vt_empty_placeholder_metadatum;
+    return true;
+  }
+
+  return VT_CAT( NAME, _rehash )( table, bucket_count );
+}
+
+VT_API_FN_QUALIFIERS VT_CAT( NAME, _itr ) VT_CAT( NAME, _first )( NAME *table )
+{
+  if( !table->key_count )
+    return VT_CAT( NAME, _end_itr )();
+
+  VT_CAT( NAME, _itr ) itr = { table->buckets, table->metadata, table->metadata + table->buckets_mask + 1, SIZE_MAX };
+  VT_CAT( NAME, _fast_forward )( &itr );
+  return itr;
+}
+
+VT_API_FN_QUALIFIERS void VT_CAT( NAME, _clear )( NAME *table )
+{
+  if( !table->key_count )
+    return;
+
+  for( size_t i = 0; i < VT_CAT( NAME, _bucket_count )( table ); ++i )
+  {
+    if( table->metadata[ i ] != VT_EMPTY )
+    {
+      #ifdef KEY_DTOR_FN
+      KEY_DTOR_FN( table->buckets[ i ].key );
+      #endif
+      #ifdef VAL_DTOR_FN
+      VAL_DTOR_FN( table->buckets[ i ].val );
+      #endif
+    }
+
+    table->metadata[ i ] = VT_EMPTY;
+  }
+
+  table->key_count = 0;
+}
+
+VT_API_FN_QUALIFIERS void VT_CAT( NAME, _cleanup )( NAME *table )
+{
+  if( !table->buckets_mask )
+    return;
+
+  #if defined( KEY_DTOR_FN ) || defined( VAL_DTOR_FN )
+  VT_CAT( NAME, _clear )( table );
+  #endif
+
+  FREE_FN(
+    table->buckets,
+    VT_CAT( NAME, _total_alloc_size )( table )
+    #ifdef CTX_TY
+    , &table->ctx
+    #endif
+  );
+
+  VT_CAT( NAME, _init )(
+    table
+    #ifdef CTX_TY
+    , table->ctx
+    #endif
+  );
+}
+
+#endif
+
+/*--------------------------------------------------------------------------------------------------------------------*/
+/*                                Wrapper types and functions for the C11 generic API                                 */
+/*--------------------------------------------------------------------------------------------------------------------*/
+
+#if defined(__STDC_VERSION__) &&       \
+    __STDC_VERSION__ >= 201112L &&     \
+    !defined( IMPLEMENTATION_MODE ) && \
+    !defined( VT_NO_C11_GENERIC_API )  \
+
+typedef NAME VT_CAT( vt_table_, VT_TEMPLATE_COUNT );
+typedef VT_CAT( NAME, _itr ) VT_CAT( vt_table_itr_, VT_TEMPLATE_COUNT );
+
+static inline void VT_CAT( vt_init_, VT_TEMPLATE_COUNT )(
+  NAME *table
+  #ifdef CTX_TY
+  , CTX_TY ctx
+  #endif
+)
+{
+  VT_CAT( NAME, _init )(
+    table
+    #ifdef CTX_TY
+    , ctx
+    #endif
+  );
+}
+
+static inline bool VT_CAT( vt_init_clone_, VT_TEMPLATE_COUNT )(
+  NAME *table,
+  NAME* source
+  #ifdef CTX_TY
+  , CTX_TY ctx
+  #endif
+)
+{
+  return VT_CAT( NAME, _init_clone )(
+    table,
+    source
+    #ifdef CTX_TY
+    , ctx
+    #endif
+  );
+}
+
+static inline size_t VT_CAT( vt_size_, VT_TEMPLATE_COUNT )( NAME *table )
+{
+  return VT_CAT( NAME, _size )( table );
+}
+
+static inline size_t VT_CAT( vt_bucket_count_, VT_TEMPLATE_COUNT )( NAME *table )
+{
+  return VT_CAT( NAME, _bucket_count )( table );
+}
+
+static inline bool VT_CAT( vt_is_end_, VT_TEMPLATE_COUNT )( VT_CAT( NAME, _itr ) itr )
+{
+  return VT_CAT( NAME, _is_end )( itr );
+}
+
+static inline VT_CAT( NAME, _itr ) VT_CAT( vt_insert_, VT_TEMPLATE_COUNT )(
+  NAME *table,
+  KEY_TY key
+  #ifdef VAL_TY
+  , VAL_TY val
+  #endif
+)
+{
+  return VT_CAT( NAME, _insert )(
+    table,
+    key
+    #ifdef VAL_TY
+    , val
+    #endif
+  );
+}
+
+static inline VT_CAT( NAME, _itr ) VT_CAT( vt_get_or_insert_, VT_TEMPLATE_COUNT )(
+  NAME *table,
+  KEY_TY key
+  #ifdef VAL_TY
+  , VAL_TY val
+  #endif
+)
+{
+  return VT_CAT( NAME, _get_or_insert )(
+    table,
+    key
+    #ifdef VAL_TY
+    , val
+    #endif
+  );
+}
+
+static inline VT_CAT( NAME, _itr ) VT_CAT( vt_get_, VT_TEMPLATE_COUNT )( NAME *table, KEY_TY key )
+{
+  return VT_CAT( NAME, _get )( table, key );
+}
+
+static inline bool VT_CAT( vt_erase_, VT_TEMPLATE_COUNT )( NAME *table, KEY_TY key )
+{
+  return VT_CAT( NAME, _erase )( table, key );
+}
+
+static inline VT_CAT( NAME, _itr ) VT_CAT( vt_next_, VT_TEMPLATE_COUNT )( VT_CAT( NAME, _itr ) itr )
+{
+  return VT_CAT( NAME, _next )( itr );
+}
+
+static inline VT_CAT( NAME, _itr ) VT_CAT( vt_erase_itr_, VT_TEMPLATE_COUNT )( NAME *table, VT_CAT( NAME, _itr ) itr )
+{
+  return VT_CAT( NAME, _erase_itr )( table, itr );
+}
+
+static inline bool VT_CAT( vt_reserve_, VT_TEMPLATE_COUNT )( NAME *table, size_t bucket_count )
+{
+  return VT_CAT( NAME, _reserve )( table, bucket_count );
+}
+
+static inline bool VT_CAT( vt_shrink_, VT_TEMPLATE_COUNT )( NAME *table )
+{
+  return VT_CAT( NAME, _shrink )( table );
+}
+
+static inline VT_CAT( NAME, _itr ) VT_CAT( vt_first_, VT_TEMPLATE_COUNT )( NAME *table )
+{
+  return VT_CAT( NAME, _first )( table );
+}
+
+static inline void VT_CAT( vt_clear_, VT_TEMPLATE_COUNT )( NAME *table )
+{
+  VT_CAT( NAME, _clear )( table );
+}
+
+static inline void VT_CAT( vt_cleanup_, VT_TEMPLATE_COUNT )( NAME *table )
+{
+  VT_CAT( NAME, _cleanup )( table );
+}
+
+// Increment the template counter.
+#if     VT_TEMPLATE_COUNT_D1 == 0
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 1
+#elif   VT_TEMPLATE_COUNT_D1 == 1
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 2
+#elif   VT_TEMPLATE_COUNT_D1 == 2
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 3
+#elif   VT_TEMPLATE_COUNT_D1 == 3
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 4
+#elif   VT_TEMPLATE_COUNT_D1 == 4
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 5
+#elif   VT_TEMPLATE_COUNT_D1 == 5
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 6
+#elif   VT_TEMPLATE_COUNT_D1 == 6
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 7
+#elif   VT_TEMPLATE_COUNT_D1 == 7
+#undef  VT_TEMPLATE_COUNT_D1
+#define VT_TEMPLATE_COUNT_D1 0
+#if     VT_TEMPLATE_COUNT_D2 == 0
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 1
+#elif   VT_TEMPLATE_COUNT_D2 == 1
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 2
+#elif   VT_TEMPLATE_COUNT_D2 == 2
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 3
+#elif   VT_TEMPLATE_COUNT_D2 == 3
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 4
+#elif   VT_TEMPLATE_COUNT_D2 == 4
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 5
+#elif   VT_TEMPLATE_COUNT_D2 == 5
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 6
+#elif   VT_TEMPLATE_COUNT_D2 == 6
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 7
+#elif   VT_TEMPLATE_COUNT_D2 == 7
+#undef  VT_TEMPLATE_COUNT_D2
+#define VT_TEMPLATE_COUNT_D2 0
+#if     VT_TEMPLATE_COUNT_D3 == 0
+#undef  VT_TEMPLATE_COUNT_D3
+#define VT_TEMPLATE_COUNT_D3 1
+#elif   VT_TEMPLATE_COUNT_D3 == 1
+#undef  VT_TEMPLATE_COUNT_D3
+#define VT_TEMPLATE_COUNT_D3 2
+#elif   VT_TEMPLATE_COUNT_D3 == 2
+#undef  VT_TEMPLATE_COUNT_D3
+#define VT_TEMPLATE_COUNT_D3 3
+#elif   VT_TEMPLATE_COUNT_D3 == 3
+#undef  VT_TEMPLATE_COUNT_D3
+#define VT_TEMPLATE_COUNT_D3 4
+#elif   VT_TEMPLATE_COUNT_D3 == 4
+#undef  VT_TEMPLATE_COUNT_D3
+#define VT_TEMPLATE_COUNT_D3 5
+#elif   VT_TEMPLATE_COUNT_D3 == 5
+#undef  VT_TEMPLATE_COUNT_D3
+#define VT_TEMPLATE_COUNT_D3 6
+#elif   VT_TEMPLATE_COUNT_D3 == 6
+#undef  VT_TEMPLATE_COUNT_D3
+#define VT_TEMPLATE_COUNT_D3 7
+#elif   VT_TEMPLATE_COUNT_D3 == 7
+#error  Sorry, the number of template instances is limited to 511. Define VT_NO_C11_GENERIC_API globally and use the \
+C99 prefixed function API to circumvent this restriction.
+#endif
+#endif
+#endif
+
+#endif
+
+#undef NAME
+#undef KEY_TY
+#undef VAL_TY
+#undef HASH_FN
+#undef CMPR_FN
+#undef MAX_LOAD
+#undef KEY_DTOR_FN
+#undef VAL_DTOR_FN
+#undef CTX_TY
+#undef MALLOC_FN
+#undef FREE_FN
+#undef HEADER_MODE
+#undef IMPLEMENTATION_MODE
+#undef VT_API_FN_QUALIFIERS


### PR DESCRIPTION
This PR contains several big improvements to the mesa driver:

* We don't allocate nouns all over the place anymore.
* To enable the previous we don't use our HAMT anymore, instead we use a [off-the-shelf hashtable](https://github.com/JacksonAllan/Verstable).
* We don't do individual `malloc` and `free` calls all over the place anymore. The allocations have been grouped into lifetimes each with their own memory arena.
* We don't allocate at all when we don't need to.

As a result we go from around 15 megabytes/second to 190 megabytes/second bandwidth for localhost peeking on my macbook M2. Corresponding speeds between two terrible 1 cpu 2gb VM:s situated on the other sides of the Atlantic go from around 2 megabytes/s to 18 megabytes/s.

There is still room to optimize the speed of directed messaging but this is certainly good enough for an initial release. The main thing that's somewhat wonky still is the congestion control.