### PR TITLE
http: only check cache on GET requests

### DIFF
--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1122,6 +1122,11 @@ _http_req_cache(u3_hreq* req_u)
 {
   u3_assert(u3_rsat_init == req_u->sat_e);
 
+  h2o_iovec_t method = req_u->rec_u->method;
+  if (0 != strncmp("GET", method.base, method.len)) {
+    return c3n;
+  }
+
   u3_httd* htd_u = req_u->hon_u->htp_u->htd_u;
 
   u3_noun url = u3dc("scot", 't', _http_vec_to_atom(req_u->rec_u->path));


### PR DESCRIPTION
fixes a bug where a POST request to /foo/bar would return the cached response for a GET at /foo/bar