### PR TITLE
nock: fix string allocation in bytecode renderer

### DIFF
--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1826,7 +1826,7 @@ _cn_etch_bytecode(u3_noun fol) {
   c3_y* pog_y = pog_u->byc_u.ops_y;
   c3_w len_w = pog_u->byc_u.len_w;
   c3_w ip_w=0, num_w=0, bop_w=0, dex_w=0;
-  c3_w len_c = 1; // opening "{"
+  c3_w len_c = 2; // closing "}", null terminator
   // set par_w (parameter flag) to an invalid value,
   // so we can break imeadately if needed
   c3_w par_w = 5;


### PR DESCRIPTION
Contrary to the initial comment, there is no need to allocate a character for opening brace: we replace the first leading space with it when we are done rendering. We do, however, need space for **two** extra characters: the closing brace and null terminator. ASAN was blowing on line 1883 (buffer overflow), it doesn't anymore.