### PR TITLE
conn: optionally deliver channel response after EOF on read

### DIFF
--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -699,7 +699,6 @@ _conn_sock_cb(uv_stream_t* sem_u, c3_i tas_i)
   u3_chan*  can_u;
   c3_i      err_i;
 
-
   can_u = c3_calloc(sizeof(u3_chan));
   can_u->mor_u.ptr_v = can_u;
   can_u->mor_u.pok_f = _conn_moor_poke;

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -703,6 +703,7 @@ _conn_sock_cb(uv_stream_t* sem_u, c3_i tas_i)
   can_u->mor_u.ptr_v = can_u;
   can_u->mor_u.pok_f = _conn_moor_poke;
   can_u->mor_u.bal_f = _conn_moor_bail;
+  can_u->mor_u.fag_w = 1; // XX cleanup, nonzero means ignore EOF
   can_u->coq_l = san_u->nex_l++;
   can_u->san_u = san_u;
   err_i = uv_timer_init(u3L, &can_u->mor_u.tim_u);

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -699,6 +699,7 @@ _conn_sock_cb(uv_stream_t* sem_u, c3_i tas_i)
   u3_chan*  can_u;
   c3_i      err_i;
 
+
   can_u = c3_calloc(sizeof(u3_chan));
   can_u->mor_u.ptr_v = can_u;
   can_u->mor_u.pok_f = _conn_moor_poke;
@@ -865,6 +866,10 @@ _conn_ef_handle(u3_conn*  con_u,
     else {
       can_u->mor_u.bal_f(can_u, -4, "handle-unknown");
       u3_king_bail();
+    }
+
+    if ( !uv_is_readable((uv_stream_t*)&con_u->san_u->pyp_u) ) {
+      _conn_close_chan(con_u->san_u, can_u);
     }
   }
   else {

--- a/pkg/vere/newt.c
+++ b/pkg/vere/newt.c
@@ -179,9 +179,9 @@ _newt_read_cb(uv_stream_t*    str_u,
 
     if ( UV_EOF != len_i ) {
       fprintf(stderr, "newt: read failed %s\r\n", uv_strerror(len_i));
+      mot_u->bal_f(mot_u->ptr_v, len_i, uv_strerror(len_i));
     }
 
-    mot_u->bal_f(mot_u->ptr_v, len_i, uv_strerror(len_i));
   }
   //  EAGAIN/EWOULDBLOCK
   //

--- a/pkg/vere/newt.c
+++ b/pkg/vere/newt.c
@@ -181,6 +181,9 @@ _newt_read_cb(uv_stream_t*    str_u,
       fprintf(stderr, "newt: read failed %s\r\n", uv_strerror(len_i));
       mot_u->bal_f(mot_u->ptr_v, len_i, uv_strerror(len_i));
     }
+    else if ( !mot_u->fag_w ) {
+      mot_u->bal_f(mot_u->ptr_v, len_i, uv_strerror(len_i));
+    }
 
   }
   //  EAGAIN/EWOULDBLOCK

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -94,6 +94,7 @@
       typedef struct _u3_moat {
         uv_pipe_t        pyp_u;             //  input stream
         u3_moor_bail     bal_f;             //  error response function
+        c3_w             fag_w;
         void*            ptr_v;             //  callback pointer
         u3_moor_poke     pok_f;             //  action function
         u3_mess          mes_u;             //  message in progress
@@ -107,6 +108,7 @@
       typedef struct _u3_mojo {
         uv_pipe_t        pyp_u;             //  output stream
         u3_moor_bail     bal_f;             //  error response function
+        c3_w             fag_w;
         void*            ptr_v;             //  callback pointer
       } u3_mojo;
 
@@ -114,6 +116,7 @@
       typedef struct _u3_moor {
         uv_pipe_t        pyp_u;             //  duplex stream
         u3_moor_bail     bal_f;             //  error response function
+        c3_w             fag_w;
         void*            ptr_v;             //  callback pointer
         u3_moor_poke     pok_f;             //  action function
         u3_mess          mes_u;             //  message in progress


### PR DESCRIPTION
Includes and supersedes #892, ensuring no behavior change for mars/urth IPC pipe.