### PR TITLE
pier: do not leak all effects in urth

### DIFF
--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -185,6 +185,7 @@ _pier_on_lord_work_done(void*    ptr_v,
   //  XX consider async
   //
   u3_auto_kick(pir_u->wok_u->car_u, act);
+  u3z(act);
 
   _pier_work(pir_u->wok_u);
 }


### PR DESCRIPTION
All ships on `edge` have been experiencing mysterious crashes in the urth process ever since we merged `next/kelvin/409` to `develop`. It took us two weeks to run this down, but the issue seems to be twofold:

1. We were leaking all effects in urth, causing a surprisingly slow leak on all but the most busy ships. This PR fixes the leak.

2. Unifying equality on the home road was enabled in `vere-v3.5`. `~dozreg-toplud` noticed that unifying equality is unsafe in the presence of uncounted references, and it seems likely that some change in `vere-v4.0` caused this pattern to occur in urth. This problem was mostly showing up as `palloc: page out of heap` or other allocator errors caused by the use-after-free. We will most likely disable the unifying equality on the home road later (at least for urth).