### PR TITLE
manage: detect downgrades by inspecting fut_w on boot

### DIFF
--- a/pkg/c3/defs.h
+++ b/pkg/c3/defs.h
@@ -283,4 +283,6 @@ c3_align_p(void const * p, size_t al, align_dir hilo) {
 #define c3_likely(x)    ( __builtin_expect(!!(x), 1) )
 #define c3_unlikely(x)  ( __builtin_expect(!!(x), 0) )
 
+#define c3_array_len(arr)  ( sizeof(arr) / sizeof(arr[0]) )
+
 #endif /* ifndef C3_DEFS_H */

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -617,6 +617,10 @@ _find_home(void)
     u3R->mat_p = u3R->cap_p = top_p;
   }
 
+  for (c3_w i_w = 0; i_w < c3_array_len(u3R->fut_w); i_w++) {
+    u3_assert(!u3R->fut_w[i_w] && "loom: downgrade detected");
+  }
+
   //  check for obvious corruption
   //
   {


### PR DESCRIPTION
Replaces #971

Detects downgrades by checking if zero-initialized future-proof buffer is actually full of zeros.