### PR TITLE
wasm: stash more globals

### DIFF
--- a/ext/wasm3/build.zig.zon
+++ b/ext/wasm3/build.zig.zon
@@ -8,8 +8,8 @@
         },
         .wasm3 = .{
             // .path = "../../../../wasm3"
-            .url = "https://github.com/urbit/wasm3/archive/48832a8e023b57d671be6c0bab8608d30cb57101.tar.gz",
-            .hash = "N-V-__8AANAcSQBq71EmfSas8hV9_SOtu1AjOvuUcWZce5VM",
+            .url = "https://github.com/urbit/wasm3/archive/be8cbeafa8b2301350484ecb494ed0288589d985.tar.gz",
+            .hash = "N-V-__8AAHEiSQD6ts4e3wCZ7CFp6FAQU4Dg5kBTwgSQpIDY",
         },
     },
     .paths = .{

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -138,26 +138,17 @@ uw_slam_check(u3_noun gat, u3_noun sam, c3_t is_stateful)
   }
   else
   {
-    u3_noun ton = u3n_nock_an(cor, bat);
-    
-    u3_noun tag, res;
-    if (c3n == u3r_cell(ton, &tag, &res))
-    {
-      return u3m_bail(c3__fail);
-    }
-    if (0 == tag)
-    {
-      u3k(res);
-      u3z(ton);
-      pro = res;
-    }
-    else if (2 == tag)
-    {
-      return u3m_bail(c3__exit);
-    }
-    else
-    {
-      return u3m_bail(c3__fail);
+    u3_noun tag, ton = u3n_nock_an(cor, bat);
+    if ( c3n == u3r_cell(ton, &tag, &pro) ) return u3m_bail(c3__fail);
+
+    switch ( tag ) {
+      case 0: {
+        u3k(pro);
+        u3z(ton);
+      } break;
+
+      case 2:  return u3m_bail(c3__exit);
+      default: return u3m_bail(c3__fail);
     }
   }
 

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -92,31 +92,64 @@ uw_slam_nock(u3_noun gat, u3_noun sam)
   return uw_kick_nock(cor, 2);
 }
 
+// memory arena with exponential growth
+typedef struct {
+  c3_w      siz_w;  // size in bytes
+  c3_y      pad_y;  // alignment padding
+  c3_t      ini_t;  // already initialized
+  u3i_slab  sab_u;  // associated slab
+  c3_y*     buf_y;  // allocated buffer
+  c3_y*     nex_y;  // next allocation
+  c3_y*     end_y;  // end of arena
+  jmp_buf*  esc_u;  // escape buffer
+} uw_arena;
+
+// Struct/array allocation: [len_d cap_d data]
+// BoxArena->esc_u MUST be initialized by the caller to handle OOM
+//
+static uw_arena* BoxArena;
+
+// Code page allocation: simple bump allocator for non-growing objects,
+// i.e. code pages
+// save allocation length for realloc
+// CodeArena->esc_u MUST be initialized by the caller to handle OOM
+//
+static uw_arena* CodeArena;
+
 static u3_noun
 uw_slam_check(u3_noun gat, u3_noun sam, c3_t is_stateful)
 {
   u3_noun bat = u3k(u3h(gat));
   u3_noun cor = u3nc(u3k(bat), u3nc(sam, u3k(u3t(u3t(gat)))));
   u3z(gat);
+  u3_noun pro;
+  M3GlobalSettable stash_u;
+
+  //  any unconstrained nock computation is a potential urwasm reentry:
+  //  save the pointers before that, restore after
+  //
+  uw_arena* box_arena_stash = BoxArena;
+  uw_arena* code_arena_stash = CodeArena;
+  m3_StashSettable(&stash_u);
 
   if (!is_stateful)
   {
-    return u3n_nock_on(cor, bat);
+    pro = u3n_nock_on(cor, bat);
   }
   else
   {
     u3_noun ton = u3n_nock_an(cor, bat);
     
-    u3_noun tag, pro;
-    if (c3n == u3r_cell(ton, &tag, &pro))
+    u3_noun tag, res;
+    if (c3n == u3r_cell(ton, &tag, &res))
     {
       return u3m_bail(c3__fail);
     }
     if (0 == tag)
     {
-      u3k(pro);
+      u3k(res);
       u3z(ton);
-      return pro;
+      pro = res;
     }
     else if (2 == tag)
     {
@@ -127,6 +160,12 @@ uw_slam_check(u3_noun gat, u3_noun sam, c3_t is_stateful)
       return u3m_bail(c3__fail);
     }
   }
+
+  BoxArena = box_arena_stash;
+  CodeArena = code_arena_stash;
+  m3_RestoreSettable(&stash_u);
+
+  return pro;
 }
 
 static inline void
@@ -198,18 +237,6 @@ typedef struct {
   u3_noun get_all_glob_ctx;
   u3_noun set_all_glob_ctx;
 } match_data_struct;
-
-// memory arena with exponential growth
-typedef struct {
-  c3_w      siz_w;  // size in bytes
-  c3_y      pad_y;  // alignment padding
-  c3_t      ini_t;  // already initialized
-  u3i_slab  sab_u;  // associated slab
-  c3_y*     buf_y;  // allocated buffer
-  c3_y*     nex_y;  // next allocation
-  c3_y*     end_y;  // end of arena
-  jmp_buf*  esc_u;  // escape buffer
-} uw_arena;
 
 typedef struct {
   IM3Module wasm_module;    // p
@@ -316,13 +343,6 @@ _uw_arena_free(uw_arena* ren_u)
   ren_u->ini_t = 0;
 }
 
-// Code page allocation: simple bump allocator for non-growing objects,
-// i.e. code pages
-// save allocation length for realloc
-// CodeArena->esc_u MUST be initialized by the caller to handle OOM
-//
-static uw_arena* CodeArena;
-
 static void*
 _calloc_code(size_t num_i, size_t len_i)
 {
@@ -397,11 +417,6 @@ _free_code(void* lag_v)
   }
   // noop
 }
-
-// Struct/array allocation: [len_d cap_d data]
-// BoxArena->esc_u MUST be initialized by the caller to handle OOM
-//
-static uw_arena* BoxArena;
 
 //  allocate with capacity
 //  the allocated buffer 
@@ -997,17 +1012,11 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
 
       if (0 == u3h(yil))
       {
-        //  any unconstrained nock computation is a potential urwasm reentry:
-        //  save the pointers before that, restore after
-        uw_arena* box_arena_frame = BoxArena;
-        uw_arena* code_arena_frame = CodeArena;
         monad_cont = uw_slam_check(
           u3k(cont),
           u3k(u3t(yil)),
           sat_u->is_stateful
         );
-        BoxArena = box_arena_frame;
-        CodeArena = code_arena_frame;
         u3z(yil);
         yil = u3_none;
       }
@@ -1064,15 +1073,11 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
 
       if (0 == u3h(yil))
       {
-        uw_arena* box_arena_frame = BoxArena;
-        uw_arena* code_arena_frame = CodeArena;
         monad_cont = uw_slam_check(
           u3k(cont),
           u3k(u3t(yil)),
           sat_u->is_stateful
         );
-        BoxArena = box_arena_frame;
-        CodeArena = code_arena_frame;
         u3z(yil);
         yil = u3_none;
       }
@@ -1112,15 +1117,11 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
 
         if (0 == u3h(yil))
         {
-          uw_arena* box_arena_frame = BoxArena;
-          uw_arena* code_arena_frame = CodeArena;
           monad_cont = uw_slam_check(
             u3k(cont),
             u3k(u3t(yil)),
             sat_u->is_stateful
           );
-          BoxArena = box_arena_frame;
-          CodeArena = code_arena_frame;
           u3z(yil);
           yil = u3_none;
         }
@@ -1559,15 +1560,11 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
         {
           u3_noun cont = u3t(frame);
           u3_noun p_res = u3t(sat_u->resolution);
-          uw_arena* box_arena_frame = BoxArena;
-          uw_arena* code_arena_frame = CodeArena;
           u3_noun monad_cont = uw_slam_check(
             u3k(cont),
             u3k(p_res),
             sat_u->is_stateful
           );
-          BoxArena = box_arena_frame;
-          CodeArena = code_arena_frame;
           u3z(sat_u->resolution);
           sat_u->resolution = _reduce_monad(monad_cont, sat_u);
         }
@@ -1598,15 +1595,11 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
         {
           u3_noun cont = u3t(u3t(frame));
           u3_noun p_res = u3t(sat_u->resolution);
-          uw_arena* box_arena_frame = BoxArena;
-          uw_arena* code_arena_frame = CodeArena;
           u3_noun monad_cont = uw_slam_check(
             u3k(cont),
             u3k(p_res),
             sat_u->is_stateful
           );
-          BoxArena = box_arena_frame;
-          CodeArena = code_arena_frame;
           u3z(sat_u->resolution);
           sat_u->resolution = _reduce_monad(monad_cont, sat_u);
         }
@@ -1659,15 +1652,11 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
           else  // %0
           {
             u3_noun p_res = u3t(yil);
-            uw_arena* box_arena_frame = BoxArena;
-            uw_arena* code_arena_frame = CodeArena;
             u3_noun monad_cont = uw_slam_check(
               u3k(cont),
               u3k(p_res),
               sat_u->is_stateful
             );
-            BoxArena = box_arena_frame;
-            CodeArena = code_arena_frame;
             u3z(sat_u->resolution);
             u3z(yil);
             sat_u->resolution = _reduce_monad(monad_cont, sat_u);
@@ -1697,15 +1686,11 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
         {
           u3_noun cont = u3t(frame);
           u3_noun p_res = u3t(sat_u->resolution);
-          uw_arena* box_arena_frame = BoxArena;
-          uw_arena* code_arena_frame = CodeArena;
           u3_noun monad_cont = uw_slam_check(
             u3k(cont),
             u3k(p_res),
             sat_u->is_stateful
           );
-          BoxArena = box_arena_frame;
-          CodeArena = code_arena_frame;
           u3z(sat_u->resolution);
           sat_u->resolution = _reduce_monad(monad_cont, sat_u);
         }
@@ -1822,11 +1807,7 @@ _link_wasm_with_arrow_map(
     m3_SuspendStackPushExtTag(runtime);
   }
 
-  uw_arena* box_arena_frame = BoxArena;
-  uw_arena* code_arena_frame = CodeArena;
   u3_noun script = uw_slam_check(arrow, coin_wasm_list, sat_u->is_stateful);
-  BoxArena = box_arena_frame;
-  CodeArena = code_arena_frame;
   u3_noun yil = _reduce_monad(script, sat_u); 
 
   M3Result result = m3Err_none;


### PR DESCRIPTION
Updates wasm3 dependency after https://github.com/urbit/wasm3/pull/2 and adds additional stashing of global variables in case of reentrance.
Previously only pointers to the arenas were stashed but not the allocating functions, which could have caused more `bail:fail`s than it had to.