### PR TITLE
vere: refactor mars + persistence for migration

### DIFF
--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -370,6 +370,25 @@ _ce_image_open(u3e_image* img_u, c3_c* ful_c)
   return _ce_image_stat(img_u, &img_u->pgs_w);
 }
 
+c3_i
+u3e_image_open_any(c3_c* nam_c, c3_c* dir_c, c3_z* len_z)
+{
+  u3e_image img_u = { .nam_c = nam_c };
+
+  switch ( _ce_image_open(&img_u, dir_c) ) {
+    case _ce_img_good: {
+      *len_z = _ce_len(img_u.pgs_w);
+      return img_u.fid_i;
+    } break;
+
+    case _ce_img_fail:
+    case _ce_img_size: {
+      *len_z = 0;
+      return -1;
+    } break;
+  }
+}
+
 /* _ce_patch_write_control(): write control block file.
 */
 static void

--- a/pkg/noun/events.h
+++ b/pkg/noun/events.h
@@ -125,4 +125,7 @@
       void
       u3e_ward(u3_post low_p, u3_post hig_p);
 
+      c3_i
+      u3e_image_open_any(c3_c* nam_c, c3_c* dir_c, c3_z* len_z);
+
 #endif /* ifndef U3_EVENTS_H */

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1,9 +1,6 @@
 /// @file
 
 #include "manage.h"
-// #include "v2/manage.h"
-// #include "v3/manage.h"
-// #include "v4/manage.h"
 
 #include <ctype.h>
 #include <dlfcn.h>
@@ -543,22 +540,12 @@ static void
 _find_home(void)
 {
   c3_d ver_d = *((c3_d*)u3_Loom);
-  c3_o mig_o = c3y;  //  did we migrate?
 
-  switch ( ver_d ) {
-    // case U3V_VER1: u3m_v2_migrate();
-    // case U3V_VER2: u3m_v3_migrate();
-    // case U3V_VER3: u3m_v4_migrate();
-    case U3V_VER4: {
-      mig_o = c3n;
-      break;
-    }
-    default: {
-      fprintf(stderr, "loom: checkpoint version mismatch: "
-                      "have %" PRIu64 ", need %" PRIu64 "\r\n",
-                      ver_d, U3V_VERLAT);
-      abort();
-    }
+  if ( ver_d != U3V_VERLAT ) {
+    fprintf(stderr, "loom: checkpoint version mismatch: "
+                    "have %" PRIu64 ", need %" PRIu64 "\r\n",
+                    ver_d, U3V_VERLAT);
+    abort();
   }
 
   //  NB: the home road is always north
@@ -577,7 +564,7 @@ _find_home(void)
 
   //  check for obvious corruption
   //
-  if ( c3n == mig_o ) {
+  {
     c3_w    nor_w;
     u3_post low_p, hig_p;
     u3m_water(&low_p, &hig_p);

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -45,7 +45,8 @@
         u3o_soft_mugs     = 1 << 11,          //  continue replay on mismatch
         u3o_swap          = 1 << 12,          //  enables ephemeral file
         u3o_toss          = 1 << 13,          //  reclaim often
-        u3o_cash          = 1 << 14           //  memo cache harvesting
+        u3o_cash          = 1 << 14,          //  memo cache harvesting
+        u3o_yolo          = 1 << 15           //  no brakes!
       };
 
   /** Globals.

--- a/pkg/noun/version.h
+++ b/pkg/noun/version.h
@@ -1,42 +1,35 @@
 #ifndef U3_VERSION_H
 #define U3_VERSION_H
 
-/* VORTEX
+/*  loom layout
  */
-
 typedef c3_d       u3v_version;
 
-#define U3V_VER1   (u3v_version)1
-#define U3V_VER2   (u3v_version)2
-#define U3V_VER3   (u3v_version)3
-#define U3V_VER4   (u3v_version)4
-#define U3V_VERLAT U3V_VER4
+#define U3V_VER1   (u3v_version)1  //  1.0
+#define U3V_VER2   (u3v_version)2  //  2.0:    pointer compression
+#define U3V_VER3   (u3v_version)3  //  3.0-rc: persistent memoization
+#define U3V_VER4   (u3v_version)4  //  3.0:    bytecode alignment
+#define U3V_VER5   (u3v_version)5  //  ??      palloc
+#define U3V_VERLAT U3V_VER5
 
-/* PATCHES
+/*  snapshot patch format
  */
-
 typedef c3_w       u3e_version;
 
-#define U3P_VER1   (u3e_version)1
-#define U3P_VER2   (u3e_version)2
+#define U3P_VER2   (u3e_version)2  //  top-level checksum added
 #define U3P_VERLAT U3P_VER2
 
-/* DISK FORMAT
- *
- * synchronized between:
- * - u3_disk->ver_w
- * - version key in META table of data.mdb files
+/*  top-level event log format
  */
-
-#define U3D_VER1   1         // <= vere-v2
-#define U3D_VER2   2         // migrating to >= vere-v3
-#define U3D_VER3   3         // >= vere-v3
+#define U3D_VER1   1               //  <= 2.0
+#define U3D_VER2   2               //  migration to 3.0 in-progress
+#define U3D_VER3   3               //  3.0 (epoch system)
 #define U3D_VERLAT U3D_VER3
 
-/* EPOCH SYSTEM
+/*  epoch layout
 */
-
-#define U3E_VER1   1
-#define U3E_VERLAT U3E_VER1
+#define U3E_VER1   1               //  north+south.bin
+#define U3E_VER2   2               //  image.bin
+#define U3E_VERLAT U3E_VER2
 
 #endif /* ifndef U3_VERSION_H */

--- a/pkg/past/migrate_v5.c
+++ b/pkg/past/migrate_v5.c
@@ -4,7 +4,7 @@
 static c3_d
 _v4_hash(u3_noun foo)
 {
-  return u3r_v4_mug(foo) * 11400714819323198485ULL;
+  return foo * 11400714819323198485ULL;
 }
 
 static c3_i
@@ -145,7 +145,9 @@ u3_migrate_v5(void)
   cop_u.ham_p = u3R_v5->cax.per_p;
   u3h_v4_walk_with(u3R_v4->cax.per_p, _copy_v4_hamt, &cop_u);
 
-  u3j_v5_boot(c3n);
+  //  NB: pave does *not* allocate hot_p
+  //
+  u3j_v5_boot(c3y);
   u3j_v5_ream();
 
   vt_cleanup(&cop_u.map_u);

--- a/pkg/past/v1.c
+++ b/pkg/past/v1.c
@@ -621,3 +621,16 @@ u3_v1_load(c3_z wor_i)
 
   u3R_v1->cap_p = u3R_v1->mat_p = u3a_v1_outa(u3H_v1);
 }
+
+
+/***  manage.c
+***/
+
+void
+u3m_v1_reclaim(void)
+{
+  u3v_v1_reclaim();
+  u3j_v1_reclaim();
+  u3n_v1_reclaim();
+  u3a_v1_reclaim();
+}

--- a/pkg/past/v4.c
+++ b/pkg/past/v4.c
@@ -4,16 +4,9 @@
 
   /***  current
   ***/
-
-#     define  u3_v4_cell          u3_v5_cell
-#     define  u3_v4_noun          u3_v5_noun
-
-#     define  u3a_v4_is_atom          u3a_v5_is_atom
 #     define  u3a_v4_is_pom           u3a_v5_is_pom
 #     define  u3a_v4_north_is_normal  u3a_v5_north_is_normal
 #     define  u3n_v4_prog             u3n_v5_prog
-#     define  u3r_v4_mug_both         u3r_v5_mug_both
-#     define  u3r_v4_mug_words        u3r_v5_mug_words
 
 #     define  u3a_v4_boxed(len_w)  (len_w + c3_wiseof(u3a_v4_box) + 1)
 #     define  u3a_v4_boxto(box_v)  ( (void *) \
@@ -800,117 +793,6 @@ u3m_v4_reclaim(void)
   //  NB: subset: u3a and u3v excluded
   u3j_v4_reclaim();
   u3n_v4_reclaim();
-}
-
-  /***  retrieve.c
-  ***/
-
-typedef struct {
-  c3_l     mug_l;
-  u3_v4_cell cel;
-} _cr_mugf;
-
-typedef struct {
-  c3_w    len_w;
-  c3_w    siz_w;
-  _cr_mugf *tac;
-} _cr_mug_ctx;
-
-/* _cr_v4_mug_next(): advance mug calculation, pushing cells onto the stack.
-*/
-static inline c3_l
-_cr_v4_mug_next(_cr_mug_ctx* ctx_u, u3_v4_noun veb)
-{
-  while ( 1 ) {
-    //  veb is a direct atom, mug is not memoized
-    //
-    if ( c3y == u3a_v4_is_cat(veb) ) {
-      return (c3_l)u3r_v4_mug_words(&veb, 1);
-    }
-    //  veb is indirect, a pointer into the loom
-    //
-    else {
-      u3a_v4_noun* veb_u = u3a_v4_to_ptr(veb);
-
-      //  veb has already been mugged, return memoized value
-      //
-      //    XX add debug assertion that mug is 31-bit?
-      //
-      if ( veb_u->mug_w ) {
-        return (c3_l)veb_u->mug_w;
-      }
-      //  veb is an indirect atom, mug its bytes and memoize
-      //
-      else if ( c3y == u3a_v4_is_atom(veb) ) {
-        u3a_v4_atom* vat_u = (u3a_v4_atom*)veb_u;
-        c3_l         mug_l = u3r_v4_mug_words(vat_u->buf_w, vat_u->len_w);
-        vat_u->mug_w = mug_l;
-        return mug_l;
-      }
-      //  veb is a cell, push a stack frame to mark head-recursion
-      //  and read the head
-      //
-      else {
-        u3a_v4_cell* cel_u = (u3a_v4_cell*)veb_u;
-
-        if ( ctx_u->len_w == ctx_u->siz_w ) {
-          ctx_u->siz_w += c3_min(ctx_u->siz_w, 1024);
-          ctx_u->tac    = c3_realloc(ctx_u->tac, sizeof(*ctx_u->tac) * ctx_u->siz_w);
-        }
-
-        _cr_mugf *fam_u = &(ctx_u->tac[ctx_u->len_w++]);
-        fam_u->mug_l = 0;
-        fam_u->cel   = veb;
-
-        veb = cel_u->hed;
-        continue;
-      }
-    }
-  }
-}
-
-/* u3r_v4_mug(): statefully mug a noun with 31-bit murmur3.
-*/
-c3_l
-u3r_v4_mug(u3_noun veb)
-{
-  _cr_mug_ctx  ctx_u = {0};
-  _cr_mugf    *fam_u;
-  u3a_v4_cell *cel_u;
-  c3_l         mug_l;
-
-  ctx_u.siz_w = 4;
-  ctx_u.tac   = c3_malloc(sizeof(*ctx_u.tac) * ctx_u.siz_w);
-
-  //  commence mugging
-  //
-  mug_l = _cr_v4_mug_next(&ctx_u, veb);
-
-  //  process cell results
-  //
-  while ( ctx_u.len_w ) {
-    fam_u = &(ctx_u.tac[ctx_u.len_w - 1]);
-
-    //  head-frame: stash mug and continue into the tail
-    //
-    if ( !fam_u->mug_l ) {
-      cel_u = u3a_v4_to_ptr(fam_u->cel);
-      fam_u->mug_l = mug_l;
-      mug_l = _cr_v4_mug_next(&ctx_u, cel_u->tel);
-    }
-    //  tail-frame: calculate/memoize cell mug and pop the stack
-    //
-    else {
-      cel_u = u3a_v4_to_ptr(fam_u->cel);
-      mug_l = u3r_v4_mug_both(fam_u->mug_l, mug_l);
-      cel_u->mug_w = mug_l;
-      ctx_u.len_w--;
-    }
-  }
-
-  c3_free(ctx_u.tac);
-
-  return mug_l;
 }
 
 /***  init

--- a/pkg/past/v4.c
+++ b/pkg/past/v4.c
@@ -21,6 +21,9 @@
 #     define  u3a_v4_botox(tox_v)  ( (u3a_v4_box *)(void *)(tox_v) - 1 )
 #     define  u3h_v4_slot_to_node(sot)  (u3a_v4_into(((sot) & 0x3fffffff) << u3a_v4_vits))
 
+u3a_v4_road* u3a_v4_Road;
+u3v_v4_home* u3v_v4_Home;
+
 /***  allocate.c
 ***/
 

--- a/pkg/past/v4.h
+++ b/pkg/past/v4.h
@@ -209,11 +209,6 @@
         void
         u3m_v4_reclaim(void);
 
-  /***  retrieve.h
-  ***/
-        c3_l
-        u3r_v4_mug(u3_v4_noun);
-
   /***  vortex.h
   ***/
       typedef struct __attribute__((__packed__)) _u3v_v4_arvo {

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -965,10 +965,10 @@ _disk_epoc_meta(u3_disk*    log_u,
   return c3y;
 }
 
-/* u3_disk_epoc_zero: make epoch zero.
+/* _disk_epoc_zero: make epoch zero.
 */
-c3_o
-u3_disk_epoc_zero(c3_c* pax_c)
+static c3_o
+_disk_epoc_zero(c3_c* pax_c)
 {
   //  create new epoch directory if it doesn't exist
   c3_c epo_c[8193];
@@ -1311,7 +1311,7 @@ static c3_o
 _disk_migrate(u3_disk* log_u, c3_d eve_d)
 {
   /*  migration steps:
-   *  1. initialize epoch 0i0 (see u3_disk_epoc_zero)
+   *  1. initialize epoch 0i0 (see _disk_epoc_zero)
    *  2. create hard links to data.mdb and lock.mdb in 0i0/
    *  3. use scratch space to initialize new log/data.db in log/tmp
    *  4. save old metadata to new db in scratch space
@@ -1344,7 +1344,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
   fprintf(stderr, "disk: migrating disk to v%d format\r\n", U3D_VERLAT);
 
   //  initialize first epoch "0i0"
-  if ( c3n == u3_disk_epoc_zero(log_u->com_u->pax_c) ) {
+  if ( c3n == _disk_epoc_zero(log_u->com_u->pax_c) ) {
     fprintf(stderr, "disk: failed to initialize first epoch\r\n");
     return c3n;
   }
@@ -1823,7 +1823,7 @@ u3_disk_make(c3_c* pax_c)
 
     //  make epoch zero
     //
-    if ( c3n == u3_disk_epoc_zero(log_c) ) {
+    if ( c3n == _disk_epoc_zero(log_c) ) {
       fprintf(stderr, "disk: failed to make epoch zero\r\n");
       return c3n;
     }

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1768,7 +1768,7 @@ u3_disk_make(c3_c* pax_c)
   //
   {
     if (  ( -1 == c3_mkdir(pax_c, 0700) )
-       && ( EEXIST != errno ) )
+       && ( EEXIST != errno ) ) // XX remove
     {
       fprintf(stderr, "disk: failed to make pier at %s\r\n", pax_c);
       return c3n;
@@ -1783,7 +1783,7 @@ u3_disk_make(c3_c* pax_c)
     strcat(urb_c, "/.urb");
 
     if (  ( -1 == c3_mkdir(urb_c, 0700) )
-       && ( EEXIST != errno ) )
+       && ( EEXIST != errno ) ) // XX remove
     {
       fprintf(stderr, "disk: failed to make /.urb in %s\r\n", pax_c);
       c3_free(urb_c);
@@ -1815,7 +1815,7 @@ u3_disk_make(c3_c* pax_c)
     snprintf(log_c, sizeof(log_c), "%s/.urb/log", pax_c);
 
     if (  ( -1 == c3_mkdir(log_c, 0700) )
-       && ( EEXIST != errno ) )
+       && ( EEXIST != errno ) ) // XX remove
     {
       fprintf(stderr, "disk: failed to make /.urb/log in %s\r\n", pax_c);
       return c3n;
@@ -1846,6 +1846,7 @@ u3_disk_init(c3_c* pax_c)
 
   //  load pier directory
   //
+  //  XX stat, require directory exists
   {
     if ( 0 == (log_u->dir_u = u3_dire_init(pax_c)) ) {
       fprintf(stderr, "disk: failed to load pier at %s\r\n", pax_c);
@@ -1866,6 +1867,7 @@ u3_disk_init(c3_c* pax_c)
     strcpy(urb_c, pax_c);
     strcat(urb_c, "/.urb");
 
+    //  XX stat, require directory exists
     if ( 0 == (log_u->urb_u = u3_dire_init(urb_c)) ) {
       fprintf(stderr, "disk: failed to load /.urb in %s\r\n", pax_c);
       c3_free(urb_c);
@@ -1881,6 +1883,7 @@ u3_disk_init(c3_c* pax_c)
     c3_c log_c[8193];
     snprintf(log_c, sizeof(log_c), "%s/.urb/log", pax_c);
 
+    //  XX stat, require directory exists
     if ( 0 == (log_u->com_u = u3_dire_init(log_c)) ) {
       fprintf(stderr, "disk: failed to load /.urb/log in %s\r\n", pax_c);
       c3_free(log_u);

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -965,15 +965,15 @@ _disk_epoc_meta(u3_disk*    log_u,
   return c3y;
 }
 
-/* u3_disk_epoc_zero: create epoch zero.
+/* u3_disk_epoc_zero: make epoch zero.
 */
 c3_o
-u3_disk_epoc_zero(u3_disk* log_u)
+u3_disk_epoc_zero(c3_c* pax_c)
 {
   //  create new epoch directory if it doesn't exist
   c3_c epo_c[8193];
   c3_i epo_i;
-  snprintf(epo_c, sizeof(epo_c), "%s/0i0", log_u->com_u->pax_c);
+  snprintf(epo_c, sizeof(epo_c), "%s/0i0", pax_c);
   c3_d ret_d = c3_mkdir(epo_c, 0700);
   if ( ( ret_d < 0 ) && ( errno != EEXIST ) ) {
     fprintf(stderr, "disk: epoch 0i0 mkdir failed: %s\r\n", strerror(errno));
@@ -1032,10 +1032,6 @@ u3_disk_epoc_zero(u3_disk* log_u)
     goto fail3;
   }
   close(epo_i);
-
-  //  load new epoch directory and set it in log_u
-  log_u->epo_d = 0;
-  log_u->ver_w = U3D_VERLAT;
 
   //  success
   return c3y;
@@ -1348,7 +1344,7 @@ _disk_migrate(u3_disk* log_u, c3_d eve_d)
   fprintf(stderr, "disk: migrating disk to v%d format\r\n", U3D_VERLAT);
 
   //  initialize first epoch "0i0"
-  if ( c3n == u3_disk_epoc_zero(log_u) ) {
+  if ( c3n == u3_disk_epoc_zero(log_u->com_u->pax_c) ) {
     fprintf(stderr, "disk: failed to initialize first epoch\r\n");
     return c3n;
   }

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1842,7 +1842,9 @@ epoch versions (epoc.txt)
         //  XX bad
       }
 
-      if ( !log_u->epo_d || (c3y == _disk_vere_diff(log_u)) ) {
+      if (  (!log_u->epo_d && log_u->dun_d)
+         || (c3y == _disk_vere_diff(log_u)) )
+      {
         if ( log_u->dun_d != u3A->eve_d ) {
           // XX stale snapshot, new binary, error out
         }
@@ -1866,13 +1868,10 @@ u3_disk_make(c3_c* pax_c)
 {
   //  make pier directory
   //
-  {
-    if (  ( -1 == c3_mkdir(pax_c, 0700) )
-       && ( EEXIST != errno ) ) // XX remove
-    {
-      fprintf(stderr, "disk: failed to make pier at %s\r\n", pax_c);
-      return c3n;
-    }
+  if ( -1 == c3_mkdir(pax_c, 0700) ) {
+    fprintf(stderr, "disk: failed to make pier at %s: %s\r\n",
+                    pax_c, strerror(errno));
+    return c3n;
   }
 
   //  make $pier/.urb
@@ -1882,13 +1881,13 @@ u3_disk_make(c3_c* pax_c)
     strcpy(urb_c, pax_c);
     strcat(urb_c, "/.urb");
 
-    if (  ( -1 == c3_mkdir(urb_c, 0700) )
-       && ( EEXIST != errno ) ) // XX remove
-    {
-      fprintf(stderr, "disk: failed to make /.urb in %s\r\n", pax_c);
+    if ( -1 == c3_mkdir(urb_c, 0700) ) {
+      fprintf(stderr, "disk: failed to make /.urb in %s: %s\r\n",
+                      pax_c, strerror(errno));
       c3_free(urb_c);
       return c3n;
     }
+
     c3_free(urb_c);
   }
 
@@ -1914,10 +1913,9 @@ u3_disk_make(c3_c* pax_c)
     c3_c log_c[8193];
     snprintf(log_c, sizeof(log_c), "%s/.urb/log", pax_c);
 
-    if (  ( -1 == c3_mkdir(log_c, 0700) )
-       && ( EEXIST != errno ) ) // XX remove
-    {
-      fprintf(stderr, "disk: failed to make /.urb/log in %s\r\n", pax_c);
+    if ( -1 == c3_mkdir(log_c, 0700) ) {
+      fprintf(stderr, "disk: failed to make /.urb/log in %s: %s\r\n",
+                      pax_c, strerror(errno));
       return c3n;
     }
 

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -1930,6 +1930,18 @@ u3_disk_make(c3_c* pax_c)
   return c3y;
 }
 
+static u3_dire*
+_disk_require_dir(const c3_c* dir_c)
+{
+  struct stat dir_u;
+
+  if ( stat(dir_c, &dir_u) || !S_ISDIR(dir_u.st_mode) ) {
+    return 0;
+  }
+
+  return u3_dire_init(dir_c);
+}
+
 /* u3_disk_init(): init pier directories and event log.
 */
 u3_disk*
@@ -1944,9 +1956,8 @@ u3_disk_init(c3_c* pax_c)
 
   //  load pier directory
   //
-  //  XX stat, require directory exists
   {
-    if ( 0 == (log_u->dir_u = u3_dire_init(pax_c)) ) {
+    if ( 0 == (log_u->dir_u = _disk_require_dir(pax_c)) ) {
       fprintf(stderr, "disk: failed to load pier at %s\r\n", pax_c);
       c3_free(log_u);
       return 0;
@@ -1965,8 +1976,7 @@ u3_disk_init(c3_c* pax_c)
     strcpy(urb_c, pax_c);
     strcat(urb_c, "/.urb");
 
-    //  XX stat, require directory exists
-    if ( 0 == (log_u->urb_u = u3_dire_init(urb_c)) ) {
+    if ( 0 == (log_u->urb_u = _disk_require_dir(urb_c)) ) {
       fprintf(stderr, "disk: failed to load /.urb in %s\r\n", pax_c);
       c3_free(urb_c);
       c3_free(log_u);
@@ -1981,8 +1991,7 @@ u3_disk_init(c3_c* pax_c)
     c3_c log_c[8193];
     snprintf(log_c, sizeof(log_c), "%s/.urb/log", pax_c);
 
-    //  XX stat, require directory exists
-    if ( 0 == (log_u->com_u = u3_dire_init(log_c)) ) {
+    if ( 0 == (log_u->com_u = _disk_require_dir(log_c)) ) {
       fprintf(stderr, "disk: failed to load /.urb/log in %s\r\n", pax_c);
       c3_free(log_u);
       return 0;

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -2094,32 +2094,11 @@ try_init:
 
       switch ( kin_e ) {
         case _epoc_good: {
-          //  mark the log as live
-          log_u->liv_o = c3y;
-
 #if defined(DISK_TRACE_JAM) || defined(DISK_TRACE_CUE)
           u3t_trace_open(pax_c);
 #endif
 
-          if ( c3n == exs_o ) {
-            fprintf(stderr, "disk: repairing pre-release pier metadata\r\n");
-
-            //  read metadata from epoch's log
-            u3_meta met_u;
-            if ( c3n == u3_disk_read_meta(log_u->mdb_u, &met_u) )
-            {
-              fprintf(stderr, "disk: failed to read metadata\r\n");
-              c3_free(log_u);
-              return 0;
-            }
-
-            if ( c3n == u3_disk_save_meta_meta(log_c, &met_u) ) {
-              fprintf(stderr, "disk: failed to save top-level metadata\r\n");
-              c3_free(log_u);
-              return 0;
-            }
-          }
-
+          log_u->liv_o = c3y;
           return log_u;
         } break;
 

--- a/pkg/vere/foil.c
+++ b/pkg/vere/foil.c
@@ -92,6 +92,7 @@ u3_foil_folder(const c3_c* pax_c)
         return 0;
       }
       else {
+        //  XX remove mkdir and retry
         if ( 0 != (err_i = uv_fs_mkdir(u3L, &ruq_u, pax_c, 0700, 0)) ) {
           _foil_fail(pax_c, err_i);
           return 0;

--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -179,6 +179,12 @@ _king_boot_done(void* ptr_v, c3_o ret_o)
     return;
   }
 
+  //  copy binary into pier on boot
+  //
+  if ( c3y == u3_Host.ops_u.doc ) {
+    u3_king_dock(U3_VERE_PACE);
+  }
+
   u3K.pir_u = u3_pier_stay(sag_w, u3i_string(u3_Host.dir_c), rift);
 }
 
@@ -921,14 +927,6 @@ void
 _boothack_cb(uv_timer_t* tim_u)
 {
   _king_doom(_boothack_doom());
-
-  //  copy binary into pier on boot
-  //
-  if ( (c3y == u3_Host.ops_u.nuu)
-     && (c3y == u3_Host.ops_u.doc) )
-  {
-    u3_king_dock(U3_VERE_PACE);
-  }
 }
 
 /* _king_loop_init(): stuff that comes before the event loop

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1081,7 +1081,7 @@ _cw_load_pier(c3_c* dir_c)
     exit(1);
   }
 
-  u3_Host.eve_d = u3m_boot(dir_c, (size_t)1 << u3_Host.ops_u.lom_y);
+  u3_Host.eve_d = u3A->eve_d;
 
   return log_u;
 }

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -75,15 +75,15 @@ _main_readw(const c3_c* str_c, c3_w max_w, c3_w* out_w)
   else return c3n;
 }
 
-/* _main_readw_loom(): parse loom pointer bit size from a string.
+/* _main_read_loom(): parse loom pointer bit size from a string.
 */
 static c3_i
-_main_readw_loom(const c3_c* arg_c, c3_y* out_y)
+_main_read_loom(const c3_c* nam_c, const c3_c* arg_c, c3_y* out_y)
 {
   c3_w lom_w;
-  c3_o res_o = _main_readw(optarg, u3a_bits_max + 1, &lom_w);
+  c3_o res_o = _main_readw(arg_c, u3a_bits_max + 1, &lom_w);
   if ( res_o == c3n || (lom_w < 20) ) {
-    fprintf(stderr, "error: --%s must be >= 20 and <= %zu\r\n", arg_c, u3a_bits_max);
+    fprintf(stderr, "error: --%s must be >= 20 and <= %zu\r\n", nam_c, u3a_bits_max);
     return -1;
   }
   *out_y = lom_w;
@@ -317,7 +317,7 @@ _main_getopt(c3_i argc, c3_c** argv)
         break;
       }
       case 5: {  //  urth-loom
-        if (_main_readw_loom("urth-loom", &u3_Host.ops_u.lut_y)) {
+        if (_main_read_loom("urth-loom", optarg, &u3_Host.ops_u.lut_y)) {
           return c3n;
         }
         break;
@@ -369,7 +369,7 @@ _main_getopt(c3_i argc, c3_c** argv)
         break;
       }
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           return c3n;
         }
         break;
@@ -1186,7 +1186,7 @@ _cw_eval(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "cjkn", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -1387,7 +1387,7 @@ _cw_info(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -1498,7 +1498,7 @@ _cw_grab(c3_i argc, c3_c* argv[])
       case 'g': { u3_Host.ops_u.gab = c3y; break; }
 
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -1580,7 +1580,7 @@ _cw_cram(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -1684,7 +1684,7 @@ _cw_queu(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "r:", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -1799,7 +1799,7 @@ _cw_meld(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -1893,7 +1893,7 @@ _cw_melt(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -1984,7 +1984,7 @@ _cw_next(c3_i argc, c3_c* argv[])
       } break;
 
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -2061,7 +2061,7 @@ _cw_pack(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -2183,7 +2183,7 @@ _cw_play(c3_i argc, c3_c* argv[])
       case 'g': { u3_Host.ops_u.gab = c3y; break; }
 
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -2303,7 +2303,7 @@ _cw_prep(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -2378,7 +2378,7 @@ _cw_chop(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -2468,7 +2468,7 @@ _cw_roll(c3_i argc, c3_c* argv[])
       }
 
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -2642,7 +2642,7 @@ _cw_vile(c3_i argc, c3_c* argv[])
   while ( -1 != (ch_i=getopt_long(argc, argv, "", lop_u, &lid_i)) ) {
     switch ( ch_i ) {
       case c3__loom: {
-        if (_main_readw_loom("loom", &u3_Host.ops_u.lom_y)) {
+        if (_main_read_loom("loom", optarg, &u3_Host.ops_u.lom_y)) {
           exit(1);
         }
       } break;
@@ -2758,12 +2758,13 @@ _cw_boot(c3_i argc, c3_c* argv[])
   //  load runtime config
   //
   {
-    c3_w lom_w;
-
     sscanf(wag_c, "%" SCNu32, &u3C.wag_w);
     sscanf(hap_c, "%" SCNu32, &u3_Host.ops_u.hap_w);
-    sscanf(lom_c, "%" SCNu32, &lom_w);
-    u3_Host.ops_u.lom_y = (c3_y)lom_w;
+
+    if ( _main_read_loom("loom", lom_c, &u3_Host.ops_u.lom_y) ) {
+      exit(1);
+    }
+
     sscanf(per_c, "%" SCNu32, &u3C.per_w);
 
     if ( 1 != sscanf(tos_c, "%" SCNu32, &u3C.tos_w) ) {
@@ -2829,13 +2830,13 @@ _cw_work(c3_i argc, c3_c* argv[])
   //  load runtime config
   //
   {
-    c3_w lom_w;
-
     sscanf(wag_c, "%" SCNu32, &u3C.wag_w);
     sscanf(hap_c, "%" SCNu32, &u3_Host.ops_u.hap_w);
-    sscanf(lom_c, "%" SCNu32, &lom_w);
-    u3_Host.ops_u.lom_y = (c3_y)lom_w;
     sscanf(per_c, "%" SCNu32, &u3C.per_w);
+
+    if ( _main_read_loom("loom", lom_c, &u3_Host.ops_u.lom_y) ) {
+      exit(1);
+    }
 
     if ( 1 != sscanf(eve_c, "%" PRIu64, &eve_d) ) {
       fprintf(stderr, "mars: -n (--replay-to) invalid number '%s'\r\n", eve_c);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2912,15 +2912,16 @@ _cw_boot(c3_i argc, c3_c* argv[])
   //    XX s/b explicitly initialization, not maybe-restore
   //
   u3C.eph_c = (strcmp(eph_c, "0") == 0 ? 0 : strdup(eph_c));
-  u3m_boot(dir_c, (size_t)1 << lom_w);
+  //  XX revise
+  // u3m_boot(dir_c, (size_t)1 << lom_w);
 
   //  set up logging
   //
   //    XX must be after u3m_boot due to u3l_log
   //
   {
-    u3C.stderr_log_f = _cw_io_send_stdr;
-    u3C.slog_f = _cw_io_send_slog;
+    // u3C.stderr_log_f = _cw_io_send_stdr;
+    // u3C.slog_f = _cw_io_send_slog;
   }
 
   //  start reading
@@ -2976,18 +2977,21 @@ _cw_work(c3_i argc, c3_c* argv[])
     }
   }
 
+  u3_Host.ops_u.lom_y = lom_w;  //  XX
+
   //  setup loom XX strdup?
   //
   u3C.eph_c = (strcmp(eph_c, "0") == 0 ? 0 : strdup(eph_c));
-  u3m_boot(dir_c, (size_t)1 << lom_w);
+  //  XX revise
+  // u3m_boot(dir_c, (size_t)1 << lom_w);
 
   //  set up logging
   //
   //    XX must be after u3m_boot due to u3l_log
   //
   {
-    u3C.stderr_log_f = _cw_io_send_stdr;
-    u3C.slog_f = _cw_io_send_slog;
+    // u3C.stderr_log_f = _cw_io_send_stdr;
+    // u3C.slog_f = _cw_io_send_slog;
   }
 
   //  setup mars

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -939,14 +939,6 @@ report(void)
          LIBCURL_VERSION_PATCH);
 }
 
-/* _stop_exit_fore(): exit before.
-*/
-static void
-_stop_exit_fore(c3_i int_i)
-{
-  kill(getpid(), SIGTERM);
-}
-
 /* _stop_exit(): exit immediately.
 */
 static void
@@ -3055,7 +3047,7 @@ main(c3_i   argc,
   //
   //    Configured here using signal() so as to be immediately available.
   //
-  signal(SIGTSTP, _stop_exit_fore);
+  signal(SIGTSTP, _stop_exit);
 
   printf("~\n");
   //  printf("welcome.\n");

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2250,10 +2250,6 @@ _cw_play_impl(c3_d eve_d, c3_d sap_d, c3_o mel_o, c3_o sof_o, c3_o ful_o)
 
     pay_d = u3_mars_play(&mar_u, eve_d, sap_d);
     u3_Host.eve_d = mar_u.dun_d;
-
-    //  migrate or rollover as needed
-    //
-    u3_disk_kindly(log_u, u3_Host.eve_d);
   }
 
   u3_disk_exit(log_u);
@@ -2525,7 +2521,6 @@ _cw_chop(c3_i argc, c3_c* argv[])
 
   u3_disk* log_u = _cw_load_pier(u3_Host.dir_c);
 
-  u3_disk_kindly(log_u, u3_Host.eve_d);
   u3_disk_chop(log_u, u3_Host.eve_d);
 
   u3_disk_exit(log_u);
@@ -2592,7 +2587,6 @@ _cw_roll(c3_i argc, c3_c* argv[])
 
   u3_disk* log_u = _cw_load_pier(u3_Host.dir_c);
 
-  u3_disk_kindly(log_u, u3_Host.eve_d);
   u3_disk_roll(log_u, u3_Host.eve_d);
 
   u3_disk_exit(log_u);

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1074,6 +1074,15 @@ _cw_init_io(uv_loop_t* lup_u)
 static u3_disk*
 _cw_disk_init(c3_c* dir_c)
 {
+  //  if fresh boot, make pier
+  //
+  if _(u3_Host.ops_u.nuu) {
+    if ( c3n == u3_disk_make(dir_c) ) {
+      fprintf(stderr, "unable to make pier\n");
+      exit(1);
+    }
+  }
+
   u3_disk* log_u = u3_disk_init(dir_c);
 
   if ( !log_u ) {

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1101,6 +1101,9 @@ _mars_do_boot(u3_disk* log_u, c3_d eve_d, u3_noun cax)
   //
   u3m_hate(1 << 18);
 
+  //  XX this function should only ever be called in epoch 0
+  //  XX read_list reads *up-to* eve_d, should be exact
+  //
   if ( u3_none == (eve = u3_disk_read_list(log_u, 1, eve_d, &mug_l)) ) {
     fprintf(stderr, "boot: read failed\r\n");
     u3m_love(u3_nul);
@@ -1428,11 +1431,11 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d)
 /* u3_mars_load(): load pier.
 */
 void
-u3_mars_load(u3_mars* mar_u)
+u3_mars_load(u3_mars* mar_u, u3_disk_load_e lod_e)
 {
   //  initialize persistence
   //
-  if ( !(mar_u->log_u = u3_disk_init(mar_u->dir_c)) ) {
+  if ( !(mar_u->log_u = u3_disk_load(mar_u->dir_c, lod_e)) ) {
     fprintf(stderr, "mars: disk init fail\r\n");
     exit(1); // XX
   }
@@ -1870,7 +1873,7 @@ u3_mars_make(u3_mars* mar_u)
 
   //  NB: initializes loom
   //
-  if ( !(mar_u->log_u = u3_disk_init(mar_u->dir_c)) ) {
+  if ( !(mar_u->log_u = u3_disk_load(mar_u->dir_c, u3_dlod_boot)) ) {
     fprintf(stderr, "boot: disk init fail\r\n");
     exit(1);
   }

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1425,26 +1425,33 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d)
   return pay_d;
 }
 
-/* u3_mars_init(): init mars, replay if necessary.
+/* u3_mars_load(): load pier.
 */
-u3_mars*
-u3_mars_init(c3_c*    dir_c,
-             u3_moat* inn_u,
-             u3_mojo* out_u,
-             c3_d     eve_d)
+void
+u3_mars_load(u3_mars* mar_u)
 {
-  u3_mars* mar_u = c3_malloc(sizeof(*mar_u));
-  mar_u->dir_c = dir_c;
-  mar_u->inn_u = inn_u;
-  mar_u->out_u = out_u;
-  mar_u->sen_d = mar_u->dun_d = 0;
-  mar_u->mug_l = 0;
-  mar_u->fag_w = _mars_fag_none;
-  mar_u->sac   = u3_nul;
-  mar_u->sat_e = u3_mars_work_e;
-  mar_u->gif_u.ent_u = mar_u->gif_u.ext_u = 0;
-  mar_u->xit_f = 0;
+  //  initialize persistence
+  //
+  if ( !(mar_u->log_u = u3_disk_init(mar_u->dir_c)) ) {
+    fprintf(stderr, "mars: disk init fail\r\n");
+    exit(1); // XX
+  }
 
+  mar_u->sen_d = mar_u->dun_d = u3A->eve_d;
+  mar_u->mug_l = u3r_mug(u3A->roc);
+
+  if ( c3n == u3_disk_read_meta(mar_u->log_u->mdb_u, &(mar_u->met_u)) ) {
+    fprintf(stderr, "mars: disk meta fail\r\n");
+    u3_disk_exit(mar_u->log_u);
+    exit(1); // XX
+  }
+}
+
+/* u3_mars_work(): init mars
+*/
+void
+u3_mars_work(u3_mars* mar_u)
+{
   mar_u->sil_u = u3s_cue_xeno_init();
 
   //  start signal handlers
@@ -1459,56 +1466,6 @@ u3_mars_init(c3_c*    dir_c,
   //
   u3C.sign_hold_f = _mars_sign_hold;
   u3C.sign_move_f = _mars_sign_move;
-
-  //  initialize persistence
-  //
-  //    XX load/set secrets
-  //
-  if ( !(mar_u->log_u = u3_disk_init(dir_c)) ) {
-    fprintf(stderr, "mars: disk init fail\r\n");
-    c3_free(mar_u);
-    return 0;
-  }
-
-  mar_u->sen_d = mar_u->dun_d = u3A->eve_d;
-  mar_u->mug_l = u3r_mug(u3A->roc);
-
-  if ( c3n == u3_disk_read_meta(mar_u->log_u->mdb_u, &(mar_u->met_u)) ) {
-    fprintf(stderr, "mars: disk meta fail\r\n");
-    u3_disk_exit(mar_u->log_u);
-    c3_free(mar_u);
-    return 0;
-  }
-
-  if ( !mar_u->dun_d ) {
-    if ( c3n == _mars_do_boot(mar_u->log_u, mar_u->met_u.lif_w, u3_nul) ) {
-      fprintf(stderr, "mars: boot fail\r\n");
-      u3_disk_exit(mar_u->log_u);
-      c3_free(mar_u);
-      return 0;
-    }
-
-    mar_u->sen_d = mar_u->dun_d = mar_u->met_u.lif_w;
-    u3m_save();
-  }
-
-  if ( eve_d && (eve_d <= mar_u->dun_d) ) {
-    fprintf(stderr, "mars: replay-to %" PRIu64
-                    " already done (at %" PRIu64 ")\r\n",
-                    eve_d, mar_u->dun_d);
-    u3_disk_exit(mar_u->log_u);
-    c3_free(mar_u);
-    return 0;
-  }
-
-  if ( mar_u->log_u->dun_d > mar_u->dun_d ) {
-    u3_mars_play(mar_u, eve_d, 0);
-    u3m_save();
-  }
-
-  //  migrate or rollover as needed
-  //
-  u3_disk_kindly(mar_u->log_u, mar_u->dun_d);
 
   //  XX do something better
   //
@@ -1547,8 +1504,6 @@ u3_mars_init(c3_c*    dir_c,
 
   mar_u->sav_u.eve_d = mar_u->dun_d;
   mar_u->sav_u.tim_u.data = mar_u;
-
-  return mar_u;
 }
 
 #define VERE_NAME  "vere"

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1900,6 +1900,27 @@ _mars_boot_make(u3_boot_opts* inp_u,
   return c3y;
 }
 
+/* u3_mars_make(): construct a pier.
+*/
+void
+u3_mars_make(u3_mars* mar_u)
+{
+  //  XX s/b unnecessary
+  u3_Host.ops_u.nuu = c3y;
+
+  if ( c3n == u3_disk_make(mar_u->dir_c) ) {
+    fprintf(stderr, "boot: disk make fail\r\n");
+    exit(1);
+  }
+
+  //  NB: initializes loom
+  //
+  if ( !(mar_u->log_u = u3_disk_init(mar_u->dir_c)) ) {
+    fprintf(stderr, "boot: disk init fail\r\n");
+    exit(1);
+  }
+}
+
 /* u3_mars_boot(): boot a ship.
 *
 *  $=  com
@@ -1913,12 +1934,12 @@ _mars_boot_make(u3_boot_opts* inp_u,
 *
 */
 c3_o
-u3_mars_boot(c3_c* dir_c, u3_noun com)
+u3_mars_boot(u3_mars* mar_u, c3_d len_d, c3_y* hun_y)
 {
+  u3_disk*     log_u = mar_u->log_u;
   u3_boot_opts inp_u;
   u3_meta      met_u;
-  u3_noun        ova;
-  u3_noun        cax;
+  u3_noun   com, ova, cax;
 
   inp_u.veb_o = __( u3C.wag_w & u3o_verbose );
   inp_u.lit_o = c3n; // unimplemented in arvo
@@ -1937,21 +1958,22 @@ u3_mars_boot(c3_c* dir_c, u3_noun com)
     u3z(now);
   }
 
+  {
+    u3_weak jar = u3s_cue_xeno(len_d, hun_y);
+    if (  (u3_none == jar)
+       || (c3n == u3r_p(jar, c3__boot, &com)) )
+    {
+      fprintf(stderr, "boot: parse fail\r\n");
+      exit(1);
+    }
+    else {
+      u3k(com);
+      u3z(jar);
+    }
+  }
+
   if ( c3n == _mars_boot_make(&inp_u, com, &ova, &cax, &met_u) ) {
     fprintf(stderr, "boot: preparation failed\r\n");
-    return c3n;
-  }
-
-  u3_disk* log_u;
-
-  //  XX
-  u3_Host.ops_u.nuu = c3y;
-  if ( c3n == u3_disk_make(dir_c) ) {
-    fprintf(stderr, "boot: disk make fail\r\n");
-    return c3n;
-  }
-  if ( !(log_u = u3_disk_init(dir_c)) ) {
-    fprintf(stderr, "boot: disk init fail\r\n");
     return c3n;
   }
 
@@ -1965,14 +1987,18 @@ u3_mars_boot(c3_c* dir_c, u3_noun com)
     return c3n;  //  XX cleanup
   }
 
-  _mars_step_trace(dir_c);
+  _mars_step_trace(mar_u->dir_c);
 
   if ( c3n == _mars_do_boot(log_u, log_u->dun_d, cax) ) {
     return c3n;  //  XX cleanup
   }
 
   u3m_save();
+
+  //  XX move to caller? close uv handles?
+  //
   u3_disk_exit(log_u);
+  exit(0);
 
   return c3y;
 }

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1943,6 +1943,10 @@ u3_mars_boot(c3_c* dir_c, u3_noun com)
 
   //  XX
   u3_Host.ops_u.nuu = c3y;
+  if ( c3n == u3_disk_make(dir_c) ) {
+    fprintf(stderr, "boot: disk make fail\r\n");
+    return c3n;
+  }
   if ( !(log_u = u3_disk_init(dir_c)) ) {
     fprintf(stderr, "boot: disk init fail\r\n");
     return c3n;

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1437,8 +1437,8 @@ u3_mars_init(c3_c*    dir_c,
   mar_u->dir_c = dir_c;
   mar_u->inn_u = inn_u;
   mar_u->out_u = out_u;
-  mar_u->sen_d = mar_u->dun_d = u3A->eve_d;
-  mar_u->mug_l = u3r_mug(u3A->roc);
+  mar_u->sen_d = mar_u->dun_d = 0;
+  mar_u->mug_l = 0;
   mar_u->fag_w = _mars_fag_none;
   mar_u->sac   = u3_nul;
   mar_u->sat_e = u3_mars_work_e;
@@ -1469,6 +1469,9 @@ u3_mars_init(c3_c*    dir_c,
     c3_free(mar_u);
     return 0;
   }
+
+  mar_u->sen_d = mar_u->dun_d = u3A->eve_d;
+  mar_u->mug_l = u3r_mug(u3A->roc);
 
   if ( c3n == u3_disk_read_meta(mar_u->log_u->mdb_u, &(mar_u->met_u)) ) {
     fprintf(stderr, "mars: disk meta fail\r\n");

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1974,7 +1974,12 @@ u3_mars_boot(u3_mars* mar_u, c3_d len_d, c3_y* hun_y)
 
   if ( c3n == _mars_boot_make(&inp_u, com, &ova, &cax, &met_u) ) {
     fprintf(stderr, "boot: preparation failed\r\n");
-    return c3n;
+    return c3n;  //  XX cleanup
+  }
+
+  if ( c3n == u3_disk_save_meta_meta(log_u->com_u->pax_c, &met_u) ) {
+    fprintf(stderr, "boot: failed to save top-level metadata\r\n");
+    return c3n;  //  XX cleanup
   }
 
   if ( c3n == u3_disk_save_meta(log_u->mdb_u, &met_u) ) {

--- a/pkg/vere/mars.h
+++ b/pkg/vere/mars.h
@@ -69,7 +69,7 @@
     /* u3_mars_load(): load pier.
     */
       void
-      u3_mars_load(u3_mars* mar_u);
+      u3_mars_load(u3_mars* mar_u, u3_disk_load_e lod_e);
 
     /* u3_mars_work(): init mars
     */

--- a/pkg/vere/mars.h
+++ b/pkg/vere/mars.h
@@ -56,10 +56,15 @@
 
   /** Functions.
   **/
+    /* u3_mars_make(): construct a pier.
+    */
+      void
+      u3_mars_make(u3_mars* mar_u);
+
     /* u3_mars_boot(): boot a new ship.
     */
       c3_o
-      u3_mars_boot(c3_c* dir_c, u3_noun com);
+      u3_mars_boot(u3_mars* mar_u, c3_d len_d, c3_y* hun_y);
 
     /* u3_mars_init(): restart an existing ship.
     */

--- a/pkg/vere/mars.h
+++ b/pkg/vere/mars.h
@@ -66,13 +66,15 @@
       c3_o
       u3_mars_boot(u3_mars* mar_u, c3_d len_d, c3_y* hun_y);
 
-    /* u3_mars_init(): restart an existing ship.
+    /* u3_mars_load(): load pier.
     */
-      u3_mars*
-      u3_mars_init(c3_c*    dir_c,
-                   u3_moat* inn_u,
-                   u3_mojo* out_u,
-                   c3_d     eve_d);
+      void
+      u3_mars_load(u3_mars* mar_u);
+
+    /* u3_mars_work(): init mars
+    */
+      void
+      u3_mars_work(u3_mars* mar_u);
 
     /* u3_mars_kick(): try to send a task into mars.
     */
@@ -85,7 +87,6 @@
       u3_mars_grab(c3_o pri_o);
 
     /* u3_mars_play(): replay up to [eve_d], snapshot every [sap_d].
-    ** TODO: replace?
     */
       c3_d
       u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d);

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -506,6 +506,14 @@
       */
         typedef void (*u3_disk_news)(void*, c3_d, c3_o);
 
+      /* u3_disk_load_e: disk load mode.
+      */
+        typedef enum {
+          u3_dlod_boot = 0,                 //  load for boot
+          u3_dlod_epoc = 1,                 //  load for full replay
+          u3_dlod_last = 2                  //  load latest
+        } u3_disk_load_e;
+
       /* u3_disk: manage event persistence.
       */
         typedef struct _u3_disk {
@@ -880,10 +888,10 @@
         c3_o
         u3_disk_make(c3_c* pax_c);
 
-      /* u3_disk_init(): init pier directories and event log.
+      /* u3_disk_load(): load pier directories, log, and snapshot.
       */
         u3_disk*
-        u3_disk_init(c3_c* pax_c);
+        u3_disk_load(c3_c* pax_c, u3_disk_load_e lod_e);
 
       /* u3_disk_etch(): serialize an event for persistence. RETAIN [eve]
       */

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -964,11 +964,6 @@
         c3_z
         u3_disk_epoc_list(u3_disk* log_u, c3_d* sot_d);
 
-      /* u3_disk_kindly(): do the needful.
-      */
-        void
-        u3_disk_kindly(u3_disk* log_u, c3_d eve_d);
-
       /* u3_disk_chop(): delete all but the latest 2 epocs.
        */
         void

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -875,7 +875,12 @@
                      u3_ovum_peer news_f,
                      u3_ovum_bail bail_f);
 
-      /* u3_disk_init(): load or create pier directories and event log.
+      /* u3_disk_make(): make pier directories and event log.
+      */
+        c3_o
+        u3_disk_make(c3_c* pax_c);
+
+      /* u3_disk_init(): init pier directories and event log.
       */
         u3_disk*
         u3_disk_init(c3_c* pax_c);

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -959,6 +959,11 @@
         c3_z
         u3_disk_epoc_list(u3_disk* log_u, c3_d* sot_d);
 
+      /* u3_disk_epoc_zero: make epoch zero.
+      */
+        c3_o
+        u3_disk_epoc_zero(c3_c* pax_c);
+
       /* u3_disk_kindly(): do the needful.
       */
         void

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -964,11 +964,6 @@
         c3_z
         u3_disk_epoc_list(u3_disk* log_u, c3_d* sot_d);
 
-      /* u3_disk_epoc_zero: make epoch zero.
-      */
-        c3_o
-        u3_disk_epoc_zero(c3_c* pax_c);
-
       /* u3_disk_kindly(): do the needful.
       */
         void


### PR DESCRIPTION
This PR restructures the "mars" process and "disk" module to colocate all loom and pier migrations. Includes #853