### PR TITLE
jets: fix sort jet

### DIFF
--- a/pkg/noun/jets/b/sort.c
+++ b/pkg/noun/jets/b/sort.c
@@ -10,8 +10,8 @@ static_assert( (UINT32_MAX > u3a_cells),
                "length precision" );
 
 static_assert(
-  (UINT32_MAX < (SIZE_MAX / (2 * sizeof(u3_noun)))),
-  "len_w * sizeof u3_noun overflow"
+  (UINT32_MAX < (SIZE_MAX / (3 * sizeof(u3_noun)))),
+  "allocation size overflow"
 );
 
 static void


### PR DESCRIPTION
There was a jet mismatch discovered by ~nomryg-nilref for these values of the comparator gate and the list:

```
|=  [a=@ b=@]
~+
^-  ?
?:  =(a b)  %.y
=/  e  *(list ?)
|-
=+  [c=(end 3 a) d=(end 3 b)]
?:  =(c 0)
  ?:  &(=(d 0) (gth (lent e) 0))
    -:(flop e)
  %.y
?:  =(d 0)
  %.n
::
?:  &((gte (mix c d) 32) (gte (dis c d) 64))
  ?:  (lth c d)
    ?:  (lth c (sub d 32))   %.y
    ?:  (gth c (sub d 32))   %.n
    ?:  =(c (sub d 32))      $(a (rsh 3 a), b (rsh 3 b), e [%.y e])
    $(a (rsh 3 a), b (rsh 3 b), e [%.y e])
  ?:  =((sub c 32) d)
    ?:  =((rsh 3 a) 0)
      ?:  =((rsh 3 b) 0)
        %.n
      %.y
    %.n
  ?:  (gth c d)
    ?:  (lth (sub c 32) d)
      %.y
    %.n
  ~|("can't get here" !!)
::
?:  =(c d)
  $(a (rsh 3 a), b (rsh 3 b))
(lth c d)
::
:~  'abc'
    'aBc'
    'ab'
    'Abc'
    'A'
    'b'
    'bb'
    'abC'
    'aB'
    'ABC'
    'AbC'
    'a'
    'bac'
    'aBC'
    'Ab'
    'ABc'
    'AB'
==
```

The jet and the Hoon implementation partitioned/merged sorted sublists differently, leading to a different result. I tested the jet implementation for stability using pairs of values and initial indices, but apparently that was not enough.

This implementation partitions the lists in the same way Hoon version of `+sort` does. ~This is a draft as I want to compare the performance with the original version of the jet.~ This implementation works the same way [the old one](https://github.com/urbit/vere/blob/9fe5401b7e498acd95024ffb6996972eb52af10e/pkg/noun/jets/b/sort.c) did, except it doesn't allocate a ton of cells in the process:

1. Make two partitions using the first element as a pivot. The order within partitions is preserved
2. Partitions are sorted
3. First partition, the pivot and the second partition are concatenated

The only difference is the order of operations: here I copy the partitions back into the array first, then sort the partitions. But since they are sorted independently, these operations are orthogonal to each other