### PR TITLE
Async signal/bail safety

### DIFF
--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -15,6 +15,22 @@
 */
 #define BIT_SET(a_w, b_w) ((a_w) & ((c3_w)1 << (b_w)))
 
+/* asserting noun deconstruction to make sure HAMTs are bail-safe
+*/
+static inline u3_noun
+_h_need(u3_noun som)
+{
+  u3_assert( _(u3a_is_cell(som)) );
+  return ((u3a_cell *)u3a_to_ptr(som))->hed;
+}
+
+static inline u3_noun
+_t_need(u3_noun som)
+{
+  u3_assert( _(u3a_is_cell(som)) );
+  return ((u3a_cell *)u3a_to_ptr(som))->tel;
+}
+
 static u3_weak
 _ch_trim_slot(u3h_root* har_u, u3h_slot *sot_w, c3_w lef_w, c3_w rem_w);
 
@@ -135,7 +151,7 @@ _ch_buck_add(u3h_buck* hab_u, u3_noun kev, c3_w *use_w)
   //
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
     u3_noun kov = u3h_slot_to_noun(hab_u->sot_w[i_w]);
-    if ( c3y == u3r_sing(u3h(kev), u3h(kov)) ) {
+    if ( c3y == u3r_sing(_h_need(kev), _h_need(kov)) ) {
       hab_u->sot_w[i_w] = u3h_noun_to_slot(kev);
       u3z(kov);
       return hab_u;
@@ -233,13 +249,13 @@ _ch_slot_put(u3h_slot* sot_w, u3_noun kev, c3_w lef_w, c3_w rem_w, c3_w* use_w)
   else {
     u3_noun  kov   = u3h_slot_to_noun(*sot_w);
     u3h_slot add_w = u3h_noun_be_warm(u3h_noun_to_slot(kev));
-    if ( c3y == u3r_sing(u3h(kev), u3h(kov)) ) {
+    if ( c3y == u3r_sing(_h_need(kev), _h_need(kov)) ) {
       // replace old value
       u3z(kov);
       *sot_w = add_w;
     }
     else {
-      c3_w ham_w = CUT_END(u3r_mug(u3h(kov)), lef_w);
+      c3_w ham_w = CUT_END(u3r_mug(_h_need(kov)), lef_w);
       *sot_w     = _ch_two(*sot_w, add_w, lef_w, ham_w, rem_w);
       *use_w    += 1;
     }
@@ -309,7 +325,7 @@ _ch_buck_del(u3h_slot* sot_w, u3_noun key)
   //
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
     u3_noun kov = u3h_slot_to_noun(hab_u->sot_w[i_w]);
-    if ( c3y == u3r_sing(key, u3h(kov)) ) {
+    if ( c3y == u3r_sing(key, _h_need(kov)) ) {
       fin_w = i_w;
       u3z(kov);
       break;
@@ -446,7 +462,7 @@ _ch_uni_with(u3_noun kev, void* wit)
 {
   u3p(u3h_root) har_p = *(u3p(u3h_root)*)wit;
   u3_noun key, val;
-  u3x_cell(kev, &key, &val);
+  u3_assert(c3y == u3r_cell(kev, &key, &val));
 
   u3h_put(har_p, key, u3k(val));
 }
@@ -650,7 +666,7 @@ _ch_buck_hum(u3h_buck* hab_u, c3_w mug_w)
   c3_w i_w;
 
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
-    if ( mug_w == u3r_mug(u3h(u3h_slot_to_noun(hab_u->sot_w[i_w]))) ) {
+    if ( mug_w == u3r_mug(_h_need(u3h_slot_to_noun(hab_u->sot_w[i_w]))) ) {
       return c3y;
     }
   }
@@ -679,7 +695,7 @@ _ch_node_hum(u3h_node* han_u, c3_w lef_w, c3_w rem_w, c3_w mug_w)
     if ( _(u3h_slot_is_noun(sot_w)) ) {
       u3_noun kev = u3h_slot_to_noun(sot_w);
 
-      if ( mug_w == u3r_mug(u3h(kev)) ) {
+      if ( mug_w == u3r_mug(_h_need(kev)) ) {
         return c3y;
       }
       else {
@@ -715,7 +731,7 @@ u3h_hum(u3p(u3h_root) har_p, c3_w mug_w)
   else if ( _(u3h_slot_is_noun(sot_w)) ) {
     u3_noun kev = u3h_slot_to_noun(sot_w);
 
-    if ( mug_w == u3r_mug(u3h(kev)) ) {
+    if ( mug_w == u3r_mug(_h_need(kev)) ) {
       return c3y;
     }
     else {
@@ -738,8 +754,8 @@ _ch_buck_git(u3h_buck* hab_u, u3_noun key)
 
   for ( i_w = 0; i_w < hab_u->len_w; i_w++ ) {
     u3_noun kev = u3h_slot_to_noun(hab_u->sot_w[i_w]);
-    if ( _(u3r_sing(key, u3h(kev))) ) {
-      return u3t(kev);
+    if ( _(u3r_sing(key, _h_need(kev))) ) {
+      return _t_need(kev);
     }
   }
   return u3_none;
@@ -767,8 +783,8 @@ _ch_node_git(u3h_node* han_u, c3_w lef_w, c3_w rem_w, u3_noun key)
     if ( _(u3h_slot_is_noun(sot_w)) ) {
       u3_noun kev = u3h_slot_to_noun(sot_w);
 
-      if ( _(u3r_sing(key, u3h(kev))) ) {
-        return u3t(kev);
+      if ( _(u3r_sing(key, _h_need(kev))) ) {
+        return _t_need(kev);
       }
       else {
         return u3_none;
@@ -804,9 +820,9 @@ u3h_git(u3p(u3h_root) har_p, u3_noun key)
   else if ( _(u3h_slot_is_noun(sot_w)) ) {
     u3_noun kev = u3h_slot_to_noun(sot_w);
 
-    if ( _(u3r_sing(key, u3h(kev))) ) {
+    if ( _(u3r_sing(key, _h_need(kev))) ) {
       har_u->sot_w[inx_w] = u3h_noun_be_warm(sot_w);
-      return u3t(kev);
+      return _t_need(kev);
     }
     else {
       return u3_none;
@@ -991,8 +1007,8 @@ static u3h_slot
 _ch_take_noun(u3h_slot sot_w, u3_funk fun_f)
 {
   u3_noun kov = u3h_slot_to_noun(sot_w);
-  u3_noun kev = u3nc(u3a_take(u3h(kov)),
-                     fun_f(u3t(kov)));
+  u3_noun kev = u3nc(u3a_take(_h_need(kov)),
+                     fun_f(_t_need(kov)));
 
   return u3h_noun_to_slot(kev);
 }

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1383,7 +1383,14 @@ u3m_warm(u3_noun pro)
   c3_o tim_o = u3du(u3R->tim);
   u3m_fall();
   if ( _(tim_o) ) _m_renew_now();
-  return u3a_take(pro);
+  pro = u3a_take(pro);
+
+  //  pop the stack
+  //
+  u3a_drop_heap(u3R->cap_p, u3R->ear_p);
+  u3R->cap_p = u3R->ear_p;
+  u3R->ear_p = 0;
+  return pro;
 }
 
 /* u3m_pour(): return error ball from leap, promoting the state if the error

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1375,6 +1375,36 @@ u3m_love(u3_noun pro)
   return pro;
 }
 
+/* u3m_warm(): return product from leap without promoting state
+*/
+u3_noun
+u3m_warm(u3_noun pro)
+{
+  c3_o tim_o = u3du(u3R->tim);
+  u3m_fall();
+  if ( _(tim_o) ) _m_renew_now();
+  return u3a_take(pro);
+}
+
+/* u3m_pour(): return error ball from leap, promoting the state if the error
+ * is deterministic
+*/
+u3_noun
+u3m_pour(u3_noun why)
+{
+  u3_assert(c3y == u3du(why));
+  switch (u3h(why)) {
+    case 0:
+    case 1: {
+      return u3m_love(why);
+    } break;
+
+    default: {
+      return u3m_warm(why);
+    } break;
+  }
+}
+
 /* u3m_golf(): record cap_p length for u3m_flog().
 */
 c3_w
@@ -1505,7 +1535,7 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
   else {
     /* Overload the error result.
     */
-    pro = u3m_love(why);
+    pro = u3m_pour(why);
   }
 
   /* Revert to external signal regime.
@@ -1636,7 +1666,7 @@ u3m_soft_cax(u3_funq fun_f,
         } break;
 
         case 3: {                             //  failure; rebail w/trace
-          u3_noun yod = u3m_love(u3t(why));
+          u3_noun yod = u3m_warm(u3t(why));
 
           u3m_bail
             (u3nt(3,
@@ -1739,7 +1769,7 @@ u3m_soft_run(u3_noun gul,
         } break;
 
         case 3: {                             //  failure; rebail w/trace
-          u3_noun yod = u3m_love(u3t(why));
+          u3_noun yod = u3m_warm(u3t(why));
 
           u3m_bail
             (u3nt(3,
@@ -1748,7 +1778,7 @@ u3m_soft_run(u3_noun gul,
         } break;
 
         case 4: {                             //  meta-bail
-          u3m_bail(u3m_love(u3t(why)));
+          u3m_bail(u3m_pour(u3t(why)));
         } break;
       }
     }
@@ -1808,7 +1838,7 @@ u3m_soft_esc(u3_noun ref, u3_noun sam)
     /* Push the error back up to the calling context - not the run we
     ** are in, but the caller of the run, matching pure nock semantics.
     */
-    u3m_bail(u3nc(4, u3m_love(why)));
+    u3m_bail(u3nc(4, u3m_pour(why)));
   }
 
   /* Release the sample.  Note that we used it above, but in a junior

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -285,7 +285,14 @@ _cm_stack_unwind(void)
   u3_noun tax;
 
   while ( u3R != &(u3H->rod_u) ) {
-    u3_noun yat = u3m_love(u3R->bug.tax);
+    u3_noun yat = u3R->bug.tax;
+    u3m_fall();
+    yat = u3a_take(yat);
+    //  pop the stack
+    //
+    u3a_drop_heap(u3R->cap_p, u3R->ear_p);
+    u3R->cap_p = u3R->ear_p;
+    u3R->ear_p = 0;
 
     u3R->bug.tax = u3kb_weld(yat, u3R->bug.tax);
   }


### PR DESCRIPTION
This PR draft documents the attempt to make road promotion safer when it comes to async signal handling and `u3m_bail` calls.

- [ ] `jets.c`
- [ ] `nock.c`

### Problem

In Vere we have nonlinear control flow in the form of exception raising with `u3m_bail` and catching it in various wrappers like `u3m_soft_run` and signal handling via `u3m_soft_top`/`u3m_signal`. So there are three ways we can "return" from a wrapped computation:

1. We can actually return from it, copying the product and some persistent state out of the child road, returning the product to the caller and integrating the produced persistent state into the state of the parent road;
2. We can jump out via `u3m_bail` call. The exception will either be turned into a noun, allowing Nock virtualization via metacircular jets, or the exception will be raised again to bubble it up to the top, eventually crashing the event transaction and printing a stacktrace. We still promote and integrate the accumulated persistent state;
3. We can jump out all the way to the top wrapper via a signal. In this case we repeatedly perform road promotion and accumulate the stack traces from all roads. Doing so, **we also promote and integrate the accumulated persistent state**.

I noticed the latter when experimenting with Ford Lightning build system: hitting ^C mid build would interrupt it, and if the build was retried it would take less time than if it was done the first time without interruption. This is because some persistent caches were already accumulated and promoted to the home road on SIGINT handling.

This rang an alarm bell in my head: for this to properly work we would need to make sure that all functions that modify road state (`u3h_*`, functions that modify bytecode programs) are async-signal safe, otherwise, we might be promoting state that does not uphold its invariants.

After a discussion at core blitz on ~2026.1.9, @joemfb raised a concern that the issue has a broader scope, as signals are not the only piece of non-linear control flow in the codebase. Functions that modify road state must also be exception-handling safe: at each `u3m_bail` callsite the road state needs to conform to its invariants too.

It is worth noting that not all invariants need to be upheld at either bail or signal raise: for HAMTs it is sufficient to be walkable and have valid values. An example of HAMT having an invalid value: if a SIGINT comes between lines 1502-1506 here:
https://github.com/urbit/vere/blob/33671ea187baff627a05996b66f98dc579239fca/pkg/noun/jets.c#L1502-L1506

, the site struct will have a bytecode program pointer that does not correspond to the battery stored in `bat` field.

_(This particular example does not allow to produce a bug because this fields are erased anyway when [we call a program from a senior road](https://github.com/urbit/vere/blob/33671ea187baff627a05996b66f98dc579239fca/pkg/noun/nock.c#L1722-L1723))_

### Solution

I decided to minimize the surface area of code where the async-signal safety is required by only promoting the road state if:

- the wrapped function returned sucesfully,
- OR if the error is deterministic

With that, the only thing we are doing when async signal or nondeterministic error are raised is copying out nouns.

#### Nouns are (almost) async-signal safe

The only operation that is not async-signal safe is `u3i_edit`, if it is performed on a mutable noun (refcount of 1). The only place where it is used is in the Nock bytecode interpreter, and in case of any crash the product from the road stack is not being promoted anyway, so the stacktraces and error reports are safe.

#### HAMTs are fine

The only calls to `u3m_bail` in `hashtable.c` were in `u3_assert` (bail with c3__oops mote, which is not recoverable) and `u3h/t` macros to disassemble key-value pairs. These are always cells by construction, so no change is necessary, but I replaced them with asserting versions for documentation purposes, just to be sure.

#### Nock interpreter: to verify

Cursory look at `nock.c`/`jets.c` didn't raise any alarms, but I might be missing something. In `jets.c` `u3h/t` macros are used everywhere to dissassemble nouns from jet state and to disassemble cores for Nock 9 calls. The former should be infallible, and the latter could legitimately crash, so more attention is necessary there.