### PR TITLE
branch elimination in _n_formulaic

### DIFF
--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1178,10 +1178,23 @@ _n_formulaic(u3_noun fol)
     case 12:
       return (c3y == u3r_cell(ar, &a, &b))
         && _n_formulaic(a) && _n_formulaic(b);
-    case 6:
-      return ( c3y == u3r_trel(ar, &a, &b, &c) )
-        && _n_formulaic(a) &&
-        (_n_formulaic(b) || _n_formulaic(c));
+    case 6: {
+      u3_noun lit;
+
+      if ( c3n == u3r_trel(ar, &a, &b, &c) || !_n_formulaic(a) ) {
+        return 0;
+      }
+
+      if ( c3n == u3r_safe(a, &lit) || u3_none == lit ) {
+        return _n_formulaic(b) || _n_formulaic(c);
+      }
+
+      switch (lit) {
+        case 0:  return _n_formulaic(b);
+        case 1:  return _n_formulaic(c);
+        default: return 0;
+      }
+    }
     case 9:
       return (c3y == u3r_cell(ar, &a, &b))
         && (c3y == u3ud(a))


### PR DESCRIPTION
I realized that branch elimination introduced in #850 led to crashes like in this example:

```
.*(0 [%6 [%5 [%0 1] %1 0] [%1 42] [%6 [%1 %0] [%0 0 0] [%1 42]]])
```

When outer %6 is compiled, `_n_formulaic` checks the validity of formulas in branches, replacing them with single `BAIL` instruction if the formula is malformed, which would make it always crash. From POV of _n_formulaic inner %6 is valid, since the condition expression and at least one of the branch expressions are valid. But when inner %6 is compiled, we only compile the invalid branch due to branch elimination, leading to a crash.

For that reason _n_formulaic has to be more strict in the presence of branch elimination.