### PR TITLE
term: clamp zero window size from Docker PTY

### DIFF
--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -1041,8 +1041,8 @@ u3_term_get_blew(c3_l tid_l)
     //  clamp to defaults if ioctl returns zero
     //  (e.g. Docker PTY with no attached reader)
     //
-    if ( !col_l ) { col_l = 80; }
-    if ( !row_l ) { row_l = 24; }
+    if ( 0 == col_l ) { col_l = 80; }
+    if ( 0 == row_l ) { row_l = 24; }
     uty_u->tat_u.siz.col_l = col_l;
     uty_u->tat_u.siz.row_l = row_l;
   }

--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -149,7 +149,7 @@ u3_term_log_init(void)
     //
     {
       uty_u->tat_u.siz.col_l = 80;
-      uty_u->tat_u.siz.row_l = 0;
+      uty_u->tat_u.siz.row_l = 24;
     }
 
     //  initialize spinner state
@@ -1038,6 +1038,11 @@ u3_term_get_blew(c3_l tid_l)
   if ( (c3n == u3_Host.ops_u.tem) && uty_u &&
        (c3y == uty_u->wsz_f(uty_u, &col_l, &row_l)) )
   {
+    //  clamp to defaults if ioctl returns zero
+    //  (e.g. Docker PTY with no attached reader)
+    //
+    if ( !col_l ) { col_l = 80; }
+    if ( !row_l ) { row_l = 24; }
     uty_u->tat_u.siz.col_l = col_l;
     uty_u->tat_u.siz.row_l = row_l;
   }


### PR DESCRIPTION
## Summary
- When Docker allocates a PTY (`tty: true` + `stdin_open: true`) but nobody is attached, `TIOCGWINSZ` succeeds but reports 0x0
- This causes unsigned underflow in `row_l - 1` calculations throughout term.c and a `decrement-underflow` crash in drum when it receives `%blew [0 0]`
- Clamp to 80x24 defaults when ioctl returns zero dimensions (matching existing fallback when ioctl fails)
- Fix initial default `row_l` from 0 to 24

Resolves #159.
See also [urbit/urbit#4750](https://github.com/urbit/urbit/issues/4750)

## Disclaimer

I made this change using a coding agent. Please pardon any slop.

## Test plan
- [x] Build with `zig build`
- [x] Cross-compile with `zig build -Dtarget=aarch64-linux-musl -Doptimize=ReleaseFast`
- [x] Run in Docker with `tty: true` + `stdin_open: true` and no `docker attach` — ship boots without crashing
- [x] Verify `docker attach` / detach still works after boot

### Reproduction steps
```bash
# Cross-compile for Linux
zig build -Dtarget=aarch64-linux-musl -Doptimize=ReleaseFast

# Build Docker image
cp zig-out/aarch64-linux-musl/urbit docker/
docker build -t vere-test docker/

# Create volume with comet file
docker volume create test-comet
docker run --rm -v test-comet:/urbit alpine touch /urbit/test-ship.comet

# Run with tty + stdin_open, no attach (previously crashed)
docker run -d --name test-vere -t -i -v test-comet:/urbit vere-test

# Verify ship boots
docker logs -f test-vere

# Cleanup
docker stop test-vere && docker rm test-vere
docker volume rm test-comet
```