### PR TITLE
memo: road-local harvesting flag

### DIFF
--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -215,7 +215,8 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
     /* u3a_flag: flags for how.fag_w.  All arena related.
     */
       enum u3a_flag {
-        u3a_flag_sand  = 0x1,                 //  bump allocation (XX not impl)
+        u3a_flag_sand  = 1 << 1,              //  bump allocation (XX not impl)
+        u3a_flag_cash  = 1 << 2,              //  memo cache harvesting
       };
 
     /* u3a_pile: stack control, abstracted over road direction.

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -530,6 +530,8 @@ _pave_parts(void)
   u3R->jed.han_p = u3h_new();
   u3R->jed.bas_p = u3h_new();
   u3R->byc.har_p = u3h_new();
+
+  u3R->how.fag_w = 0;
 }
 
 static c3_d
@@ -1455,14 +1457,11 @@ u3m_soft_cax(u3_funq fun_f,
   u3_noun why = 0, pro;
   u3_noun cax = u3_nul;
 
-  /* Save and set memo cache harvesting flag.
-  */
-  c3_w wag_w = u3C.wag_w;
-  u3C.wag_w |= u3o_cash;
-
   /* Record the cap, and leap.
   */
   u3m_hate(1 << 18);
+
+  u3R->how.fag_w |= u3a_flag_cash;
 
   /* Configure the new road.
   */
@@ -1479,7 +1478,6 @@ u3m_soft_cax(u3_funq fun_f,
   if ( 0 == (why = (u3_noun)setjmp(u3R->esc.buf)) ) {
     u3t_off(coy_o);
     pro = fun_f(aga, agb);
-    u3C.wag_w = wag_w;
 
 #ifdef U3_CPU_DEBUG
     if ( u3R->all.max_w > 1000000 ) {
@@ -1504,7 +1502,6 @@ u3m_soft_cax(u3_funq fun_f,
   }
   else {
     u3t_init();
-    u3C.wag_w = wag_w;
 
     /* Produce - or fall again.
     */
@@ -1554,6 +1551,8 @@ u3m_soft_run(u3_noun gul,
 {
   u3_noun why = 0, pro;
 
+  c3_t cash_t = !!(u3R->how.fag_w & u3a_flag_cash);
+
   /* Record the cap, and leap.
   */
   u3m_hate(1 << 18);
@@ -1562,8 +1561,7 @@ u3m_soft_run(u3_noun gul,
   */
 
   {
-    // XX review
-    if ( (u3_nul == gul) || (u3C.wag_w & u3o_cash) ) {
+    if ( (u3_nul == gul) || cash_t ) {
       u3R->ski.gul = u3_nul;
     }
     else {
@@ -1572,6 +1570,7 @@ u3m_soft_run(u3_noun gul,
     u3R->pro.don = u3to(u3_road, u3R->par_p)->pro.don;
     u3R->pro.trace = u3to(u3_road, u3R->par_p)->pro.trace;
     u3R->bug.tax = 0;
+    u3R->how.fag_w |= ( cash_t ) ? u3a_flag_cash : 0;
   }
   u3t_on(coy_o);
 

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -45,7 +45,7 @@
         u3o_soft_mugs     = 1 << 11,          //  continue replay on mismatch
         u3o_swap          = 1 << 12,          //  enables ephemeral file
         u3o_toss          = 1 << 13,          //  reclaim often
-        u3o_cash          = 1 << 14,          //  memo cache harvesting
+        // u3o_cash          = 1 << 14,          //  deprecated
         u3o_yolo          = 1 << 15           //  no brakes!
       };
 

--- a/pkg/noun/zave.c
+++ b/pkg/noun/zave.c
@@ -55,7 +55,7 @@ _har(u3a_road* rod_u, u3z_cid cid)
 u3_weak
 u3z_find(u3z_cid cid, u3_noun key)
 {
-  if ( (u3z_memo_toss == cid) || (u3C.wag_w & u3o_cash) ) {
+  if ( (u3z_memo_toss == cid) || (u3R->how.fag_w & u3a_flag_cash) ) {
     // XX under cash lookup in parent roads,
     // copying cache hits into the current road
     return u3h_get(_har(u3R, cid), key);


### PR DESCRIPTION
Current memo cache harvesting mode set a bit in the global parameter `u3C.wag_w`, leading to it still being set if the road was not left properly, e.g. ^C in `+mice`. This PR adds a road-local flag that is set by `u3m_soft_cax` and inherited by all subroads.