### PR TITLE
build: update zlib dependency for zig 0.14

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -54,8 +54,8 @@
             .path = "./ext/whereami",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/0918e87b7629b9c6a50a08edd0ce30d849758faf.tar.gz",
-            .hash = "zlib-1.3.1-AAAAACEMAAA0qyoSrfgBb_p25ItL4yRf_TBRk-26TYMF",
+            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
+            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
         },
         .wasm3 = .{
             .path = "./ext/wasm3",

--- a/ext/h2o/build.zig.zon
+++ b/ext/h2o/build.zig.zon
@@ -16,8 +16,8 @@
             .path = "../curl",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/0918e87b7629b9c6a50a08edd0ce30d849758faf.tar.gz",
-            .hash = "zlib-1.3.1-AAAAACEMAAA0qyoSrfgBb_p25ItL4yRf_TBRk-26TYMF",
+            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
+            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
         },
         .sse2neon = .{
             .url = "https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.5.1.tar.gz",

--- a/pkg/noun/build.zig.zon
+++ b/pkg/noun/build.zig.zon
@@ -50,8 +50,8 @@
             .path = "../../ext/whereami",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/0918e87b7629b9c6a50a08edd0ce30d849758faf.tar.gz",
-            .hash = "zlib-1.3.1-AAAAACEMAAA0qyoSrfgBb_p25ItL4yRf_TBRk-26TYMF",
+            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
+            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
         },
         .wasm3 = .{
             .path = "../../ext/wasm3",

--- a/pkg/vere/build.zig.zon
+++ b/pkg/vere/build.zig.zon
@@ -47,8 +47,8 @@
             .path = "../../ext/urcrypt",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/0918e87b7629b9c6a50a08edd0ce30d849758faf.tar.gz",
-            .hash = "zlib-1.3.1-AAAAACEMAAA0qyoSrfgBb_p25ItL4yRf_TBRk-26TYMF",
+            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
+            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
         },
     },
     .paths = .{


### PR DESCRIPTION
Otherwise zlib is fetched all the time for no reason, see https://github.com/ziglang/zig/issues/23051 for details.