### PR TITLE
jinx fix for hot loops

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1232,11 +1232,10 @@ _m_renew_timer(u3_atom now)
         min = ( u3_nul == min ) ? u3k(fut) : u3ka_min(min, u3k(fut));
       }
       else {
-        c3_c* now_c = u3m_pretty_road(now);
-        c3_c* fut_c = u3m_pretty_road(fut);
-        u3l_log("strange timer: now %s, fut %s", now_c, fut_c);
-        u3a_free(now_c);
-        u3a_free(fut_c);
+        //  we are waiting for the signal to come, do nothing
+        //
+        u3z(min);
+        return;
       }
     }
     if ( !rod_u->par_p ) break;


### PR DESCRIPTION
Apparently SIGVTALRM does not happen soon enough if we are producing `%jinx` hints in a hot loop, like:

```
|-  ~>  %jinx.~s1  $
```

With "strange timer" printouts the runtime would stall, trying to print a ton of stale timers. Even without the printouts stale deadlines would get ignored, causing the virtual timer to be set with a new timeout, so the signal would never come.

Now we noop if we encounter at least one stale timer, unlike previously, when we would noop if all timers were stale.