### PR TITLE
mars: really don't install the ivory pill in the serf

### DIFF
--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -190,24 +190,24 @@ _mars_do_boot(u3_disk* log_u, c3_d eve_d)
   //
   //    XX support -J
   //
-  {
-    c3_d  len_d = u3_Ivory_pill_len;
-    c3_y* byt_y = u3_Ivory_pill;
-    u3_cue_xeno* sil_u = u3s_cue_xeno_init_with(ur_fib27, ur_fib28);
-    u3_weak pil;
+  /* { */
+  /*   c3_d  len_d = u3_Ivory_pill_len; */
+  /*   c3_y* byt_y = u3_Ivory_pill; */
+  /*   u3_cue_xeno* sil_u = u3s_cue_xeno_init_with(ur_fib27, ur_fib28); */
+  /*   u3_weak pil; */
 
-    if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) {
-      u3l_log("lite: unable to cue ivory pill");
-      exit(1);
-    }
+  /*   if ( u3_none == (pil = u3s_cue_xeno_with(sil_u, len_d, byt_y)) ) { */
+  /*     u3l_log("lite: unable to cue ivory pill"); */
+  /*     exit(1); */
+  /*   } */
 
-    u3s_cue_xeno_done(sil_u);
+  /*   u3s_cue_xeno_done(sil_u); */
 
-    if ( c3n == u3v_boot_lite(pil)) {
-      u3l_log("lite: boot failed");
-      exit(1);
-    }
-  }
+  /*   if ( c3n == u3v_boot_lite(pil)) { */
+  /*     u3l_log("lite: boot failed"); */
+  /*     exit(1); */
+  /*   } */
+  /* } */
 
   u3l_log("--------------- bootstrap starting ----------------");
 


### PR DESCRIPTION
I removed the ivory pill from the serf in #750, but I missed this code path in _mars_do_boot. This code only ever runs if the process has been killed during initial boot and we have to replay. The older ivory pill being installed breaks the structural sharing for jet registrations, causing ships that crash during boot to perform extremely poorly until they get melded.