### PR TITLE
conn: robustly deliver response after channel read EOF

### DIFF
--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -699,7 +699,6 @@ _conn_sock_cb(uv_stream_t* sem_u, c3_i tas_i)
   u3_chan*  can_u;
   c3_i      err_i;
 
-
   can_u = c3_calloc(sizeof(u3_chan));
   can_u->mor_u.ptr_v = can_u;
   can_u->mor_u.pok_f = _conn_moor_poke;

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -699,6 +699,7 @@ _conn_sock_cb(uv_stream_t* sem_u, c3_i tas_i)
   u3_chan*  can_u;
   c3_i      err_i;
 
+
   can_u = c3_calloc(sizeof(u3_chan));
   can_u->mor_u.ptr_v = can_u;
   can_u->mor_u.pok_f = _conn_moor_poke;
@@ -865,6 +866,10 @@ _conn_ef_handle(u3_conn*  con_u,
     else {
       can_u->mor_u.bal_f(can_u, -4, "handle-unknown");
       u3_king_bail();
+    }
+
+    if ( !uv_is_readable((uv_stream_t*)&con_u->san_u->pyp_u) ) {
+      _conn_close_chan(con_u->san_u, can_u);
     }
   }
   else {

--- a/pkg/vere/newt.c
+++ b/pkg/vere/newt.c
@@ -179,9 +179,9 @@ _newt_read_cb(uv_stream_t*    str_u,
 
     if ( UV_EOF != len_i ) {
       fprintf(stderr, "newt: read failed %s\r\n", uv_strerror(len_i));
+      mot_u->bal_f(mot_u->ptr_v, len_i, uv_strerror(len_i));
     }
 
-    mot_u->bal_f(mot_u->ptr_v, len_i, uv_strerror(len_i));
   }
   //  EAGAIN/EWOULDBLOCK
   //


### PR DESCRIPTION
It is presently impossible to interface with conn using the typical pattern of sending a command using one program, and receiving the result with another through Unix pipes. Conn will eagerly close the connection as soon as it hears EOF from the read end of the pipe, which does not leave any chance to deliver an future result to the recipient. The only way to reliably receive results from conn in this situation is to set long timeouts in tools such as `netcat` or `socat`.

This PR is (1) request for clarification about the protocol, whether the original behavior was intended, and (2) a first attempt to rectify this situation by:
1. Only closing the read end of the pipe on genuine errors in `newt.c`
2. Closing the channel after the result has been delivered, if the read end of the channel's pipe had reached EOF.

This PR requires an expert's look whether this change fits well with other IO drivers, given that `newt.c` is used in many other places.

With this PR applied, I have been able to successfully use `socat` with the `click` script to dramatically speedup interactions with an Urbit ship via conn.

Our backend tests runner now completes in under `20s`, while previously it took more than 4m to complete, due to a need for long timeouts at each interaction.

