### PR TITLE
manage: zero-initialize future proof buffer

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -665,6 +665,8 @@ _find_home(void)
   if (!u3R->lop_p) {
     u3R->lop_p = u3h_new();
   }
+  
+  memset(u3R->fut_w, 0, sizeof(u3R->fut_w));
 }
 
 /* u3m_pave(): instantiate or activate image.


### PR DESCRIPTION
@pkova noticed that a bunch of Tlon-hosted ship started exhibiting strange behavior: they were breaking on `|pack`/`|mass` and/or other such utilities. Investigations lead to noticing that `u3_road.lop_p` was pointing to some garbage instead of an empty HAMT as one would expect. It was also discovered that these ships went from vere 4.1 to 4.0 back to 4.1. Notably, loop hint was introduced in 4.1.

Was seems to be happening is, when a ship was packed with a downgraded binary, the value of `lop_p` would not be rewritten, as from Vere 4.0 POV `lop_p` is just a part of the future-proof buffer, making it point into some nonsense. When the ship was booted with Vere 4.1 again, the "upgrade" code that initialized `lop_p` with `u3h_new` if it was set to 0 would not fire, as it was not 0.

This PR adds explicit zero-initialization of the future-proof buffer on boot to prevent stale references from persisting after downgrade. If this code was present back in 4.0, the effect would be much less harmful: the original HAMT would just get leaked and a new one would be allocated on boot with Vere 4.1. The former would be freed any time `|mass` is ran.

In the future one must be cognizant of adding things to the future-proof buffer without incrementing loom version (and thus, firsly, having to write a full loom migration, and secondly, disallowing downgrades).

---

@pkova, this just occured to me: what if instead of zero-initializing `fut_w` on boot we check if it is full of zeros, and not booting if it is not true? Sort of preventing downgrades that way without incrementing the loom version number...