### PR TITLE
term: clamp zero window size from Docker PTY

### DIFF
--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -1038,6 +1038,11 @@ u3_term_get_blew(c3_l tid_l)
   if ( (c3n == u3_Host.ops_u.tem) && uty_u &&
        (c3y == uty_u->wsz_f(uty_u, &col_l, &row_l)) )
   {
+    //  clamp to defaults if ioctl returns zero
+    //  (e.g. Docker PTY with no attached reader)
+    //
+    if ( 0 == col_l ) { col_l = 80; }
+    if ( 0 == row_l ) { row_l = 24; }
     uty_u->tat_u.siz.col_l = col_l;
     uty_u->tat_u.siz.row_l = row_l;
   }


### PR DESCRIPTION
## Summary

- When Docker allocates a PTY (`tty: true` + `stdin_open: true`) but nobody is attached, `TIOCGWINSZ` succeeds but reports 0x0
- This causes a `decrement-underflow` crash in drum when it receives `%blew [0 0]`
- Clamp to 80x24 defaults when ioctl returns zero dimensions (matching existing fallback when ioctl fails)

This is a v2 of #959, which was merged then reverted due to a regression. The prior version also changed the initial `row_l` from 0 to 24, which broke terminal output on macOS — `row_l = 0` is a sentinel used by `hija`/`loja` and the spinner to skip cursor positioning during early boot. Setting it to 24 caused every `u3l_log()` call before the first `%blew` event to reposition the cursor, producing blank lines. This version keeps `row_l = 0` and only adds the clamping in `u3_term_get_blew`.

Resolves #159.
See also [urbit/urbit#4750](https://github.com/urbit/urbit/issues/4750)

## Test results

**Docker on x86_64 Linux VPS** (Ubuntu, `tty: true` + `stdin_open: true`, no attach):
- Cross-compiled for `x86_64-linux-musl`, built Docker image, transferred to VPS
- Fresh comet booted successfully, ran 8+ minutes with no crash
- Container config matches the exact scenario that triggers the bug

**macOS aarch64** (native build, PTY via `script`):
- Fresh comet booted, full bootstrap completed
- No spurious blank lines in boot output (the regression from #959 is fixed)
- Early boot log lines use plain text (no cursor positioning), confirming `row_l = 0` sentinel works correctly