### PR TITLE
jets: remove +muk registration from /lib/tiny

### DIFF
--- a/pkg/noun/jets/tree.c
+++ b/pkg/noun/jets/tree.c
@@ -2617,7 +2617,6 @@ u3j_core _a50_d[] =
   { "mix", 7,  _140_two_mix_a, 0, _140_two_mix_ha },
   { "mor", 7,  _140_two_mor_a, 0, _140_two_mor_ha },
   { "mug", 7,  _140_two_mug_a, 0, _140_two_mug_ha },
-  { "muk", 59, _140_two_muk_a, 0, _140_two_muk_ha },  //  TODO: why 59?
   { "rep", 7,  _140_two_rep_a, 0, _140_two_rep_ha },
   { "rip", 7,  _140_two_rip_a, 0, _140_two_rip_ha },
   { "rsh", 7,  _140_two_rsh_a, 0, _140_two_rsh_ha },


### PR DESCRIPTION
There was a jet mismatch between `+muk` definition in hoon.hoon and the jetting function that was fixed in [dcb4231@urbit](https://github.com/urbit/urbit/commit/dcb42318131d83a08cdd03e44fb7cb692cf93608). Same fix could not be applied in /lib/tiny.hoon due to logistical complexities. However, the library and the naive rollup contract do not call `+muk` directly, and the mismatch is not directly observable, since it involves passing the length of the key that exceeds its size measured with `+met`, and `+muk` callers `+mug` and `+mum` don't do that. So it would suffice to just remove the registration from `%a50` root.