### PR TITLE
jets: don't bail in _cj_spot if core is atom

### DIFF
--- a/pkg/noun/jets.c
+++ b/pkg/noun/jets.c
@@ -620,6 +620,8 @@ _cj_spot_hot(u3_noun cor, u3_noun bas, u3_noun* loc)
 static u3_weak
 _cj_spot(u3_noun cor, u3_weak* bas)
 {
+  if ( c3y == u3ud(cor) ) return u3_none;
+
   u3_weak bak = u3_none,
           bar = u3_none,
           reg = u3_none,


### PR DESCRIPTION
```
> .*([-:dec 10.000 ~] [9 2 0 1])
dojo: hoon expression failed
> .*([-:dec 10.000 ~] -:dec)
9.999
```

Obviously these two expressions should produce `9.999`. If you are not convinced, let's run `+mink` unjetted on the first expression:

```
> .*([-:mink [[[-:dec 10.000 ~] 9 2 0 1] _~] +>:mink] -:mink)
[0 9.999]
```

The difference is that the first expression goes through jet matching code since it uses a Nock 9. `+dec` is registered with its parent at axis 7. When `_cj_spot` tries to match that parent it bails with `c3__exit` inside of `u3h` macro calls, since we replaced the parent with `~`. This assertion ends up breaking Nock semantics.