### PR TITLE
auto: fix driver priority

### DIFF
--- a/pkg/vere/auto.c
+++ b/pkg/vere/auto.c
@@ -432,14 +432,14 @@ u3_auto_init(u3_pier* pir_u)
   car_u = _auto_link(u3_hind_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_behn_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_conn_io_init(pir_u), pir_u, car_u);
+  car_u = _auto_link(u3_lick_io_init(pir_u), pir_u, car_u);
+  car_u = _auto_link(u3_mesa_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_ames_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_http_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_cttp_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_unix_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_term_io_init(pir_u), pir_u, car_u);
   car_u = _auto_link(u3_fore_io_init(pir_u), pir_u, car_u);
-  car_u = _auto_link(u3_lick_io_init(pir_u), pir_u, car_u);
-  car_u = _auto_link(u3_mesa_io_init(pir_u), pir_u, car_u);
 
   return car_u;
 }


### PR DESCRIPTION
Each driver in the king has an event queue. When new events are about to be handled, these queues get pulled from in a specific order. We do this so that a ship that receives a ton of ames packets doesn't block handling terminal keystrokes or web interface HTTP requests.

`vere-v3.2` added the `mesa.c` driver for Directed Messaging. The driver was incorrectly put at the very bottom of `auto.c` which means the highest priority driver. This combined with the proliferation of "dead" permanent networking flows caused some ships to appear less responsive when compared to `vere-v3.1`.