### PR TITLE
http: don't wait for bodies of empty responses

### DIFF
--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1357,10 +1357,12 @@ _http_start_respond(u3_hreq* req_u,
                       (status < 500) ? "missing" :
                       "hosed";
 
+  h2o_iovec_t meth_u = req_u->rec_u->method;
   c3_o emp_t = ( status < 200 )
             || ( 204 == status )
             || ( 205 == status )
-            || ( 304 == status );
+            || ( 304 == status )
+            || ( 0 == strncmp("HEAD", meth_u.base, meth_u.len) );
 
   u3_hhed* hed_u = _http_heds_from_noun(u3k(headers));
   u3_hhed* deh_u = hed_u;


### PR DESCRIPTION
I was seeing 502 Bad Gateway in some of responses to polling requests in the web interface of a Gall agent. Caddy logs showed an error:

```
transport connection broken: malformed HTTP version "nullHTTP/1.1"
```

Notably, I was sending "null" body with 204 No Content response, which must not have a body. Changing response to "true" changed the HTTP version to "trueHTTP/1.1"

After playing around in http.c I came to a conclusion that h2o is probably not waiting for the rest of the response, since it assumes that it won't have a body according to [the HTTP spec](https://datatracker.ietf.org/doc/html/rfc9110#section-15.3.5-5).

So what probably happens is, Eyre sends the rest of 204 response body, while h2o already moved on. Body of the response is left in some buffer which gets concatenated with the next response, corrupting it.

This PR adds another HTTP request state, `u3_rsat_sown`, which guarantees that the response was already sent. Following `%continue` and `%cancel` effects are noops.

Additionaly, response body is set to 0 for all informational responses (1xx), 204, 205 (Reset Content) and 304 (Not Modified).