### PR TITLE
u3: remove unnecessary refcount operations (losing u3_none)

### DIFF
--- a/pkg/noun/jets.c
+++ b/pkg/noun/jets.c
@@ -327,7 +327,7 @@ _cj_install(u3j_core* ray_u, c3_w jax_l, u3_noun pel, u3_noun lab, u3j_core* dev
         c3_w j_w;
         for ( j_w = 0; 0 != kid_u->bas_u[j_w]; j_w++ ) {
           u3_noun key = _cj_hash(kid_u->bas_u[j_w]),
-                  hot = u3h_get(u3R->jed.hot_p, key),
+                  hot = u3h_git(u3R->jed.hot_p, key),
                   old = ( u3_none == hot ) ? u3_none : u3k(u3h(hot)),
                   reg = _cj_gust(old, kid_u->axe_l, u3k(pel), u3k(loc)),
                   huc = u3t(u3t(loc)),
@@ -335,7 +335,7 @@ _cj_install(u3j_core* ray_u, c3_w jax_l, u3_noun pel, u3_noun lab, u3j_core* dev
                   toh = u3nq(reg, jax_l, hap, u3k(bal));
 
           u3h_put(u3R->jed.hot_p, key, toh);
-          u3z(key); u3z(hot);
+          u3z(key);
         }
       }
 
@@ -1445,7 +1445,7 @@ u3j_site_merge(u3j_site* dst_u, u3j_site* src_u)
   dst_u->axe = src_u->axe;
 
   if ( u3_none != src_u->loc ) {
-    u3z(dst_u->loc);
+    u3z(dst_u->loc);  //  XX these may be u3_none
     u3z(dst_u->lab);
     dst_u->loc   = src_u->loc;
     dst_u->lab   = src_u->lab;

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -2441,7 +2441,7 @@ _n_burn(u3n_prog* pog_u, u3_noun bus, c3_ys mov, c3_ys off)
       o     = *top;
       *top = _n_kick(o, sit_u);
       if ( u3_none == *top ) {
-        _n_toss(mov, off);
+        _n_pop(mov);
 
         fam         = u3to(burnframe, u3R->cap_p) + off + mov;
         u3R->cap_p  = u3of(burnframe, fam - off);


### PR DESCRIPTION
`u3k()` / `u3a_gain()` asserts that a noun reference is not `u3_none`, while `u3z()` / `u3a_lose()` does not. Neither needs -- they will both safely no-op given `u3_none` (due to the `..._is_normal()` conditions inside their implementation functions). The inconsistency here makes for inconsistent code -- the presence of `u3z(u3_none)` may indicate misconceived refcount handling.

This PR does not resolve the overall issue. It just corrects a couple cases by removing unneeded refcount operations and notes another.