### PR TITLE
spin: stash stack pointer on the parent road, restore from it

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -998,12 +998,6 @@ u3m_bail(u3_noun how)
     }
   }
 
-  // Reset the spin stack pointer
-  if ( NULL != stk_u ) {
-    stk_u->off_w = u3R->off_w;
-    stk_u->fow_w = u3R->fow_w;
-  }
-
   _longjmp(u3R->esc.buf, how);
 }
 
@@ -1134,10 +1128,10 @@ u3m_leap(c3_w pad_w)
     u3R->kid_p = u3of(u3_road, rod_u);
   }
 
-  // Add slow stack pointer to rod_u
+  // Stash slow stack pointer
   if ( NULL != stk_u ) {
-    rod_u->off_w = stk_u->off_w;
-    rod_u->fow_w = stk_u->fow_w;
+    u3R->off_w = stk_u->off_w;
+    u3R->fow_w = stk_u->fow_w;
   } 
 
   /* Set up the new road.
@@ -1352,6 +1346,12 @@ u3m_love(u3_noun pro)
   u3m_fall();
 
   if ( _(tim_o) ) _m_renew_now();
+
+  // restore slow stack pointer
+  if ( NULL != stk_u ) {
+    stk_u->off_w = u3R->off_w;
+    stk_u->fow_w = u3R->fow_w;
+  }
 
   //  copy product and caches off our stack
   //


### PR DESCRIPTION
Resolves #965

Currently, when new road is entered, the state of the spin stack is saved on that road, and it is restored in `u3m_bail` before longjump. However, u3m_bail is not the only way to leave a road with non-local control flow, we can also jump back all the way to the home road on a signal, e.g. SIGINT.

This caused the spin stack offset to be set to zero (because apparently it was the initial value in the home road), which broke logic in `_http_spin_timer_cb`, which assumes that there is always an offset of at least 4 (likely comes from `c3__root` initialization).

This PR fixes the road entry/exit logic by stashing the stack info on the road that we are about to leave, and restoring it on road promotion. That way the home road values are set on leap from the home road, so `_cm_signal_recover` correctly restores the state of the spin stack on ^C.