### PR TITLE
http: set bem.cas to 0 if scrying at latest

### DIFF
--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -39,6 +39,7 @@
 #   define c3__axis   c3_s4('a','x','i','s')
 #   define c3__b      c3_s1('b')
 #   define c3__bac    c3_s3('b','a','c')
+#   define c3__bad    c3_s3('b','a','d')
 #   define c3__bach   c3_s4('b','a','c','h')
 #   define c3__bag    c3_s3('b','a','g')
 #   define c3__bail   c3_s4('b','a','i','l')

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -900,7 +900,11 @@ _get_beam(u3_hreq* req_u, c3_c* txt_c, c3_w len_w)
       }
       else {
         req_u->peq_u->las_o = c3y;
-        *wer = u3_nul;
+        // if you are seeing scries with the case %bad/6.578.530/6578530
+        // then this placeholder value is used somewhere even though it
+        // shouldn't be
+        //
+        *wer = c3__bad;
       }
       txt_c++;
       len_w--;


### PR DESCRIPTION
Before #912 `bem.cas` was set to some garbage value if the scry occured at latest case, which was not equal to `u3_none`, allowing the scry request to go through. After #912 scrying at latest was essentially forbidden. This commit sets `bem.cas` to 0 to pass the check. The actual value does not matter since it won't be used.