### PR TITLE
ames: scry for lanes using /chums/[ship]/lanes

### DIFF
--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -726,9 +726,9 @@ _fine_etch_response(u3_pact* pac_u)
 static inline u3_noun
 _lane_scry_path(u3_noun who)
 {
-  return u3nq(u3i_string("peers"),
+  return u3nq(u3i_string("chums"),
               u3dc("scot", 'p', who),
-              u3i_string("forward-lane"),
+              u3i_string("lanes"),
               u3_nul);
 }
 


### PR DESCRIPTION
This looks for ships in both .peers and .chums, to account for migrated ships

(see: https://github.com/urbit/urbit/blob/develop/pkg/arvo/sys/vane/ames.hoon#L10661-L10700)
