### PR TITLE
Do not abort process on bad %slog

### DIFF
--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -293,6 +293,10 @@ _lord_plea_slog(u3_lord* god_u, u3_noun dat)
   {
     god_u->cb_u.slog_f(god_u->cb_u.ptr_v, pri_w, u3k(tan));
   }
+  else
+  {
+    u3l_log("%%bad-slog");
+  }
   u3z(dat);
 }
 

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1358,6 +1358,7 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
     }
   }
 
+  c3_t bad_t = 0;
   //  if we have no arvo kernel and can't evaluate nock
   //  only print %leaf tanks
   //
@@ -1368,10 +1369,15 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
   }
   else {
     u3_noun low = u3dc("(slum soft wash)", u3nc(tab_l, col_l), u3k(tac));
-    if (u3_nul != low)
-    {
-      _pier_dump_wall(fil_u, u3k(u3t(low)));
-      u3z(low);
+    u3_noun wol;
+    if (c3y == u3r_cell(low, NULL, &wol)) {
+      u3k(wol); u3z(low);
+      _pier_dump_wall(fil_u, wol);
+    }
+    else {
+      // low == u3_nul, no need to lose it
+      //
+      bad_t = 1;
     }
   }
 
@@ -1384,6 +1390,10 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
   u3_term_io_loja(0, fil_u);
   u3z(blu);
   u3z(tac);
+  
+  if ( bad_t ) {
+    u3l_log("%%slog-bad-tank");
+  }
 }
 
 /* u3_pier_punt(): dump tank list.


### PR DESCRIPTION
Actually resolves #558.

`_lord_plea_slog` just ignores malformed hint value instead of killing the process, and `u3_pier_tank` virtualizes tank rendering.

I don't like that `+wash` call has to be virtualized to avoid aborting the process, since it somehow runs on the home road. Why would that happen? Is it intentional?