### PR TITLE
build: update tracy hash

### DIFF
--- a/ext/tracy/build.zig.zon
+++ b/ext/tracy/build.zig.zon
@@ -4,7 +4,7 @@
     .dependencies = .{
         .tracy = .{
             .url = "https://github.com/wolfpld/tracy/archive/v0.12.2.tar.gz",
-            .hash = "12203c118392e70e8a4735727e5969381b6161172eb90bd8861c5bb64da269b4327d",
+            .hash = "N-V-__8AANptPwE8EYOS5w6KRzVyfllpOBthYRcuuQvYhhxb",
         },
     },
     .paths = .{


### PR DESCRIPTION
Dependencies with legacy hashes are fetched on each build (https://github.com/ziglang/zig/issues/23051), this commit updates the hash format for Tracy.