### PR TITLE
Revert "nock: lose subject in autocons more eagerly"

### DIFF
--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -409,8 +409,8 @@ _n_nock_on(u3_noun bus, u3_noun fol)
   X(SWAP, "swap", &&do_swap),  /*  3 */                                        \
   X(TOSS, "toss", &&do_toss),  /*  4 */                                        \
   /* auto-cons */                                                              \
-  X(AUTO, "auto", &&do_auto),  /*  5: kept */                                  \
-  X(AULT, "ault", &&do_ault),  /*  6: lost */                                  \
+  X(AUTO, "auto", &&do_auto),  /*  5: keep */                                  \
+  X(AULT, "ault", &&do_ault),  /*  6: lose */                                  \
   /* general purposes */                                                       \
   X(SNOC, "snoc", &&do_snoc),  /*  7: keep */                                  \
   X(SNOL, "snol", &&do_snol),  /*  8: lose */                                  \
@@ -1230,7 +1230,7 @@ _n_comp(u3_noun* ops, u3_noun fol, c3_o los_o, c3_o tel_o)
   if ( c3y == u3du(cod) ) {
     tot_w += _n_comp(ops, cod, c3n, c3n);
     ++tot_w; _n_emit(ops, SWAP);
-    tot_w += _n_comp(ops, arg, los_o, c3n);
+    tot_w += _n_comp(ops, arg, c3n, c3n);
     ++tot_w; _n_emit(ops, (c3y == los_o ) ? AULT : AUTO);
   }
   else switch ( cod ) {
@@ -2131,8 +2131,9 @@ _n_burn(u3n_prog* pog_u, u3_noun bus, c3_ys mov, c3_ys off)
       *top = u3nc(*top, x);          // [pro bus]
       BURN();
 
-    do_ault:                         // [tel hed]
-      x    = _n_pep(mov, off);       // [hed]
+    do_ault:                         // [tel bus hed]
+      x    = _n_pep(mov, off);       // [bus hed]
+      _n_toss(mov, off);             // [hed]
       top  = _n_peek(off);
       *top = u3nc(*top, x);          // [pro]
       BURN();


### PR DESCRIPTION
Reverts urbit/vere#827

This PR causes an instant segfault in the serf after upgrading on `~dinleb-rambep`, `~norsyr-torryn` and probably all pre-existing ships. The segfault has the following stacktrace:

```
urbit 3.4-0969b6de10
boot: home is /root/dinleb-rambep
disk: loaded epoch 0i575532513
loom: mapped 2048MB
boot: protected loom
live: mapped: GB/1.945.878.528
live: loaded: KB/16.384
boot: installed 1362 jets
loom: image backup complete
disk: created epoch 575532513
loom: mapped 2048MB
lite: arvo formula 4ce68411
lite: core 641296f
lite: final state 641296f
disk: loaded epoch 0i575532513
loom: mapped 2048MB
boot: protected loom
live: mapped: GB/1.945.878.528
live: loaded: KB/16.384
boot: installed 1362 jets
vere: checking version compatibility
loom: external fault: 0 (0x200000000 : 0x280000000)

Breakpoint 1, u3m_fault (adr_v=0x0, ser_i=<optimized out>) at pkg/noun/manage.c:1967
1967	pkg/noun/manage.c: No such file or directory.
(gdb) bt
#0  u3m_fault (adr_v=0x0, ser_i=<optimized out>) at pkg/noun/manage.c:1967
#1  0x00000000014b9544 in sigsegv_handler (sig=<optimized out>, sip=<optimized out>, ucp=0x1840b40 <Sigstk+6896>) at /home/runner/.cache/zig/p/N-V-__8AAHQhHwCCMyKUtQhO0AMsY182In-wQIwXVhenOql5/src/handler-unix.c:269
#2  <signal handler called>
#3  _n_burn (pog_u=0x1ffffe121ffffe5a, bus=<optimized out>, mov=1 '\001', off=-1 '\377') at pkg/noun/nock.c:2100
#4  0x0000000001273653 in _n_burn_out (bus=1950065936, pog_u=0x1fffffff4) at pkg/noun/nock.c:2814
#5  _n_burn_on (bus=1950065936, bus@entry=3460980861, fol=<optimized out>) at pkg/noun/nock.c:2837
#6  u3n_nock_on (bus=1950065936, bus@entry=3460980861, fol=<optimized out>) at pkg/noun/nock.c:2851
#7  0x0000000001271938 in u3v_poke_raw (sam=50403342) at pkg/noun/vortex.c:293
#8  u3v_poke (ovo=ovo@entry=3459182210) at pkg/noun/vortex.c:285
#9  0x0000000001262948 in u3m_soft_top (mil_w=mil_w@entry=0, pad_w=pad_w@entry=1048576, fun_f=0x12718d0 <u3v_poke>, arg=3459182210) at pkg/noun/manage.c:1311
#10 0x00000000012630ad in u3m_soft (mil_w=4294967284, mil_w@entry=0, fun_f=0x1d0ee947, arg=1950064560) at pkg/noun/manage.c:1577
#11 0x000000000161888d in _serf_poke (sef_u=<optimized out>, cap_c=<optimized out>, mil_w=0, job=job@entry=3455400141) at pkg/vere/serf.c:556
#12 0x0000000001617804 in _serf_work (sef_u=0x183ec20 <u3V>, mil_w=0, job=3455400141) at pkg/vere/serf.c:604
#13 u3_serf_work (sef_u=sef_u@entry=0x183ec20 <u3V>, mil_w=mil_w@entry=0, job=3455400141) at pkg/vere/serf.c:692
#14 0x0000000001618666 in u3_serf_writ (sef_u=0x183ec20 <u3V>, wit=3462698097, pel=pel@entry=0x7fffffff9a0c) at pkg/vere/serf.c:1160
#15 0x000000000126141d in _cw_serf_writ (vod_p=<optimized out>, len_d=113, byt_y=0x7ffff7ff8780 "\001\377\356Mn\235\001\b") at pkg/vere/main.c:1079
#16 0x00000000014ddf08 in _newt_meat_poke (mot_u=0x183ed90 <inn_u>, met_u=0x7ffff7ff8770) at pkg/vere/newt.c:62
#17 _newt_meat_next_sync (mot_u=0x183ed90 <inn_u>) at pkg/vere/newt.c:75
#18 _newt_read_sync_cb (str_u=0x183ed90 <inn_u>, len_i=<optimized out>, buf_u=<optimized out>) at pkg/vere/newt.c:236
#19 0x00000000014ccfe7 in uv__read (stream=0x183ed90 <inn_u>) at /home/runner/.cache/zig/p/N-V-__8AAH34QwB6wi5eQK_lFbfDGSN3hRE8l-6Ep198ZsGg/src/unix/stream.c:1148
#20 uv__stream_io (loop=<optimized out>, w=0x183ee18 <inn_u+136>, events=1) at /home/runner/.cache/zig/p/N-V-__8AAH34QwB6wi5eQK_lFbfDGSN3hRE8l-6Ep198ZsGg/src/unix/stream.c:1208
#21 0x00000000014c6b94 in uv__io_poll (loop=loop@entry=0x1864148 <default_loop_struct>, timeout=-1) at /home/runner/.cache/zig/p/N-V-__8AAH34QwB6wi5eQK_lFbfDGSN3hRE8l-6Ep198ZsGg/src/unix/linux.c:1565
#22 0x00000000014c31f1 in uv_run (loop=loop@entry=0x1864148 <default_loop_struct>, mode=mode@entry=UV_RUN_DEFAULT) at /home/runner/.cache/zig/p/N-V-__8AAH34QwB6wi5eQK_lFbfDGSN3hRE8l-6Ep198ZsGg/src/unix/core.c:460
#23 0x000000000125e791 in _cw_serf_commence (argc=<optimized out>, argv=<optimized out>) at pkg/vere/main.c:1299
#24 _cw_utils (argc=argc@entry=11, argv=argv@entry=0x7fffffffdf08) at pkg/vere/main.c:3250
#25 0x000000000125c7d9 in main (argc=11, argv=0x7fffffffdf08) at pkg/vere/main.c:3275
```

@Quodss @joemfb 