### PR TITLE
vere: fix some undefined behavior

### DIFF
--- a/pkg/noun/jets/c/bex.c
+++ b/pkg/noun/jets/c/bex.c
@@ -13,7 +13,7 @@ u3qc_bex(u3_atom a)
   u3i_slab sab_u;
 
   if ( a < 31 ) {
-    return 1 << a;
+    return 1U << a;
   }
 
   if ( c3y == u3a_is_cat(a) ) {
@@ -34,7 +34,7 @@ u3qc_bex(u3_atom a)
 
   u3i_slab_init(&sab_u, 0, a_d + 1);
 
-  sab_u.buf_w[a_d >> 5] = (c3_d)1 << (a_d & 31);
+  sab_u.buf_w[a_d >> 5] = 1U << (a_d & 31);
 
   return u3i_slab_moot(&sab_u);
 }

--- a/pkg/ur/bitstream.c
+++ b/pkg/ur/bitstream.c
@@ -1079,7 +1079,7 @@ _bsw_bytes_unsafe(ur_bsw_t *bsw, const uint64_t len, const uint8_t* src)
 
       {
         uint8_t  tal = (src[len_byt] >> rest)
-                     ^ (( off > len_bit ) ? 0 : (src[len_byt + 1] << off));
+                     ^ (( off >= len_bit ) ? 0 : (src[len_byt + 1] << off));
         dst[len_byt] = tal & ((1 << len_bit) - 1);
       }
 

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -588,11 +588,11 @@ u3_lmdb_walk_next(u3_lmdb_walk* itr_u, size_t* len_i, void** buf_v)
 
   //  sanity check: ensure contiguous event numbers
   //
-  if ( *(c3_d*)key_u.mv_data != itr_u->nex_d ) {
+  if ( c3_sift_chub(key_u.mv_data) != itr_u->nex_d ) {
     fprintf(stderr, "lmdb: read gap: expected %" PRIu64
                     ", received %" PRIu64 "\r\n",
                     itr_u->nex_d,
-                    *(c3_d*)key_u.mv_data);
+                    c3_sift_chub(key_u.mv_data));
     return c3n;
   }
 

--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -198,7 +198,7 @@ u3_lmdb_gulf(MDB_env* env_u, c3_d* low_d, c3_d* hig_d)
       return c3n;
     }
     else {
-      memcpy(&fir_d, key_u.mv_data, sizeof(c3_d));
+      fir_d = c3_sift_chub(key_u.mv_data);
     }
 
     //  read with the cursor from the end of the database
@@ -206,7 +206,7 @@ u3_lmdb_gulf(MDB_env* env_u, c3_d* low_d, c3_d* hig_d)
     ret_w = mdb_cursor_get(cur_u, &key_u, &val_u, MDB_LAST);
 
     if ( !ret_w ) {
-      memcpy(&las_d, key_u.mv_data, sizeof(c3_d));
+      las_d = c3_sift_chub(key_u.mv_data);
     }
 
     //  clean up unconditionally, we're done


### PR DESCRIPTION
These issues came up while testing #812 under Asan and Ubsan. The +bex jet had already been partially fixed in #764. There are many more of these undefined left shifts in the codebase. Those should be systematically rectified, maybe as part of #794.