### PR TITLE
u3: refactor unifying equality

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -97,7 +97,7 @@ jobs:
             hashtable-test jets-test   \
             nock-test retrieve-test    \
             serial-test ames-test      \
-            pact-test                  \
+            pact-test equality-test    \
             boot-test newt-test        \
             vere-noun-test unix-test   \
             benchmarks                 \

--- a/build.zig
+++ b/build.zig
@@ -510,6 +510,11 @@ fn buildBinary(
             },
             // pkg_noun
             .{
+                .name = "equality-test",
+                .file = "pkg/noun/equality_tests.c",
+                .deps = noun_test_deps,
+            },
+            .{
                 .name = "hashtable-test",
                 .file = "pkg/noun/hashtable_tests.c",
                 .deps = noun_test_deps,

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1547,6 +1547,9 @@ u3a_use(u3_noun som)
   }
 }
 
+#define SWAP(l, r)    \
+  do { typeof(l) t = l; l = r; r = t; } while (0)
+
 /* _ca_wed_who(): unify [a] and [b] on [rod_u], keeping the senior
 **
 ** NB: this leaks a reference when it unifies in a senior road
@@ -1556,29 +1559,20 @@ _ca_wed_who(u3a_road* rod_u, u3_noun* a, u3_noun* b)
 {
   c3_t asr_t = ( c3y == u3a_is_senior(rod_u, *a) );
   c3_t bsr_t = ( c3y == u3a_is_senior(rod_u, *b) );
-  c3_t nor_t = ( c3y == u3a_is_north(rod_u) );
   c3_t own_t = ( rod_u == u3R );
 
-  //  both are on [rod_u]; gain a reference to whichever we keep
+  //  both are on [rod_u]; keep the deeper address
+  //  (and gain a reference)
   //
   if ( !asr_t && !bsr_t ) {
-    //  keep [a]; it's deeper in the heap
+    //  (N && <) || (S && >)
+    //  XX consider keeping higher refcount instead
     //
-    //    (N && <) || (S && >)
-    //
-    if ( (*a < *b) == nor_t ) {
-      _me_gain_use(*a);
-      if ( own_t ) { u3z(*b); }
-      *b = *a;
-    }
-    //  keep [b]; it's deeper in the heap
-    //
-    else {
-      _me_gain_use(*b);
-      if ( own_t ) { u3z(*a); }
-      *a = *b;
-    }
+    if ( (*a > *b) == (c3y == u3a_is_north(rod_u)) ) SWAP(a, b);
 
+    _me_gain_use(*a);
+    if ( own_t ) { u3z(*b); }
+    *b = *a;
     return c3y;
   }
   //  keep [a]; it's senior
@@ -1600,6 +1594,8 @@ _ca_wed_who(u3a_road* rod_u, u3_noun* a, u3_noun* b)
   //
   return c3n;
 }
+
+#undef SWAP
 
 /* u3a_wed(): unify noun references.
 */

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1631,9 +1631,9 @@ u3a_wed(u3_noun *restrict a, u3_noun *restrict b)
 
 #ifdef U3_MEMORY_DEBUG
   return;
-#endif
-
+#else
   if ( u3C.wag_w & u3o_debug_ram ) return;
+#endif
 
   //  while not at home, attempt to unify
   //

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1606,8 +1606,19 @@ _ca_wed_who(u3a_road* rod_u, u3_noun* a, u3_noun* b)
 void
 u3a_wed(u3_noun* a, u3_noun* b)
 {
+  u3_road* rod_u = u3R;
+  c3_o     wed_o;
+
+  if ( rod_u->kid_p ) return;
+
   if ( *a != *b ) {
-    u3_road* rod_u = u3R;
+    wed_o = _ca_wed_who(rod_u, a, b);
+
+#ifdef U3_MEMORY_DEBUG
+    return;
+#endif
+
+    if ( u3C.wag_w & u3o_debug_ram ) return;
 
     //  while not at home, attempt to unify
     //
@@ -1632,14 +1643,12 @@ u3a_wed(u3_noun* a, u3_noun* b)
     //    cause a very slow boot process as the compiler compiles
     //    itself, constantly running into duplicates.
     //
-    while ( (rod_u != &u3H->rod_u) &&
-            (c3n == _ca_wed_who(rod_u, a, b)) )
+
+    while (  (c3n == wed_o)
+          && rod_u->par_p
+          && (&u3H->rod_u != (rod_u = u3to(u3_road, rod_u->par_p))) )
     {
-#ifdef U3_MEMORY_DEBUG
-      break;
-#else
-      rod_u = u3to(u3_road, rod_u->par_p);
-#endif
+      wed_o = _ca_wed_who(rod_u, a, b);
     }
   }
 }

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1564,9 +1564,9 @@ _ca_wed_who(u3a_road* rod_u, u3_noun* a, u3_noun* b)
   if ( !asr_t && !bsr_t ) {
     //  keep [a]; it's deeper in the heap
     //
-    //    (N && >) || (S && <)
+    //    (N && <) || (S && >)
     //
-    if ( (*a > *b) == nor_t ) {
+    if ( (*a < *b) == nor_t ) {
       _me_gain_use(*a);
       if ( own_t ) { u3z(*b); }
       *b = *a;

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1604,52 +1604,51 @@ _ca_wed_who(u3a_road* rod_u, u3_noun* a, u3_noun* b)
 /* u3a_wed(): unify noun references.
 */
 void
-u3a_wed(u3_noun* a, u3_noun* b)
+u3a_wed(u3_noun *restrict a, u3_noun *restrict b)
 {
+  //  XX assume( *a != *b )
   u3_road* rod_u = u3R;
   c3_o     wed_o;
 
   if ( rod_u->kid_p ) return;
 
-  if ( *a != *b ) {
-    wed_o = _ca_wed_who(rod_u, a, b);
+  wed_o = _ca_wed_who(rod_u, a, b);
 
 #ifdef U3_MEMORY_DEBUG
-    return;
+  return;
 #endif
 
-    if ( u3C.wag_w & u3o_debug_ram ) return;
+  if ( u3C.wag_w & u3o_debug_ram ) return;
 
-    //  while not at home, attempt to unify
-    //
-    //    we try to unify on our road, and retry on senior roads
-    //    until we succeed or reach the home road.
-    //
-    //    we can't perform this kind of butchery on the home road,
-    //    where asynchronous things can allocate.
-    //    (XX anything besides u3t_samp?)
-    //
-    //    when unifying on a higher road, we can't free nouns,
-    //    because we can't track junior nouns that point into
-    //    that road.
-    //
-    //    this is just an implementation issue -- we could set use
-    //    counts to 0 without actually freeing.  but the allocator
-    //    would have to be actually designed for this.
-    //    (alternately, we could keep a deferred free-list)
-    //
-    //    not freeing may generate spurious leaks, so we disable
-    //    senior unification when debugging memory.  this will
-    //    cause a very slow boot process as the compiler compiles
-    //    itself, constantly running into duplicates.
-    //
+  //  while not at home, attempt to unify
+  //
+  //    we try to unify on our road, and retry on senior roads
+  //    until we succeed or reach the home road.
+  //
+  //    we can't perform this kind of butchery on the home road,
+  //    where asynchronous things can allocate.
+  //    (XX anything besides u3t_samp?)
+  //
+  //    when unifying on a higher road, we can't free nouns,
+  //    because we can't track junior nouns that point into
+  //    that road.
+  //
+  //    this is just an implementation issue -- we could set use
+  //    counts to 0 without actually freeing.  but the allocator
+  //    would have to be actually designed for this.
+  //    (alternately, we could keep a deferred free-list)
+  //
+  //    not freeing may generate spurious leaks, so we disable
+  //    senior unification when debugging memory.  this will
+  //    cause a very slow boot process as the compiler compiles
+  //    itself, constantly running into duplicates.
+  //
 
-    while (  (c3n == wed_o)
-          && rod_u->par_p
-          && (&u3H->rod_u != (rod_u = u3to(u3_road, rod_u->par_p))) )
-    {
-      wed_o = _ca_wed_who(rod_u, a, b);
-    }
+  while (  (c3n == wed_o)
+        && rod_u->par_p
+        && (&u3H->rod_u != (rod_u = u3to(u3_road, rod_u->par_p))) )
+  {
+    wed_o = _ca_wed_who(rod_u, a, b);
   }
 }
 

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1561,38 +1561,28 @@ _ca_wed_who(u3a_road* rod_u, u3_noun* a, u3_noun* b)
   c3_t bsr_t = ( c3y == u3a_is_senior(rod_u, *b) );
   c3_t own_t = ( rod_u == u3R );
 
-  //  both are on [rod_u]; keep the deeper address
-  //  (and gain a reference)
-  //
-  if ( !asr_t && !bsr_t ) {
-    //  (N && <) || (S && >)
-    //  XX consider keeping higher refcount instead
+  if ( asr_t == bsr_t ) {
+    //  both [a] and [b] are senior; we can't unify on [rod_u]
+    //
+    if ( asr_t ) return c3n;
+
+    //  both are on [rod_u]; keep the deeper address
+    //  (and gain a reference)
+    //
+    //    (N && <) || (S && >)
+    //    XX consider keeping higher refcount instead
     //
     if ( (*a > *b) == (c3y == u3a_is_north(rod_u)) ) SWAP(a, b);
 
     _me_gain_use(*a);
-    if ( own_t ) { u3z(*b); }
-    *b = *a;
-    return c3y;
   }
-  //  keep [a]; it's senior
+  //  one of [a] or [b] are senior; keep it
   //
-  else if ( asr_t && !bsr_t ) {
-    if ( own_t ) { u3z(*b); }
-    *b = *a;
-    return c3y;
-  }
-  //  keep [b]; it's senior
-  //
-  else if ( !asr_t && bsr_t ) {
-    if ( own_t ) { u3z(*a); }
-    *a = *b;
-    return c3y;
-  }
+  else if ( !asr_t ) SWAP(a, b);
 
-  //  both [a] and [b] are senior; we can't unify on [rod_u]
-  //
-  return c3n;
+  if ( own_t ) { u3z(*b); }
+  *b = *a;
+  return c3y;
 }
 
 #undef SWAP

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -582,7 +582,7 @@
         /* u3a_wed(): unify noun references.
         */
           void
-          u3a_wed(u3_noun* a, u3_noun* b);
+          u3a_wed(u3_noun *restrict a, u3_noun *restrict b);
 
         /* u3a_luse(): check refcount sanity.
         */

--- a/pkg/noun/equality_tests.c
+++ b/pkg/noun/equality_tests.c
@@ -11,7 +11,7 @@ _setup(void)
 }
 
 static c3_i
-_test_unify(void)
+_test_unify_home(void)
 {
   c3_i ret_i = 1;
 
@@ -19,22 +19,101 @@ _test_unify(void)
   u3_noun  b = u3nt(0, 0, 0);
   c3_w kep_w;
 
-  fprintf(stderr, "before: 0x%x 0x%x\r\n", u3t(a), u3t(b));
   u3_assert( u3t(a) < u3t(b) );
   kep_w = u3t(a);
 
   (void)u3r_sing(a, b);
 
   if ( u3t(a) != u3t(b) ) {
-    fprintf(stderr, "test: unify: failed\r\n");
+    fprintf(stderr, "test: unify home: failed\r\n");
     ret_i = 0;
   }
   else if ( kep_w != u3t(b) ) {
-    fprintf(stderr, "test: unify: deeper failed\r\n");
+    fprintf(stderr, "test: unify home: deeper failed\r\n");
     ret_i = 0;
   }
 
-  fprintf(stderr, "after: 0x%x 0x%x\r\n", u3t(a), u3t(b));
+  u3z(a); u3z(b);
+
+  return ret_i;
+}
+
+static c3_i
+_test_unify_inner(void)
+{
+  c3_i   ret_i = 1;
+  c3_w   kep_w;
+  u3_noun a, b;
+
+  a = u3nt(0, 0, 0);
+  kep_w = u3t(a);
+
+  u3m_hate(0);
+
+  b = u3nt(0, 0, 0);
+
+  (void)u3r_sing(a, b);
+
+  if ( u3t(a) != u3t(b) ) {
+    fprintf(stderr, "test: unify inner 1: failed\r\n");
+    ret_i = 0;
+  }
+  else if ( kep_w != u3t(b) ) {
+    fprintf(stderr, "test: unify inner 1: deeper failed\r\n");
+    ret_i = 0;
+  }
+
+  b = u3m_love(0);
+
+  u3z(a); u3z(b);
+
+  //  --------
+
+  b = u3nt(0, 0, 0);
+  kep_w = u3t(b);
+
+  u3m_hate(0);
+
+  a = u3nt(0, 0, 0);
+
+  u3m_hate(0);
+
+  (void)u3r_sing(a, b);
+
+  if ( u3t(a) != u3t(b) ) {
+    fprintf(stderr, "test: unify inner 2: failed\r\n");
+    ret_i = 0;
+  }
+  else if ( kep_w != u3t(a) ) {
+    fprintf(stderr, "test: unify inner 2: deeper failed\r\n");
+    ret_i = 0;
+  }
+
+  a = u3m_love(u3m_love(0));
+
+  u3z(a); u3z(b);
+
+  return ret_i;
+}
+
+static c3_i
+_test_unify_inner_home(void)
+{
+  c3_i ret_i = 1;
+
+  u3_noun  a = u3nt(0, 0, 0);
+  u3_noun  b = u3nt(0, 0, 0);
+
+  u3m_hate(0);
+
+  (void)u3r_sing(a, b);
+
+  if ( u3t(a) == u3t(b) ) {
+    fprintf(stderr, "test: unify inner-home: succeeded?\r\n");
+    ret_i = 0;
+  }
+
+  u3m_love(0);
 
   u3z(a); u3z(b);
 
@@ -46,8 +125,18 @@ _test_equality(void)
 {
   c3_i ret_i = 1;
 
-  if ( !_test_unify() ) {
-    fprintf(stderr, "test equality unify: failed\r\n");
+  if ( !_test_unify_home() ) {
+    fprintf(stderr, "test: equality: unify home: failed\r\n");
+    ret_i = 0;
+  }
+
+  if ( !_test_unify_inner() ) {
+    fprintf(stderr, "test: equality: unify inner: failed\r\n");
+    ret_i = 0;
+  }
+
+  if ( !_test_unify_inner_home() ) {
+    fprintf(stderr, "test: equality: unify inner-home: failed\r\n");
     ret_i = 0;
   }
 

--- a/pkg/noun/equality_tests.c
+++ b/pkg/noun/equality_tests.c
@@ -17,13 +17,20 @@ _test_unify(void)
 
   u3_noun  a = u3nt(0, 0, 0);
   u3_noun  b = u3nt(0, 0, 0);
+  c3_w kep_w;
 
   fprintf(stderr, "before: 0x%x 0x%x\r\n", u3t(a), u3t(b));
-  u3_assert( u3t(a) != u3t(b) );
+  u3_assert( u3t(a) < u3t(b) );
+  kep_w = u3t(a);
 
   (void)u3r_sing(a, b);
 
   if ( u3t(a) != u3t(b) ) {
+    fprintf(stderr, "test: unify: failed\r\n");
+    ret_i = 0;
+  }
+  else if ( kep_w != u3t(b) ) {
+    fprintf(stderr, "test: unify: deeper failed\r\n");
     ret_i = 0;
   }
 

--- a/pkg/noun/equality_tests.c
+++ b/pkg/noun/equality_tests.c
@@ -1,0 +1,68 @@
+/// @file
+
+#include "noun.h"
+
+/* _setup(): prepare for tests.
+*/
+static void
+_setup(void)
+{
+  u3m_boot_lite(1 << 24);
+}
+
+static c3_i
+_test_unify(void)
+{
+  c3_i ret_i = 1;
+
+  u3_noun  a = u3nt(0, 0, 0);
+  u3_noun  b = u3nt(0, 0, 0);
+
+  fprintf(stderr, "before: 0x%x 0x%x\r\n", u3t(a), u3t(b));
+  u3_assert( u3t(a) != u3t(b) );
+
+  (void)u3r_sing(a, b);
+
+  if ( u3t(a) != u3t(b) ) {
+    ret_i = 0;
+  }
+
+  fprintf(stderr, "after: 0x%x 0x%x\r\n", u3t(a), u3t(b));
+
+  u3z(a); u3z(b);
+
+  return ret_i;
+}
+
+static c3_i
+_test_equality(void)
+{
+  c3_i ret_i = 1;
+
+  if ( !_test_unify() ) {
+    fprintf(stderr, "test equality unify: failed\r\n");
+    ret_i = 0;
+  }
+
+  return ret_i;
+}
+
+/* main(): run all test cases.
+*/
+int
+main(int argc, char* argv[])
+{
+  _setup();
+
+  if ( !_test_equality() ) {
+    fprintf(stderr, "test equality: failed\r\n");
+    exit(1);
+  }
+
+  //  GC
+  //
+  u3m_grab(u3_none);
+
+  fprintf(stderr, "test equality: ok\r\n");
+  return 0;
+}

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -388,6 +388,14 @@ _cr_sing_cape_keep(u3p(u3h_root) har_p, u3_noun a, u3_noun b)
   }
 }
 
+static inline __attribute__((always_inline)) void
+_cr_sing_wed(u3_noun *restrict a, u3_noun *restrict b)
+{
+  if ( *a != *b ) {
+    u3a_wed(a, b);
+  }
+}
+
 /* _cr_sing_cape(): unifying equality with comparison deduplication
  *                  (tightly coupled to _cr_sing)
  */
@@ -456,7 +464,7 @@ _cr_sing_cape(u3a_pile* pil_u, u3p(u3h_root) har_p)
       case SING_HEAD: {
         a_u = u3a_to_ptr(a);
         b_u = u3a_to_ptr(b);
-        u3a_wed(&(a_u->hed), &(b_u->hed));
+        _cr_sing_wed(&(a_u->hed), &(b_u->hed));
 
         //  upgrade head-frame to tail-frame, check tails
         //
@@ -470,7 +478,7 @@ _cr_sing_cape(u3a_pile* pil_u, u3p(u3h_root) har_p)
       case SING_TAIL: {
         a_u = u3a_to_ptr(a);
         b_u = u3a_to_ptr(b);
-        u3a_wed(&(a_u->tel), &(b_u->tel));
+        _cr_sing_wed(&(a_u->tel), &(b_u->tel));
       } break;
 
       default: {
@@ -559,7 +567,7 @@ _cr_sing(u3_noun a, u3_noun b)
       case SING_HEAD: {
         a_u = u3a_to_ptr(a);
         b_u = u3a_to_ptr(b);
-        u3a_wed(&(a_u->hed), &(b_u->hed));
+        _cr_sing_wed(&(a_u->hed), &(b_u->hed));
 
         //  upgrade head-frame to tail-frame, check tails
         //
@@ -573,7 +581,7 @@ _cr_sing(u3_noun a, u3_noun b)
       case SING_TAIL: {
         a_u = u3a_to_ptr(a);
         b_u = u3a_to_ptr(b);
-        u3a_wed(&(a_u->tel), &(b_u->tel));
+        _cr_sing_wed(&(a_u->tel), &(b_u->tel));
       } break;
 
       default: {


### PR DESCRIPTION
These changes were developed on top of #812, as part of a(nother) failed effort to develop leak-free unification of senior memory. But they stand alone, and deserve separate review.

This PR fixes a bug wherein deeper addresses were not preferred when unifying two nouns on the same road. It also optimizes the unification implementation by using separate functions for normal and senior unification and removing branches. Finally, it enables home-road unification when the current road is the home road and there are no child roads, and adds basic unit tests for these scenarios.