### PR TITLE
mesa: move forwarding page before checking request

### DIFF
--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -2498,6 +2498,26 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
 
   _mesa_put_peer(sam_u, nam_u->her_u, per_u);
 
+  u3_pit_entry* pin_u = _mesa_get_pit(sam_u, nam_u);
+
+  if ( NULL != pin_u ) {
+    #ifdef MESA_DEBUG
+      u3l_log(" forwarding page");
+    #endif
+
+    inc_hopcount(&pac_u->hed_u);
+    c3_etch_word(pac_u->pag_u.sot_u, ntohl(lan_u.sin_addr.s_addr));
+    c3_etch_short(pac_u->pag_u.sot_u + 4, ntohs(lan_u.sin_port));
+
+    //  stick next hop in packet
+
+    _mesa_add_hop(pac_u->hed_u.hop_y, &pac_u->hed_u, &pac_u->pag_u, lan_u);
+
+    _mesa_send_pact(sam_u, pin_u->adr_u, per_u, pac_u);
+    _mesa_del_pit(sam_u, nam_u);
+    return;
+  }
+
   c3_d lev_d = mesa_num_leaves(pac_u->pag_u.dat_u.tob_d);
   u3_pend_req* req_u = _mesa_get_request(sam_u, nam_u);
   if ( !req_u ) {
@@ -2537,26 +2557,6 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
     _mesa_req_pact_init(sam_u, pic_u, lan_u, per_u);
     return;
   }
-
-  u3_pit_entry* pin_u = _mesa_get_pit(sam_u, nam_u);
-
-  if ( NULL != pin_u ) {
-    #ifdef MESA_DEBUG
-      u3l_log(" forwarding");
-    #endif
-
-    inc_hopcount(&pac_u->hed_u);
-    c3_etch_word(pac_u->pag_u.sot_u, ntohl(lan_u.sin_addr.s_addr));
-    c3_etch_short(pac_u->pag_u.sot_u + 4, ntohs(lan_u.sin_port));
-
-    //  stick next hop in packet
-
-    _mesa_add_hop(pac_u->hed_u.hop_y, &pac_u->hed_u, &pac_u->pag_u, lan_u);
-
-    _mesa_send_pact(sam_u, pin_u->adr_u, per_u, pac_u);
-    _mesa_del_pit(sam_u, nam_u);
-  }
-
 
   if ( c3y == nam_u->nit_o ) {
     u3l_log("dupe init");

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -34,7 +34,7 @@ static c3_y are_y[524288];
 
 /* #define PACKET_TEST c3y */
 
-#define MESA_DEBUG     c3y
+// #define MESA_DEBUG     c3y
 //#define MESA_TEST
 #define RED_TEXT    "\033[0;31m"
 #define DEF_TEXT    "\033[0m"
@@ -1533,7 +1533,7 @@ _mesa_resend_timer_cb(uv_timer_t* tim_u)
   }
   else {
     #ifdef MESA_DEBUG
-      // u3l_log("mesa: resend %u", res_u->ret_y);
+      u3l_log("mesa: resend %u", res_u->ret_y);
     #endif
   }
 
@@ -2530,11 +2530,11 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
   }
 
   c3_o dir_o = __(pac_u->hed_u.hop_y == 0);
-  if ( pac_u->hed_u.hop_y == 0 ) {
-    u3l_log(" received direct page");
-  } else {
-    u3l_log(" received forwarded page");
-  }
+  // if ( pac_u->hed_u.hop_y == 0 ) {
+  //   u3l_log(" received direct page");
+  // } else {
+  //   u3l_log(" received forwarded page");
+  // }
   _hear_peer(sam_u, per_u, lan_u, dir_o);
 
   if ( new_o == c3y ) {
@@ -2567,7 +2567,6 @@ _mesa_hear_page(u3_mesa_pict* pic_u, sockaddr_in lan_u)
   c3_d lev_d = mesa_num_leaves(pac_u->pag_u.dat_u.tob_d);
   u3_pend_req* req_u = _mesa_get_request(sam_u, nam_u);
   if ( !req_u ) {
-    u3l_log("bye");
     return;
   }
   if ( ( (u3_pend_req*)CTAG_WAIT == req_u ) && (0 == nam_u->fra_d) ) {
@@ -2681,7 +2680,7 @@ static void
 _mesa_hear_peek(u3_mesa_pict* pic_u, sockaddr_in lan_u)
 {
   #ifdef MESA_DEBUG
-    /* u3l_log("mesa: hear_peek()"); */
+    u3l_log("mesa: hear_peek()");
     u3_assert( PACT_PEEK == pic_u->pac_u.hed_u.typ_y );
   #endif
 


### PR DESCRIPTION
The galaxy was no-oping when hearing forwarded pages since we were checking for our own active requests before looking in the pit
