### PR TITLE
play: add `--watch-replay` flag

### DIFF
--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2442,7 +2442,7 @@ _cw_play_fork_exit(uv_process_t* req_u, c3_ds sat_d, c3_i tem_i) {
 static c3_i
 _cw_play_fork(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
 {
-  c3_c *argv[12] = {0};
+  c3_c *argv[13] = {0};
   c3_c eve_c[21] = {0};
   c3_c sap_c[21] = {0};
   c3_c lom_c[3]  = {0};
@@ -2467,6 +2467,7 @@ _cw_play_fork(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
 
     argv[i_z++] = u3_Host.wrk_c;
     argv[i_z++] = "play";
+    argv[i_z++] = "--watch-replay";
     argv[i_z++] = "--loom";
     argv[i_z++] = lom_c;
     argv[i_z++] = "--replay-to";
@@ -2534,17 +2535,19 @@ _cw_play(c3_i argc, c3_c* argv[])
   c3_o ful_o = c3n;
   c3_o mel_o = c3n;
   c3_o sof_o = c3n;
+  c3_o wat_o = c3n;
   c3_d eve_d = 0;
   c3_d sap_d = 0;
 
   static struct option lop_u[] = {
-    { "loom",      required_argument, NULL, c3__loom },
-    { "no-demand", no_argument,       NULL, 6 },
-    { "auto-meld", no_argument,       NULL, 7 },
-    { "soft-mugs", no_argument,       NULL, 8 },
-    { "full",      no_argument,       NULL, 'f' },
-    { "replay-to", required_argument, NULL, 'n' },
-    { "snap-at",   required_argument, NULL, 's' },
+    { "loom",              required_argument, NULL, c3__loom },
+    { "no-demand",         no_argument,       NULL, 6 },
+    { "auto-meld",         no_argument,       NULL, 7 },
+    { "soft-mugs",         no_argument,       NULL, 8 },
+    { "watch-replay",      no_argument,       NULL, 9 },
+    { "full",              no_argument,       NULL, 'f' },
+    { "replay-to",         required_argument, NULL, 'n' },
+    { "snap-at",           required_argument, NULL, 's' },
     { NULL, 0, NULL, 0 }
   };
 
@@ -2569,6 +2572,10 @@ _cw_play(c3_i argc, c3_c* argv[])
 
       case 8: {  //  soft-mugs
         sof_o = c3y;
+      } break;
+
+      case 9: {  //  watch-replay
+        wat_o = c3y;
       } break;
 
       case 'f': {
@@ -2616,12 +2623,17 @@ _cw_play(c3_i argc, c3_c* argv[])
     exit(1);
   }
 
-  pthread_t ted;
-  pthread_create(&ted, NULL, _cw_play_fork_heed, NULL);
+  if ( _(wat_o) ) {
+    pthread_t ted;
+    pthread_create(&ted, NULL, _cw_play_fork_heed, NULL);
 
-  _cw_play_impl(eve_d, sap_d, mel_o, sof_o, ful_o);
+    _cw_play_impl(eve_d, sap_d, mel_o, sof_o, ful_o);
 
-  pthread_cancel(ted);
+    pthread_cancel(ted);
+  }
+  else {
+    _cw_play_impl(eve_d, sap_d, mel_o, sof_o, ful_o);
+  }
 }
 
 /* _cw_prep(): prepare for upgrade


### PR DESCRIPTION
Resolves #679. Read this [comment](https://github.com/urbit/vere/issues/679#issuecomment-2706929997) for a summary of the underlying issue.

This PR adds the `--watch-replay` flag to the `play` subcommand. 

When `--watch-replay` is passed to `play`, a watcher thread is spawned to ensure process orphaning does not occur. This option is only helpful when replaying events during normal pier startup, where we spawn a child process, so it's off by default. When we start a pier normally (i.e., without the `play` subcommand), we turn it on in `_cw_play_fork`. 

Keeping `--watch-replay` off by default _prevents_ operators that run `play` with no `STDIN` from experiencing issue #679, like so:
```
matt@mbp14 vere % ./urbit play zod < /dev/null
play: god save the king! committing sudoku...
```

No affordance is granted for disabling the watcher thread during normal pier startup, since we always spawn a child process to replay and want to prevent process orphaning as far as possible.