### PR TITLE
http: enable h2o's response compression

### DIFF
--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1400,7 +1400,7 @@ _http_start_respond(u3_hreq* req_u,
     }
     else {
       h2o_add_header_by_str(&rec_u->pool, &rec_u->res.headers,
-                            hed_u->nam_c, hed_u->nam_w, 0, 0,
+                            hed_u->nam_c, hed_u->nam_w, 1, 0,
                             hed_u->val_c, hed_u->val_w);
     }
 
@@ -2185,6 +2185,17 @@ _http_serv_init_h2o(SSL_CTX* tls_u, c3_o log, c3_o red)
   h2o_u->cep_u.hosts = h2o_u->fig_u.hosts;
   h2o_u->cep_u.ssl_ctx = tls_u;
 
+  //  register compression filter first
+  //
+  {
+    h2o_compress_args_t com_u;
+    memset(&com_u, 0, sizeof(com_u));
+    com_u.min_size = 128;
+    com_u.gzip.quality = 6;
+    com_u.brotli.quality = 5;
+    h2o_compress_register(&h2o_u->hos_u->fallback_path, &com_u);
+  }
+
   h2o_u->han_u = h2o_create_handler(&h2o_u->hos_u->fallback_path,
                                     sizeof(*h2o_u->han_u));
   if ( c3y == red ) {
@@ -2248,8 +2259,6 @@ _http_serv_init_h2o(SSL_CTX* tls_u, c3_o log, c3_o red)
     u3z(now);
 #endif
   }
-
-  // XX h2o_compress_register
 
   h2o_context_init(&h2o_u->ctx_u, u3L, &h2o_u->fig_u);
 


### PR DESCRIPTION
Adds a compression handler, configured to support gzip and brotli for responses of non-trivial size.

The library takes care of applying compression only on content types where this makes sense. For now, we're deferring to h2o's defaults, which is essentially a whitelist containing most common text-based mime types.

We lightly adjust the `h2o_add_header_by_str` call so that h2o tokenizes our headers appropriately, letting it detect the content type.

With this change, we see bytes-over-the-wire reduced as expected.
A cache refresh of the groups web client on a ship with very little content (so, primarily .js file downloads) goes down from ~10mb to ~3mb transferred. (~30%)
Filling a channel with small posts by the same author gives a "recent posts" json scry result of ~23kb, but only uses ~3kb over the wire. (~13%!)

Happy to bikeshed the compression configuration here. I just picked values that seemed fairly middle-of-the-road.