### PR TITLE
lmdb: fix undefined behavior (load of misaligned address)

### DIFF
--- a/pkg/vere/db/lmdb.c
+++ b/pkg/vere/db/lmdb.c
@@ -305,7 +305,7 @@ u3_lmdb_read(MDB_env* env_u,
 
         //  sanity check: ensure contiguous event numbers
         //
-        if ( *(c3_d*)key_u.mv_data != cur_d ) {
+        if ( c3_sift_chub(key_u.mv_data) != cur_d ) {
           fprintf(stderr, "lmdb: read gap: expected %" PRIu64
                           ", received %" PRIu64 "\r\n",
                           cur_d,


### PR DESCRIPTION
Addresses:

> /Users/matt/src/urbit/vere/pkg/vere/db/lmdb.c:308:14: runtime error: load of misaligned address 0x007000017fbe for type 'c3_d' (aka 'unsigned long long'), which requires 8 byte alignment
0x007000017fbe: note: pointer points here
00 00 08 00 01 00 00 00 00 00 00 00 00 00 00 00 41 b0 26 0b 59 a2 13 59 62 26 6e 93 c5 61 17 76
^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/matt/src/urbit/vere/pkg/vere/db/lmdb.c:308:14