### PR TITLE
build: update for zig v0.14.0

### DIFF
--- a/.github/workflows/docker-shared.yml
+++ b/.github/workflows/docker-shared.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       #
       # BUILD

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Build binaries
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,13 @@
 MODULE.bazel
 MODULE.bazel.lock
 
+# Zig
 **/.zig-cache
 **/zig-out
+
+# clangd
+**/.cache
+compile_commands.json
 
 # Swap files.
 *.swo

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ Additional targets:
 
 ## Prerequisites
 
-Install version 0.13.0 of `zig` with the package manager of your choosing, e.g., `brew install zig`, or download the binary from [here][zig-download].
+Install version 0.14.0 of `zig` with the package manager of your choosing, e.g., `brew install zig`, or download the binary from [here][zig-download].
 
 ### macOS debugger
 

--- a/build.zig
+++ b/build.zig
@@ -2,20 +2,24 @@ const std = @import("std");
 
 const VERSION = "3.2";
 
-const main_targets = .{
+const main_targets: []const std.Target.Query = &[_]std.Target.Query{
     .{ .cpu_arch = .aarch64, .os_tag = .macos, .abi = null },
     .{ .cpu_arch = .x86_64, .os_tag = .macos, .abi = null },
     .{ .cpu_arch = .aarch64, .os_tag = .linux, .abi = .musl },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .musl },
 };
 
-const supported_targets: []const std.Target.Query = &(main_targets ++ .{
+const supported_targets: []const std.Target.Query = &[_]std.Target.Query{
+    .{ .cpu_arch = .aarch64, .os_tag = .macos, .abi = null },
+    .{ .cpu_arch = .x86_64, .os_tag = .macos, .abi = null },
+    .{ .cpu_arch = .aarch64, .os_tag = .linux, .abi = .musl },
+    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .musl },
     .{ .cpu_arch = .aarch64, .os_tag = .linux, .abi = .gnu },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu, .glibc_version = std.SemanticVersion{ .major = 2, .minor = 27, .patch = 0 } },
-});
+};
 
-const targets: []const std.Target.Query = &main_targets;
+const targets: []const std.Target.Query = main_targets;
 
 const BuildCfg = struct {
     version: []const u8,
@@ -395,7 +399,7 @@ fn buildBinary(
     });
     b.getInstallStep().dependOn(&target_output.step);
 
-    if (target.result.isDarwin() and !target.query.isNative()) {
+    if (target.result.os.tag.isDarwin() and !target.query.isNative()) {
         const macos_sdk = b.lazyDependency("macos_sdk", .{
             .target = target,
             .optimize = optimize,
@@ -425,7 +429,7 @@ fn buildBinary(
     urbit.linkLibrary(whereami.artifact("whereami"));
     urbit.linkLibrary(wasm3.artifact("wasm3"));
 
-    if (t.isDarwin()) {
+    if (t.os.tag.isDarwin()) {
         // Requires llvm@18 homebrew installation
         if (cfg.asan or cfg.ubsan)
             urbit.addLibraryPath(.{
@@ -577,7 +581,7 @@ fn buildBinary(
                 .optimize = optimize,
             });
 
-            if (t.isDarwin() and !target.query.isNative()) {
+            if (t.os.tag.isDarwin() and !target.query.isNative()) {
                 const macos_sdk = b.lazyDependency("macos_sdk", .{
                     .target = target,
                     .optimize = optimize,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "urbit",
+    .name = .urbit,
     .version = "0.0.1",
+    .fingerprint = 0x9e228a3003a2736b,
     .dependencies = .{
         .macos_sdk = .{
             .url = "https://github.com/joseluisq/macosx-sdks/releases/download/14.5/MacOSX14.5.sdk.tar.xz",

--- a/ext/avahi/build.zig
+++ b/ext/avahi/build.zig
@@ -538,7 +538,7 @@ pub fn build(b: *std.Build) void {
     avahi.root_module.addCMacro("HAVE_DBUS_CONNECTION_CLOSE", "0");
     avahi.root_module.addCMacro("HAVE_EXPAT_H", "1");
     avahi.root_module.addCMacro("HAVE_CONFIG_H", "1");
-    if (!t.isGnu())
+    if (!t.isGnuLibC())
         avahi.root_module.addCMacro("HAVE_STRLCPY", "1");
 
     const avahi_config_h = b.addConfigHeader(.{

--- a/ext/backtrace/build.zig
+++ b/ext/backtrace/build.zig
@@ -81,7 +81,7 @@ pub fn build(b: *std.Build) void {
         ._POSIX_SOURCE = null,
     });
 
-    if (t.isDarwin()) {
+    if (t.os.tag.isDarwin()) {
         config_h.addValues(.{
             .HAVE_MACH_O_DYLD_H = 1,
         });

--- a/ext/curl/build.zig
+++ b/ext/curl/build.zig
@@ -70,12 +70,9 @@ pub fn build(b: *std.Build) void {
     if (target.result.os.tag == .windows) {
         curl.linkSystemLibrary("bcrypt");
     } else {
-        curl.root_module.addCMacro(
-            "CURL_EXTERN_SYMBOL",
-            "__attribute__ ((__visibility__ (\"default\"))"
-        );
+        curl.root_module.addCMacro("CURL_EXTERN_SYMBOL", "__attribute__ ((__visibility__ (\"default\"))");
 
-        const isDarwin = target.result.isDarwin();
+        const isDarwin = target.result.os.tag.isDarwin();
         if (!isDarwin)
             curl.root_module.addCMacro("ENABLE_IPV6", "1");
         curl.root_module.addCMacro("HAVE_ALARM", "1");

--- a/ext/h2o/build.zig
+++ b/ext/h2o/build.zig
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) !void {
         .files = &.{"cloexec.c"},
         .flags = &.{
             "-fno-sanitize=all",
-            if (t.isGnu())
+            if (t.isGnuLibC())
                 "-D_GNU_SOURCE"
             else
                 "",

--- a/ext/openssl/build.zig
+++ b/ext/openssl/build.zig
@@ -18,9 +18,9 @@ pub fn build(b: *std.Build) !void {
         b,
         target,
         optimize,
-        if (target.result.isDarwin()) &macos_cflags else &linux_cflags,
+        if (target.result.os.tag.isDarwin()) &macos_cflags else &linux_cflags,
     );
-    if (target.result.isDarwin() and !target.query.isNative()) {
+    if (target.result.os.tag.isDarwin() and !target.query.isNative()) {
         const macos_sdk = b.lazyDependency("macos_sdk", .{
             .target = target,
             .optimize = optimize,
@@ -37,7 +37,7 @@ pub fn build(b: *std.Build) !void {
         b,
         target,
         optimize,
-        if (target.result.isDarwin()) &macos_cflags else &linux_cflags,
+        if (target.result.os.tag.isDarwin()) &macos_cflags else &linux_cflags,
     ));
 }
 
@@ -113,7 +113,7 @@ fn libcrypto(
     // lib.root_module.addCMacro("OPENSSL_NO_STDIO", "");
     // lib.root_module.addCMacro("OSSL_PKEY_PARAM_RSA_DERIVE_FROM_PQ", "1");
 
-    if (t.isDarwin() and t.cpu.arch.isAARCH64()) {
+    if (t.os.tag.isDarwin() and t.cpu.arch.isAARCH64()) {
         lib.addIncludePath(b.path("gen/macos-aarch64/include"));
         lib.addIncludePath(b.path("gen/macos-aarch64/include/crypto"));
         lib.addIncludePath(b.path("gen/macos-aarch64/include/openssl"));
@@ -163,7 +163,7 @@ fn libcrypto(
         });
     }
 
-    if (t.isDarwin() and t.cpu.arch == .x86_64) {
+    if (t.os.tag.isDarwin() and t.cpu.arch == .x86_64) {
         lib.addIncludePath(b.path("gen/macos-x86_64/include"));
         lib.addIncludePath(b.path("gen/macos-x86_64/include/crypto"));
         lib.addIncludePath(b.path("gen/macos-x86_64/include/openssl"));
@@ -329,7 +329,7 @@ fn libssl(
     lib.addIncludePath(dep.path("include/internal"));
     lib.addIncludePath(dep.path("include/openssl"));
 
-    if (t.isDarwin() and t.cpu.arch.isAARCH64()) {
+    if (t.os.tag.isDarwin() and t.cpu.arch.isAARCH64()) {
         lib.addIncludePath(b.path("gen/macos-aarch64/include"));
         lib.addIncludePath(b.path("gen/macos-aarch64/include/openssl"));
         lib.installHeadersDirectory(b.path("gen/macos-aarch64/include/openssl"), "openssl", .{});
@@ -341,7 +341,7 @@ fn libssl(
         lib.installHeadersDirectory(b.path("gen/linux-aarch64/include/openssl"), "openssl", .{});
     }
 
-    if (t.isDarwin() and t.cpu.arch == .x86_64) {
+    if (t.os.tag.isDarwin() and t.cpu.arch == .x86_64) {
         lib.addIncludePath(b.path("gen/macos-x86_64/include"));
         lib.addIncludePath(b.path("gen/macos-x86_64/include/openssl"));
         lib.installHeadersDirectory(b.path("gen/macos-x86_64/include/openssl"), "openssl", .{});
@@ -353,8 +353,8 @@ fn libssl(
         lib.installHeadersDirectory(b.path("gen/linux-x86_64/include/openssl"), "openssl", .{});
     }
 
-    lib.defineCMacro("OPENSSLDIR", "\"\"");
-    lib.defineCMacro("ENGINESDIR", "\"\"");
+    lib.root_module.addCMacro("OPENSSLDIR", "\"\"");
+    lib.root_module.addCMacro("ENGINESDIR", "\"\"");
 
     lib.addCSourceFiles(.{
         .root = dep.path(""),

--- a/ext/sigsegv/build.zig
+++ b/ext/sigsegv/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    if (target.result.isDarwin() and !target.query.isNative()) {
+    if (target.result.os.tag.isDarwin() and !target.query.isNative()) {
         const macos_sdk = b.lazyDependency("macos_sdk", .{
             .target = target,
             .optimize = optimize,
@@ -30,7 +30,7 @@ pub fn build(b: *std.Build) void {
 
     lib.linkLibC();
 
-    lib.defineCMacro("HAVE_CONFIG_H", null);
+    lib.root_module.addCMacro("HAVE_CONFIG_H", &[_]u8{});
 
     const config_h = b.addConfigHeader(.{
         .style = .{

--- a/pkg/c3/build.zig
+++ b/pkg/c3/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    if (target.result.isDarwin() and !target.query.isNative()) {
+    if (target.result.os.tag.isDarwin() and !target.query.isNative()) {
         const macos_sdk = b.lazyDependency("macos_sdk", .{
             .target = target,
             .optimize = optimize,

--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    if (target.result.isDarwin() and !target.query.isNative()) {
+    if (target.result.os.tag.isDarwin() and !target.query.isNative()) {
         const macos_sdk = b.lazyDependency("macos_sdk", .{
             .target = target,
             .optimize = optimize,

--- a/pkg/vere/build.zig
+++ b/pkg/vere/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    if (target.result.isDarwin() and !target.query.isNative()) {
+    if (target.result.os.tag.isDarwin() and !target.query.isNative()) {
         const macos_sdk = b.lazyDependency("macos_sdk", .{
             .target = target,
             .optimize = optimize,


### PR DESCRIPTION
Support for `zig-0.14.0`. Also supports the ability to use `zig build -fcompdb` to generate `compile_commands.json` (for `clangd` integration), given you [compile](https://github.com/ziglang/zig?tab=readme-ov-file#building-from-source) a Zig compiler from [452253e](https://github.com/matthew-levan/zig/commit/452253e9bff6cf726e8bf8eb8a09190b44bf3798). I used the following build commands on my `macos-aarch64` machine, though yours may vary:
```
cmake .. -DZIG_STATIC_LLVM=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSROOT=$(xcrun --show-sdk-path) -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@19/bin/clang++ -DCMAKE_EXE_LINKER_FLAGS="-L/opt/homebrew/lib -lzstd"
make -j$(sysctl -n hw.ncpu)
```

I will continue updating this PR to maintain compatibility with upstream changes and intend on opening this PR for review once it works with `zig-0.14.0` after it's released.


References:
- https://github.com/ziglang/zig/pull/22012
