### PR TITLE
Better error message for bad moon keys

### DIFF
--- a/pkg/vere/dawn.c
+++ b/pkg/vere/dawn.c
@@ -316,7 +316,7 @@ u3_dawn_vent(u3_noun ship, u3_noun feed)
          c3n == u3a_is_cell(u3h(feed)) &&
          c3__earl == rank ) {
       // bails, won't return
-      u3l_log("boot: Incorrect keyfile please use updated format");
+      u3l_log("boot: incorrect keyfile please use updated format");
       _dawn_fail(ship, rank, u3_nul);
       return u3_none;
     }

--- a/pkg/vere/dawn.c
+++ b/pkg/vere/dawn.c
@@ -327,7 +327,6 @@ u3_dawn_vent(u3_noun ship, u3_noun feed)
 
     if ( c3n == u3h(sed) ) {
       // bails, won't return
-      u3l_log("boot: wrong keyform");
       _dawn_fail(ship, rank, u3t(sed));
       return u3_none;
     }

--- a/pkg/vere/dawn.c
+++ b/pkg/vere/dawn.c
@@ -312,12 +312,22 @@ u3_dawn_vent(u3_noun ship, u3_noun feed)
 
     u3l_log("boot: verifying keys");
 
+    if ( c3y == u3a_is_cell(feed) && 
+         c3n == u3a_is_cell(u3h(feed)) &&
+         c3__earl == rank ) {
+      // bails, won't return
+      u3l_log("boot: Incorrect keyfile please use updated format");
+      _dawn_fail(ship, rank, u3_nul);
+      return u3_none;
+    }
+
     //  (each seed (lest error=@tas))
     //
     sed = u3dq("veri:dawn", u3k(ship), u3k(feed), u3k(pot), u3k(liv));
 
     if ( c3n == u3h(sed) ) {
       // bails, won't return
+      u3l_log("boot: wrong keyform");
       _dawn_fail(ship, rank, u3t(sed));
       return u3_none;
     }


### PR DESCRIPTION
Added Check of +.feed to make sure its a cell, if its a cell and a moon we crash before running

`+veri:dawn`

Resolves #818 
