### PR TITLE
u3: moves home road to loom start, simplifies snapshot system

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -332,7 +332,7 @@ _ce_image_stat(u3e_image* img_u, c3_w* pgs_w)
   struct stat buf_u;
 
   if ( -1 == fstat(img_u->fid_i, &buf_u) ) {
-    fprintf(stderr, "loom: stat %s: %s\r\n", img_u->nam_c, strerror(errno));
+    fprintf(stderr, "loom: image stat: %s\r\n", strerror(errno));
     u3_assert(0);
     return _ce_img_fail;
   }
@@ -345,11 +345,11 @@ _ce_image_stat(u3e_image* img_u, c3_w* pgs_w)
       return _ce_img_good;
     }
     else if ( siz_z != _ce_len(pgs_z) ) {
-      fprintf(stderr, "loom: %s corrupt size %zu\r\n", img_u->nam_c, siz_z);
+      fprintf(stderr, "loom: image corrupt size %zu\r\n", siz_z);
       return _ce_img_size;
     }
     else if ( pgs_z > UINT32_MAX ) {
-      fprintf(stderr, "loom: %s overflow %zu\r\n", img_u->nam_c, siz_z);
+      fprintf(stderr, "loom: image overflow %zu\r\n", siz_z);
       return _ce_img_fail;
     }
     else {
@@ -802,8 +802,7 @@ static c3_o
 _ce_image_sync(u3e_image* img_u)
 {
   if ( -1 == c3_sync(img_u->fid_i) ) {
-    fprintf(stderr, "loom: image (%s) sync failed: %s\r\n",
-                    img_u->nam_c, strerror(errno));
+    fprintf(stderr, "loom: image sync failed: %s\r\n", strerror(errno));
     return c3n;
   }
 
@@ -820,15 +819,14 @@ _ce_image_resize(u3e_image* img_u, c3_w pgs_w)
 
   if ( img_u->pgs_w > pgs_w ) {
     if ( off_z != (size_t)off_i ) {
-      fprintf(stderr, "loom: image (%s) truncate: "
+      fprintf(stderr, "loom: image truncate: "
                       "offset overflow (%" PRId64 ") for page %u\r\n",
-                      img_u->nam_c, (c3_ds)off_i, pgs_w);
+                      (c3_ds)off_i, pgs_w);
       u3_assert(0);
     }
 
     if ( ftruncate(img_u->fid_i, off_i) ) {
-      fprintf(stderr, "loom: image (%s) truncate: %s\r\n",
-                      img_u->nam_c, strerror(errno));
+      fprintf(stderr, "loom: image truncate: %s\r\n", strerror(errno));
       u3_assert(0);
     }
   }
@@ -1115,12 +1113,10 @@ _ce_page_fine(u3e_image* img_u, c3_w pag_w, c3_z off_z)
        (ret_i = pread(img_u->fid_i, buf_y, _ce_page, off_z)) )
   {
     if ( 0 < ret_i ) {
-      fprintf(stderr, "loom: image (%s) fine partial read: %zu\r\n",
-                      img_u->nam_c, (size_t)ret_i);
+      fprintf(stderr, "loom: image fine partial read: %zu\r\n", (size_t)ret_i);
     }
     else {
-      fprintf(stderr, "loom: image (%s) fine read: %s\r\n",
-                      img_u->nam_c, strerror(errno));
+      fprintf(stderr, "loom: image fine read: %s\r\n", strerror(errno));
     }
     u3_assert(0);
   }
@@ -1130,9 +1126,9 @@ _ce_page_fine(u3e_image* img_u, c3_w pag_w, c3_z off_z)
     c3_w fas_w = _ce_muk_page(buf_y);
 
     if ( mas_w != fas_w ) {
-      fprintf(stderr, "loom: image (%s) mismatch: "
+      fprintf(stderr, "loom: image checksum mismatch: "
                       "page %d, mem_w %x, fil_w %x, K %x\r\n",
-                      img_u->nam_c, pag_w, mas_w, fas_w, u3K.has_w[pag_w]);
+                      pag_w, mas_w, fas_w, u3K.has_w[pag_w]);
       return c3n;
     }
   }
@@ -1179,9 +1175,7 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
   if (  (-1 == lseek(fom_u->fid_i, 0, SEEK_SET))
      || (-1 == lseek(tou_u->fid_i, 0, SEEK_SET)) )
   {
-    fprintf(stderr, "loom: image (%s) copy seek: %s\r\n",
-                    fom_u->nam_c,
-                    strerror(errno));
+    fprintf(stderr, "loom: image copy seek: %s\r\n", strerror(errno));
     return c3n;
   }
 
@@ -1193,29 +1187,27 @@ _ce_image_copy(u3e_image* fom_u, u3e_image* tou_u)
 
     if ( _ce_page != (ret_i = read(fom_u->fid_i, buf_y, _ce_page)) ) {
       if ( 0 < ret_i ) {
-        fprintf(stderr, "loom: image (%s) copy partial read: %zu\r\n",
-                        fom_u->nam_c, (size_t)ret_i);
+        fprintf(stderr, "loom: image copy partial read: %zu\r\n",
+                        (size_t)ret_i);
       }
       else {
-        fprintf(stderr, "loom: image (%s) copy read: %s\r\n",
-                        fom_u->nam_c, strerror(errno));
+        fprintf(stderr, "loom: image copy read: %s\r\n",
+                        strerror(errno));
       }
       return c3n;
     }
     else {
       if ( -1 == lseek(tou_u->fid_i, _ce_len(off_w), SEEK_SET) ) {
-        fprintf(stderr, "loom: image (%s) copy seek: %s\r\n",
-                        tou_u->nam_c, strerror(errno));
+        fprintf(stderr, "loom: image copy seek: %s\r\n", strerror(errno));
         return c3n;
       }
       if ( _ce_page != (ret_i = write(tou_u->fid_i, buf_y, _ce_page)) ) {
         if ( 0 < ret_i ) {
-          fprintf(stderr, "loom: image (%s) copy partial write: %zu\r\n",
-                          tou_u->nam_c, (size_t)ret_i);
+          fprintf(stderr, "loom: image copy partial write: %zu\r\n",
+                          (size_t)ret_i);
         }
         else {
-          fprintf(stderr, "loom: image (%s) copy write: %s\r\n",
-                          tou_u->nam_c, strerror(errno));
+          fprintf(stderr, "loom: image copy write: %s\r\n", strerror(errno));
         }
         fprintf(stderr, "info: you probably have insufficient disk space");
         return c3n;

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -879,7 +879,7 @@ _ce_loom_track_sane(void)
     bit_w = i_w & 31;
 
     if ( u3P.dit_w[blk_w] & ((c3_w)1 << bit_w) ) {
-      fprintf(stderr, "loom: insane north %u\r\n", i_w);
+      fprintf(stderr, "loom: insane image %u\r\n", i_w);
       san_o = c3n;
     }
   }
@@ -899,10 +899,10 @@ _ce_loom_track_sane(void)
   return san_o;
 }
 
-/* _ce_loom_track_north(): [pgs_w] clean, followed by [dif_w] dirty.
+/* _ce_loom_track(): [pgs_w] clean, followed by [dif_w] dirty.
 */
 void
-_ce_loom_track_north(c3_w pgs_w, c3_w dif_w)
+_ce_loom_track(c3_w pgs_w, c3_w dif_w)
 {
   c3_w blk_w, bit_w, i_w = 0, max_w = pgs_w;
 
@@ -921,16 +921,16 @@ _ce_loom_track_north(c3_w pgs_w, c3_w dif_w)
   }
 }
 
-/* _ce_loom_protect_north(): protect/track pages from the bottom of memory.
+/* _ce_loom_protect(): protect/track pages from the bottom of memory.
 */
 static void
-_ce_loom_protect_north(c3_w pgs_w, c3_w old_w)
+_ce_loom_protect(c3_w pgs_w, c3_w old_w)
 {
   c3_w dif_w = 0;
 
   if ( pgs_w ) {
     if ( 0 != mprotect(_ce_ptr(0), _ce_len(pgs_w), PROT_READ) ) {
-      fprintf(stderr, "loom: pure north (%u pages): %s\r\n",
+      fprintf(stderr, "loom: pure (%u pages): %s\r\n",
                       pgs_w, strerror(errno));
       u3_assert(0);
     }
@@ -943,7 +943,7 @@ _ce_loom_protect_north(c3_w pgs_w, c3_w old_w)
                        _ce_len(dif_w),
                        (PROT_READ | PROT_WRITE)) )
     {
-      fprintf(stderr, "loom: foul north (%u pages, %u old): %s\r\n",
+      fprintf(stderr, "loom: foul (%u pages, %u old): %s\r\n",
                       pgs_w, old_w, strerror(errno));
       u3_assert(0);
     }
@@ -960,7 +960,7 @@ _ce_loom_protect_north(c3_w pgs_w, c3_w old_w)
 #endif
   }
 
-  _ce_loom_track_north(pgs_w, dif_w);
+  _ce_loom_track(pgs_w, dif_w);
 }
 
 /* _ce_loom_mapf_ephemeral(): map entire loom into ephemeral file
@@ -980,11 +980,11 @@ _ce_loom_mapf_ephemeral(void)
   }
 }
 
-/* _ce_loom_mapf_north(): map [pgs_w] of [fid_i] into the bottom of memory
+/* _ce_loom_mapf(): map [pgs_w] of [fid_i] into the bottom of memory
 **                        (and ephemeralize [old_w - pgs_w] after if needed).
 */
 static void
-_ce_loom_mapf_north(c3_i fid_i, c3_w pgs_w, c3_w old_w)
+_ce_loom_mapf(c3_i fid_i, c3_w pgs_w, c3_w old_w)
 {
   c3_w dif_w = 0;
 
@@ -1041,13 +1041,13 @@ _ce_loom_mapf_north(c3_i fid_i, c3_w pgs_w, c3_w old_w)
 #endif
   }
 
-  _ce_loom_track_north(pgs_w, dif_w);
+  _ce_loom_track(pgs_w, dif_w);
 }
 
-/* _ce_loom_blit_north(): apply pages, in order, from the bottom of memory.
+/* _ce_loom_blit(): apply pages, in order, from the bottom of memory.
 */
 static void
-_ce_loom_blit_north(c3_i fid_i, c3_w pgs_w)
+_ce_loom_blit(c3_i fid_i, c3_w pgs_w)
 {
   c3_w    i_w;
   void* ptr_v;
@@ -1058,17 +1058,17 @@ _ce_loom_blit_north(c3_i fid_i, c3_w pgs_w)
 
     if ( _ce_page != (ret_zs = pread(fid_i, ptr_v, _ce_page, _ce_len(i_w))) ) {
       if ( 0 < ret_zs ) {
-        fprintf(stderr, "loom: blit north partial read: %"PRIc3_zs"\r\n",
+        fprintf(stderr, "loom: blit partial read: %"PRIc3_zs"\r\n",
                         ret_zs);
       }
       else {
-        fprintf(stderr, "loom: blit north read %s\r\n", strerror(errno));
+        fprintf(stderr, "loom: blit read %s\r\n", strerror(errno));
       }
       u3_assert(0);
     }
   }
 
-  _ce_loom_protect_north(pgs_w, 0);
+  _ce_loom_protect(pgs_w, 0);
 }
 
 #ifdef U3_SNAPSHOT_VALIDATION
@@ -1229,7 +1229,7 @@ u3e_backup(c3_c* pux_c, c3_c* pax_c, c3_o ovw_o)
   if (  (0 != access(nux_c, F_OK))
      || (_ce_img_good != _ce_image_open(&nux_u, pux_c)) )
   {
-    fprintf(stderr, "loom: couldn't open north image at %s\r\n", pux_c);
+    fprintf(stderr, "loom: couldn't open image at %s\r\n", pux_c);
     return c3n;
   }
 
@@ -1344,7 +1344,7 @@ u3e_save(u3_post low_p, u3_post hig_p)
   //    since total finery requires total cleanliness,
   //    pages of the image are protected twice.
   //
-  _ce_loom_protect_north(u3P.img_u.pgs_w, old_w);
+  _ce_loom_protect(u3P.img_u.pgs_w, old_w);
 
   u3_assert( c3y == _ce_loom_track_sane() );
   u3_assert( c3y == _ce_loom_fine() );
@@ -1352,11 +1352,11 @@ u3e_save(u3_post low_p, u3_post hig_p)
 
   if ( u3C.wag_w & u3o_no_demand ) {
 #ifndef U3_SNAPSHOT_VALIDATION
-    _ce_loom_protect_north(u3P.img_u.pgs_w, old_w);
+    _ce_loom_protect(u3P.img_u.pgs_w, old_w);
 #endif
   }
   else {
-    _ce_loom_mapf_north(u3P.img_u.fid_i, u3P.img_u.pgs_w, old_w);
+    _ce_loom_mapf(u3P.img_u.fid_i, u3P.img_u.pgs_w, old_w);
   }
 
   u3e_toss(low_p, hig_p);
@@ -1472,10 +1472,10 @@ u3e_live(c3_o nuu_o, c3_c* dir_c)
         }
 
         if ( u3C.wag_w & u3o_no_demand ) {
-          _ce_loom_blit_north(u3P.img_u.fid_i, u3P.img_u.pgs_w);
+          _ce_loom_blit(u3P.img_u.fid_i, u3P.img_u.pgs_w);
         }
         else {
-          _ce_loom_mapf_north(u3P.img_u.fid_i, u3P.img_u.pgs_w, 0);
+          _ce_loom_mapf(u3P.img_u.fid_i, u3P.img_u.pgs_w, 0);
         }
 
         u3l_log("boot: protected loom");

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -1141,6 +1141,7 @@ _ce_page_fine(u3e_image* img_u, c3_w pag_w, c3_z off_z)
 static c3_o
 _ce_loom_fine(void)
 {
+  c3_w off_w = u3R->hep.bot_p >> u3a_page;
   c3_w blk_w, bit_w, pag_w, i_w;
   c3_o fin_o = c3y;
 
@@ -1149,7 +1150,11 @@ _ce_loom_fine(void)
     blk_w = pag_w >> 5;
     bit_w = pag_w & 31;
 
-    if ( !(u3P.dit_w[blk_w] & ((c3_w)1 << bit_w)) ) {
+    if ( !(u3P.dit_w[blk_w] & ((c3_w)1 << bit_w))
+       && (  (pag_w < off_w)
+          || (u3R->hep.len_w <= (pag_w - off_w))
+          || (u3a_free_pg != (u3to(u3_post, u3R->hep.pag_p))[pag_w - off_w]) ) )
+    {
       fin_o = c3a(fin_o, _ce_page_fine(&u3P.img_u, pag_w, _ce_len(pag_w)));
     }
   }
@@ -1358,9 +1363,7 @@ u3e_save(u3_post low_p, u3_post hig_p)
     u3_assert( _ce_img_good == _ce_image_stat(&u3P.img_u, &pgs_w) );
     u3_assert( pgs_w == u3P.img_u.pgs_w );
   }
-#endif
 
-#ifdef U3_SNAPSHOT_VALIDATION
   //  check that all pages in the image are clean and *fine*,
   //  all others are dirty
   //

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -20,6 +20,7 @@
     */
       typedef struct _u3e_control {
         u3e_version ver_w;                  //  version number
+        c3_w        has_w;                  //  control checksum
         c3_w        tot_w;                  //  new page count
         c3_w        pgs_w;                  //  number of changed pages
         u3e_line    mem_u[];                //  per page

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -13,7 +13,7 @@
     */
       typedef struct _u3e_line {
         c3_w pag_w;
-        c3_w mug_w;
+        c3_w has_w;
       } u3e_line;
 
     /* u3e_control: memory change, control file.

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -20,8 +20,7 @@
     */
       typedef struct _u3e_control {
         u3e_version ver_w;                  //  version number
-        c3_w        nor_w;                  //  new page count north
-        c3_w        sou_w;                  //  new page count south
+        c3_w        tot_w;                  //  new page count
         c3_w        pgs_w;                  //  number of changed pages
         u3e_line    mem_u[];                //  per page
       } u3e_control;
@@ -51,8 +50,7 @@
         c3_w      dit_w[u3a_pages >> 5];     //  touched since last save
         c3_w      pag_w;                     //  number of pages (<= u3a_pages)
         c3_w      gar_w;                     //  guard page
-        u3e_image nor_u;                     //  north segment
-        u3e_image sou_u;                     //  south segment
+        u3e_image img_u;                     //  image
       } u3e_pool;
 
     /* u3e_flaw: loom fault result.

--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -1046,16 +1046,18 @@ u3h_take_with(u3p(u3h_root) har_p, u3_funk fun_f)
   u3h_root*     har_u = u3to(u3h_root, har_p);
   u3p(u3h_root) rah_p = u3h_new_cache(har_u->max_w);
   u3h_root*     rah_u = u3to(u3h_root, rah_p);
-  c3_w            i_w;
+  c3_w     sot_w, i_w;
 
   rah_u->use_w = har_u->use_w;
   rah_u->arm_u = har_u->arm_u;
 
   for ( i_w = 0; i_w < 64; i_w++ ) {
-    c3_w        sot_w = har_u->sot_w[i_w];
-    rah_u->sot_w[i_w] = ( c3y == u3h_slot_is_noun(sot_w) )
-                        ? _ch_take_noun(sot_w, fun_f)
-                        : _ch_take_node(sot_w, 25, fun_f);
+    sot_w = har_u->sot_w[i_w];
+    if ( c3n == u3h_slot_is_null(sot_w) ) {
+      rah_u->sot_w[i_w] = ( c3y == u3h_slot_is_noun(sot_w) )
+                          ? _ch_take_noun(sot_w, fun_f)
+                          : _ch_take_node(sot_w, 25, fun_f);
+    }
   }
 
   return rah_p;

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -572,25 +572,24 @@ _find_home(void)
   //  check for obvious corruption
   //
   if ( c3n == mig_o ) {
-    c3_w    nor_w, sou_w;
+    c3_w    nor_w;
     u3_post low_p, hig_p;
     u3m_water(&low_p, &hig_p);
 
     nor_w = (low_p + ((1 << u3a_page) - 1)) >> u3a_page;
-    sou_w = u3P.pag_w - (hig_p >> u3a_page);
 
-    if ( (nor_w > u3P.nor_u.pgs_w) || (sou_w != u3P.sou_u.pgs_w) ) {
-      fprintf(stderr, "loom: corrupt size north (%u, %u) south (%u, %u)\r\n",
-                      nor_w, u3P.nor_u.pgs_w, sou_w, u3P.sou_u.pgs_w);
+    if ( nor_w > u3P.img_u.pgs_w ) {
+      fprintf(stderr, "loom: corrupt size (%u, %u)\r\n",
+                      nor_w, u3P.img_u.pgs_w);
       u3_assert(!"loom: corrupt size");
     }
 
     //  the north segment is in-order on disk; it being oversized
     //  doesn't necessarily indicate corruption.
     //
-    if ( nor_w < u3P.nor_u.pgs_w ) {
+    if ( nor_w < u3P.img_u.pgs_w ) {
       fprintf(stderr, "loom: strange size north (%u, %u)\r\n",
-                      nor_w, u3P.nor_u.pgs_w);
+                      nor_w, u3P.img_u.pgs_w);
     }
 
     //  XX move me

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -511,17 +511,14 @@ _pave_parts(void)
 static void
 _pave_home(void)
 {
-  u3_post bot_p, top_p;
+  u3_post top_p = u3C.wor_i - u3a_walign;
+  u3_post bot_p = 1U << u3a_page;
 
-  bot_p = 1U << u3a_page;
-  top_p = u3C.wor_i - c3_wiseof(u3v_home);
-  u3H   = u3to(u3v_home, top_p);
-  top_p = u3C.wor_i - bot_p;
-
+  u3H = u3to(u3v_home, 0);
+  memset(u3H, 0, sizeof(u3v_home));
   u3H->ver_w = U3V_VERLAT;
   u3R = &u3H->rod_u;
 
-  memset(u3R, 0, sizeof(u3a_road));
   u3R->rut_p = u3R->hat_p = bot_p;
   u3R->mat_p = u3R->cap_p = top_p;
 
@@ -539,7 +536,7 @@ STATIC_ASSERT( ((c3_wiseof(u3v_home) * 4) == sizeof(u3v_home)),
 static void
 _find_home(void)
 {
-  c3_w ver_w = *(u3_Loom + u3C.wor_i - 1);
+  c3_w ver_w = *(u3_Loom);
   c3_o mig_o = c3y;  //  did we migrate?
 
   switch ( ver_w ) {
@@ -561,13 +558,9 @@ _find_home(void)
   //  NB: the home road is always north
   //
   {
-    u3_post bot_p, top_p;
+    u3_post top_p = u3C.wor_i - u3a_walign;
 
-    bot_p = 1U << u3a_page;
-    top_p = u3C.wor_i - c3_wiseof(u3v_home);
-    u3H   = u3to(u3v_home, top_p);
-    top_p = u3C.wor_i - bot_p;
-
+    u3H = u3to(u3v_home, 0);
     u3R = &u3H->rod_u;
 
     //  this looks risky, but there are no legitimate scenarios

--- a/pkg/noun/version.h
+++ b/pkg/noun/version.h
@@ -18,7 +18,8 @@ typedef c3_w       u3v_version;
 typedef c3_w       u3e_version;
 
 #define U3P_VER1   1
-#define U3P_VERLAT U3P_VER1
+#define U3P_VER2   2
+#define U3P_VERLAT U3P_VER2
 
 /* DISK FORMAT
  *

--- a/pkg/noun/vortex.h
+++ b/pkg/noun/vortex.h
@@ -13,7 +13,7 @@
     /* u3v_arvo: modern arvo structure.
     **       NB: packed to perserve word alignment given [eve_d]
     */
-      typedef struct __attribute__((__packed__)) _u3v_arvo {
+      typedef struct _u3v_arvo {
         c3_d  eve_d;                      //  event number
         u3_noun yot;                      //  cached gates
         u3_noun now;                      //  current time
@@ -24,9 +24,9 @@
     **       NB: version must be last for discriminability in north road
     */
       typedef struct _u3v_home {
+        u3v_version ver_w;                //  version number
         u3a_road    rod_u;                //  storage state
         u3v_arvo    arv_u;                //  arvo state
-        u3v_version ver_w;                //  version number
       } u3v_home;
 
 


### PR DESCRIPTION
This PR is based on and targets #812. It also includes a copy of #825, as that fix is necessary for the relocated home road to not interfere with inner-road promotion. It implements "option 2" from https://github.com/urbit/vere/issues/451#issuecomment-1591719816.

Moving the home road makes sense given #812, as it requires that the entire first page be reserved from the heap. Once the road home is moved, there's no reason for the snapshot to consist of two separage memory-image segments, as only the bottom of the loom needs to be preserved. This simplifies the snapshot system by removing much of the complicated, direction-switching redundancy in its implementation, and simplifies the handling of snapshots themselves as they are now a single file.

Since these changes require a snapshot-system migration, I've taken the opportunity to add and verify a top-level checksum for all snapshot patch metadata.