### PR TITLE
term: fix eof hangup when pasting multiple of the libuv read buffer

### DIFF
--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -79,11 +79,9 @@ _term_alloc(uv_handle_t* had_u,
             )
 {
   //  this read can range from a single byte to a paste buffer
-  //  123 bytes has been chosen because its not a power of 2
-  //  this is probably still broken
   //
-  void* ptr_v = c3_malloc(123);
-  *buf = uv_buf_init(ptr_v, 123);
+  void* ptr_v = c3_malloc(128);
+  *buf = uv_buf_init(ptr_v, 128);
 }
 
 /* u3_term_log_init(): initialize terminal for logging
@@ -798,16 +796,7 @@ _term_suck(u3_utty* uty_u, const c3_y* buf, ssize_t siz_i)
 {
   {
     if ( siz_i == UV_EOF ) {
-      //  We hear EOF (on the third read callback) if
-      //  2x the _term_alloc() buffer size is pasted.
-      //  The process hangs if we do nothing (and ctrl-z
-      //  then corrupts the event log), so we force shutdown.
-      //
-      u3l_log("term: hangup (EOF)");
-
-      //  XX revise
-      //
-      u3_pier_bail(u3_king_stub());
+      return;
     }
     else if ( siz_i < 0 ) {
       u3l_log("term %d: read: %s", uty_u->tid_l, uv_strerror(siz_i));

--- a/pkg/vere/platform/darwin/ptty.c
+++ b/pkg/vere/platform/darwin/ptty.c
@@ -178,7 +178,7 @@ u3_ptty_init(uv_loop_t* lup_u, const c3_c** err_c)
     pty_u->raw_u.c_cflag &= ~(CSIZE | PARENB);
     pty_u->raw_u.c_cflag |= CS8;
     pty_u->raw_u.c_oflag &= ~(OPOST);
-    pty_u->raw_u.c_cc[VMIN] = 0;
+    pty_u->raw_u.c_cc[VMIN] = 1;
     pty_u->raw_u.c_cc[VTIME] = 0;
   }
 

--- a/pkg/vere/platform/linux/ptty.c
+++ b/pkg/vere/platform/linux/ptty.c
@@ -178,7 +178,7 @@ u3_ptty_init(uv_loop_t* lup_u, const c3_c** err_c)
     pty_u->raw_u.c_cflag &= ~(CSIZE | PARENB);
     pty_u->raw_u.c_cflag |= CS8;
     pty_u->raw_u.c_oflag &= ~(OPOST);
-    pty_u->raw_u.c_cc[VMIN] = 0;
+    pty_u->raw_u.c_cc[VMIN] = 1;
     pty_u->raw_u.c_cc[VTIME] = 0;
   }
 


### PR DESCRIPTION
There exists a longstanding bug that shows up when you paste text into the dojo with a length of any multiple of 123 characters. This is most easily reproduced by running `(crip (reap 123 'a'))` in the dojo and copy pasting the output back into the terminal.

The root cause turns out to be a misconfigured terminal. We specify a `VMIN` of 0 for our `termios` struct, which results in the [following behavior](https://www.man7.org/linux/man-pages/man3/termios.3.html).
```
MIN == 0, TIME == 0 (polling read)
If data is available, read(2) returns immediately, with the
lesser of the number of bytes available, or the number of
bytes requested.  If no data is available, read(2) returns 0.
```

Consider what happens when libuv tries to read exactly 123 characters with a buffer that's also 123 character large. The first `read` call will return all the characters but does not indicate that there aren't more characters to come. A second `read` call will thus be made returning 0.

Libuv of course has no idea that our terminal is this wonky so it reasonably assumes that the zero returned by `read` is `EOF` and dutifully stops the read handle, which explains why hang if we no-op in response to `EOF` without this fix:

https://github.com/libuv/libuv/blob/8fb9cb919489a48880680a56efecff6a7dfb4504/src/unix/stream.c#L1110-L1111
https://github.com/libuv/libuv/blob/8fb9cb919489a48880680a56efecff6a7dfb4504/src/unix/stream.c#L932-L939