### PR TITLE
Forward --lmdb-map-size through _cw_play_fork

### DIFF
--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -2639,6 +2639,7 @@ _cw_play(c3_i argc, c3_c* argv[])
     { "auto-meld",         no_argument,       NULL, 7 },
     { "soft-mugs",         no_argument,       NULL, 8 },
     { "watch-replay",      no_argument,       NULL, 9 },
+    { "lmdb-map-size",     required_argument, NULL, 10 },
     { "full",              no_argument,       NULL, 'f' },
     { "replay-to",         required_argument, NULL, 'n' },
     { "snap-at",           required_argument, NULL, 's' },
@@ -2671,6 +2672,13 @@ _cw_play(c3_i argc, c3_c* argv[])
       case 9: {  //  watch-replay
         wat_o = c3y;
       } break;
+
+      case 10: {  //  lmdb-map-size
+        if ( 1 != sscanf(optarg, "%" SCNuMAX, &u3_Host.ops_u.siz_i) ) {
+          exit(1);
+        }
+        break;
+      }
 
       case 'f': {
         ful_o = c3y;


### PR DESCRIPTION
Resolves #878
This PR fixes an issue where --lmdb-map-size was ignored when running via cw_play. The option never reached the child process because _cw_play_fork() rebuilt argv[] manually and omitted the flag. As a result, replay sessions always used the default LMDB map size regardless of the user’s input.

The following changes were made to _cw_play_fork() so that lmdb-map-size could be passed down:
- Added map_c to hold the decimal string of u3_Host.ops_u.siz_i / lmdb_map_bytes.
- Inserted --lmdb-map-size and its value into the argv[] array in _cw_play_fork().

The following change was made because it seems that once _cw_play_fork passes --lmdb-map-size forward, if cw_play doesn't know how to handle the additional option, it causes an error:
- Adds --lmdb-map-size to _cw_play
