### PR TITLE
Revert "ames: scry for lanes using /chums/[ship]/lanes"

### DIFF
--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -726,9 +726,9 @@ _fine_etch_response(u3_pact* pac_u)
 static inline u3_noun
 _lane_scry_path(u3_noun who)
 {
-  return u3nq(u3i_string("chums"),
+  return u3nq(u3i_string("peers"),
               u3dc("scot", 'p', who),
-              u3i_string("lanes"),
+              u3i_string("forward-lane"),
               u3_nul);
 }
 


### PR DESCRIPTION
A few issues were discovered when I (~dinleb-rambep) migrated ~norsyr-torryn to directed messaging yesterday. One issue is that if a galaxy has been migrated but a peer has not, then ames-to-ames forwarding would not work. The reverted PR was meant to mitigate this, but the types from the ames and mesa lane scries are incompatible. We will address this with an arvo PR instead.