### PR TITLE
vere: prep road layout for release

### DIFF
--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -168,7 +168,6 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
           u3p(u3a_dell)  fre_p;               //  free list entry
           u3p(u3a_dell)  erf_p;               //  free list exit
           u3p(u3a_dell)  cac_p;               //  cached pgfree struct
-          u3_post        bot_p;               //  XX s/b rut_p
           c3_ws          dir_ws;              //  1 || -1 (multiplicand for local offsets)
           c3_ws          off_ws;              //  0 || -1 (word-offset for hat && rut)
           c3_w           siz_w;               //  directory size

--- a/pkg/noun/events.c
+++ b/pkg/noun/events.c
@@ -703,7 +703,7 @@ static u3_ce_patch*
 _ce_patch_compose(c3_w max_w)
 {
   c3_w pgs_w = 0;
-  c3_w off_w = u3R->hep.bot_p >> u3a_page;
+  c3_w off_w = u3R->rut_p >> u3a_page;
 
   /* Count dirty pages.
   */
@@ -1114,7 +1114,7 @@ _ce_page_fine(u3e_image* img_u, c3_w pag_w, c3_z off_z)
 static c3_o
 _ce_loom_fine(void)
 {
-  c3_w off_w = u3R->hep.bot_p >> u3a_page;
+  c3_w off_w = u3R->rut_p >> u3a_page;
   c3_w blk_w, bit_w, pag_w, i_w;
   c3_o fin_o = c3y;
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -547,13 +547,17 @@ _pave_home(void)
   memset(u3H, 0, sizeof(u3v_home));
   u3H->ver_d = U3V_VERLAT;
 
-  //  pam_d bits: { word-size[1], virtual-bits[2], page-size[3], ... }
+  //  pam_d bits:
+  //  { word-size[1], virtual-bits[2], page-size[3], bytecode[5], ... }
+  //
   //    word-size: 0==32, 1==64
   //    page-size: relative binary-log in bytes
   //
+  //
   u3H->pam_d = 0
              ^ (u3a_vits << 1)
-             ^ ((u3a_page + 2 - 12) << 3);
+             ^ ((u3a_page + 2 - 12) << 3)
+             ^ (U3N_VERLAT << 6);
 
   u3R = &u3H->rod_u;
 
@@ -568,6 +572,8 @@ STATIC_ASSERT( (c3_wiseof(u3v_home) <= (1U << u3a_page)),
 
 STATIC_ASSERT( ((c3_wiseof(u3v_home) * 4) == sizeof(u3v_home)),
                "home road alignment" );
+
+STATIC_ASSERT( U3N_VERLAT < (1U << 5), "5-bit bytecode version" );
 
 /* _find_home(): in restored image, point to home road.
 */
@@ -598,6 +604,13 @@ _find_home(void)
     fprintf(stderr, "page-size mismatch: %u  in snapshot; %u in binary\r\n",
                     1U << (12 + ((pam_d >> 3) & 7)), (c3_w)u3a_page + 2);
     abort();
+  }
+
+  if ( ((pam_d >> 6) & 31) != U3N_VERLAT ) {
+    fprintf(stderr, "loom: discarding stale bytecode programs\r\n");
+    u3n_ream();
+    u3n_reclaim();
+    u3j_reclaim();
   }
 
   //  NB: the home road is always north

--- a/pkg/noun/palloc.c
+++ b/pkg/noun/palloc.c
@@ -20,8 +20,12 @@
 #  define ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void) (addr), (void) (size))
 #endif
 
-#define page_to_post(pag_w)  (HEAP.bot_p + (HEAP.dir_ws * (c3_ws)((c3_w)(pag_w - HEAP.off_ws) << u3a_page)))
-#define post_to_page(som_p)  (_abs_dif(som_p, (c3_ws)HEAP.bot_p + HEAP.off_ws) >> u3a_page)
+#ifndef BASE
+  #define BASE u3R->rut_p
+#endif
+
+#define page_to_post(pag_w)  (BASE + (HEAP.dir_ws * (c3_ws)((c3_w)(pag_w - HEAP.off_ws) << u3a_page)))
+#define post_to_page(som_p)  (_abs_dif(som_p, (c3_ws)BASE + HEAP.off_ws) >> u3a_page)
 
 #ifndef HEAP
   #define HEAP u3R->hep
@@ -91,13 +95,9 @@ _init_heap(void)
     HEAP.off_ws = -1;
   }
 
-  // XX and rut
-  //
-  assert ( !(u3R->hat_p & ((1U << u3a_page) - 1)) );
-
-  HEAP.bot_p = u3R->hat_p;
-
+  assert( !(u3R->hat_p & ((1U << u3a_page) - 1)) );
   assert( u3R->hat_p > u3a_rest_pg );
+  assert( u3R->hat_p == u3R->rut_p );
 
   //  XX check for overflow
 

--- a/pkg/noun/palloc_tests.c
+++ b/pkg/noun/palloc_tests.c
@@ -18,6 +18,7 @@ struct heap {
 struct heap hep_u;
 
 #define HEAP  (hep_u)
+#define BASE  (hep_u.bot_p)
 
 #include "./palloc.c"
 
@@ -77,93 +78,6 @@ _test_print_pages(c3_w max_w)
   }
 }
 
-void
-u3m_fall(void);
-void
-u3m_leap(c3_w pad_w);
-
-static void
-_test_palloc(void)
-{
-  c3_w *wor_w;
-  u3_post pos_p, sop_p;
-  struct heap tmp_u;
-
-  memset(&(HEAP), 0x0, sizeof(HEAP));
-  _init_heap();
-
-  pos_p = _imalloc(4);
-
-  fprintf(stderr, "north: pos_p %x\n", pos_p);
-
-  wor_w = u3a_into(pos_p);
-
-  wor_w[0] = 0;
-  wor_w[1] = 1;
-  wor_w[2] = 2;
-  wor_w[3] = 3;
-
-  sop_p = _imalloc(4);
-
-  fprintf(stderr, "north: sop_p %x\n", sop_p);
-
-  _ifree(pos_p);
-  _ifree(sop_p);
-
-  fprintf(stderr, "palloc_tests: pre-leap: hat=0x%x cap=0x%x\n", u3R->hat_p, u3R->cap_p);
-
-  memcpy(&tmp_u, &hep_u, sizeof(tmp_u));
-  u3m_leap(1U << u3a_page);
-
-  fprintf(stderr, "palloc_tests: post-leap: hat=0x%x cap=0x%x\n", u3R->hat_p, u3R->cap_p);
-
-  memset(&(HEAP), 0x0, sizeof(HEAP));
-  _init_heap();
-
-  pos_p = _imalloc(4);
-
-  fprintf(stderr, "south: pos_p %x\n", pos_p);
-
-  wor_w = u3a_into(pos_p);
-
-  wor_w[0] = 0;
-  wor_w[1] = 1;
-  wor_w[2] = 2;
-  wor_w[3] = 3;
-
-  sop_p = _imalloc(4);
-
-  fprintf(stderr, "south: sop_p %x\n", sop_p);
-
-  _ifree(pos_p);
-  _ifree(sop_p);
-
-  fprintf(stderr, "palloc_tests: pre-fall: hat=0x%x cap=0x%x\n", u3R->hat_p, u3R->cap_p);
-
-  u3m_fall();
-  memcpy(&hep_u, &tmp_u, sizeof(tmp_u));
-
-  fprintf(stderr, "palloc_tests: post-fall: hat=0x%x cap=0x%x\n", u3R->hat_p, u3R->cap_p);
-
-  pos_p = _imalloc(4);
-
-  fprintf(stderr, "north: pos_p %x\n", pos_p);
-
-  wor_w = u3a_into(pos_p);
-
-  wor_w[0] = 0;
-  wor_w[1] = 1;
-  wor_w[2] = 2;
-  wor_w[3] = 3;
-
-  sop_p = _imalloc(4);
-
-  fprintf(stderr, "north: sop_p %x\n", sop_p);
-
-  _ifree(pos_p);
-  _ifree(sop_p);
-}
-
 /* main(): run all test cases.
 */
 int
@@ -173,9 +87,5 @@ main(int argc, char* argv[])
 
   _test_print_chunks();
   _test_print_pages(10);
-
-  _test_palloc();
-
-  fprintf(stderr, "palloc okeedokee\n");
   return 0;
 }

--- a/pkg/noun/version.h
+++ b/pkg/noun/version.h
@@ -12,6 +12,13 @@ typedef c3_d       u3v_version;
 #define U3V_VER5   (u3v_version)5  //  ??      palloc
 #define U3V_VERLAT U3V_VER5
 
+/*  bytecode semantics (within u3v_version)
+ */
+typedef c3_w       u3n_version;
+
+#define U3N_VER1   (u3n_version)0  // zero-indexedfor backcompat
+#define U3N_VERLAT U3N_VER1
+
 /*  snapshot patch format
  */
 typedef c3_w       u3e_version;


### PR DESCRIPTION
Removes redundant files from the road struct and adds support for lightweight bytecode migrations (see #831).