### PR TITLE
windows: clobber nonvolatile regs

### DIFF
--- a/pkg/c3/portable.h
+++ b/pkg/c3/portable.h
@@ -269,4 +269,9 @@
 #     define STATIC_ASSERT(e,m) \
         enum { ASSERT_CONCAT(assert_line_, __LINE__) = 1/(int)(!!(e)) }
 
+
+#ifndef u3_prep_setjmp
+#   define u3_prep_setjmp()
+#endif
+
 #endif /* ifndef C3_PORTABLE_H */

--- a/pkg/c3/portable.h
+++ b/pkg/c3/portable.h
@@ -270,8 +270,10 @@
         enum { ASSERT_CONCAT(assert_line_, __LINE__) = 1/(int)(!!(e)) }
 
 
-#ifndef u3_prep_setjmp
-#   define u3_prep_setjmp()
-#endif
+    /* setjmp prologue
+    */
+#     ifndef u3_prep_setjmp
+#       define u3_prep_setjmp()
+#     endif
 
 #endif /* ifndef C3_PORTABLE_H */

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -1957,7 +1957,8 @@ _get_state(u3_noun hint, u3_noun seed, lia_state* sat_u)
     {
       wasm3_runtime->base_transient = CodeArena->buf_y;
       
-      if (0 == (jmp_i = setjmp(esc)))
+      u3_prep_setjmp();
+      if (0 == (jmp_i = _setjmp(esc)))
       {
         for (c3_w i = 0; i < n_imports; i++)
         {
@@ -2430,7 +2431,8 @@ u3we_lia_run_v1(u3_noun cor)
 
       while (1)
       {
-        if (0 == (jmp_i = setjmp(esc)))
+        u3_prep_setjmp();
+        if (0 == (jmp_i = _setjmp(esc)))
         {
           bin_y = _calloc_box(bin_len_w, 1);
           u3r_bytes(0, bin_len_w, bin_y, u3x_atom(q_octs));

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -1990,6 +1990,7 @@ _get_state(u3_noun hint, u3_noun seed, lia_state* sat_u)
       }
       else
       {
+        u3_prep_setjmp();
         if (jmp_i == c3__code)
         {
           _uw_arena_grow(CodeArena);
@@ -2526,6 +2527,7 @@ u3we_lia_run_v1(u3_noun cor)
         }
         else
         {
+          u3_prep_setjmp();
           // escaped, grow arena and retry
           if (wasm3_runtime)
           {

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -41,15 +41,6 @@
 //
 #undef NO_OVERFLOW
 
-      /* (u3_noun)setjmp(u3R->esc.buf): setjmp within road.
-      */
-#if 0
-        c3_o
-        u3m_trap(void);
-#else
-#       define u3m_trap() (u3_noun)(_setjmp(u3R->esc.buf))
-#endif
-
       /* u3m_signal(): treat a nock-level exception as a signal interrupt.
       */
         void
@@ -1452,7 +1443,7 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
   /* Enter internal signal regime.
    */
   _cm_signal_deep();
-
+  u3_prep_setjmp();
   if ( 0 != (sig_l = rsignal_setjmp(u3_Signal)) ) {
     //  reinitialize trace state
     //
@@ -1477,6 +1468,7 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
 
   /* Trap for ordinary nock exceptions.
   */
+  u3_prep_setjmp();
   if ( 0 == (why = (u3_noun)_setjmp(u3R->esc.buf)) ) {
     pro = fun_f(arg);
 
@@ -1589,6 +1581,7 @@ u3m_soft_cax(u3_funq fun_f,
 
   /* Trap for exceptions.
   */
+  u3_prep_setjmp();
   if ( 0 == (why = (u3_noun)_setjmp(u3R->esc.buf)) ) {
     u3t_off(coy_o);
     pro = fun_f(aga, agb);
@@ -1690,6 +1683,7 @@ u3m_soft_run(u3_noun gul,
 
   /* Trap for exceptions.
   */
+  u3_prep_setjmp();
   if ( 0 == (why = (u3_noun)_setjmp(u3R->esc.buf)) ) {
     u3t_off(coy_o);
     pro = fun_f(aga, agb);
@@ -1792,6 +1786,7 @@ u3m_soft_esc(u3_noun ref, u3_noun sam)
 
   /* Trap for exceptions.
   */
+  u3_prep_setjmp();
   if ( 0 == (why = (u3_noun)_setjmp(u3R->esc.buf)) ) {
     pro = u3n_slam_on(gul, u3nc(ref, sam));
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1445,6 +1445,7 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
   _cm_signal_deep();
   u3_prep_setjmp();
   if ( 0 != (sig_l = rsignal_setjmp(u3_Signal)) ) {
+    u3_prep_setjmp();
     //  reinitialize trace state
     //
     u3t_init();
@@ -1492,6 +1493,7 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
     pro = u3nc(0, u3m_love(pro));
   }
   else {
+    u3_prep_setjmp();
     /* Overload the error result.
     */
     pro = u3m_love(why);
@@ -1608,6 +1610,7 @@ u3m_soft_cax(u3_funq fun_f,
     pro = u3m_love(pro);
   }
   else {
+    u3_prep_setjmp();
     u3t_init();
 
     /* Produce - or fall again.
@@ -1708,6 +1711,7 @@ u3m_soft_run(u3_noun gul,
     pro = u3nc(0, u3m_love(pro));
   }
   else {
+    u3_prep_setjmp();
     u3t_init();
 
     /* Produce - or fall again.
@@ -1795,6 +1799,7 @@ u3m_soft_esc(u3_noun ref, u3_noun sam)
     pro = u3m_love(pro);
   }
   else {
+    u3_prep_setjmp();
     u3t_init();
 
     /* Push the error back up to the calling context - not the run we

--- a/pkg/noun/platform/windows/setjmp.c
+++ b/pkg/noun/platform/windows/setjmp.c
@@ -3,7 +3,7 @@
 // write our own. See https://github.com/llvm/llvm-project/pull/186843 for
 // details.
 
-__attribute__((naked,returns_twice))
+__attribute__((naked,returns_twice,noinline))
 int windows_setjmp(void** buf)
 {
   // We store the frame pointer, instruction pointer and stack pointer into the

--- a/pkg/noun/platform/windows/setjmp.h
+++ b/pkg/noun/platform/windows/setjmp.h
@@ -12,7 +12,14 @@ typedef struct jmp_buf {
 #define longjmp(buf, val) {(buf).retval = (val); __builtin_longjmp((void**)((buf).buffer), 1);}
 #define setjmp(buf) (windows_setjmp((void**)(buf.buffer)) ? (buf.retval) : 0)
 
-#define u3_prep_setjmp() asm volatile("" ::: "rbx", "rbp", "r12", "r13", "r14", "r15", "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15")
+//  __builtin_setjmp, in addition to saving the pointers, also forces register
+//  spilling in the caller function so that it doesn't have to save the register
+//  file. We clobber caller-saved registers by calling a setjmp function and
+//  we clobber the rest manually
+#define u3_prep_setjmp() asm volatile("" ::: "rbx", "rbp", "r12", "r13", "r14", \
+                                             "r15", "xmm6", "xmm7", "xmm8",     \
+                                             "xmm9", "xmm10", "xmm11", "xmm12", \
+                                             "xmm13", "xmm14", "xmm15")
 
 __attribute__((naked,returns_twice,noinline)) int windows_setjmp(void** buf);
 

--- a/pkg/noun/platform/windows/setjmp.h
+++ b/pkg/noun/platform/windows/setjmp.h
@@ -12,6 +12,8 @@ typedef struct jmp_buf {
 #define longjmp(buf, val) {(buf).retval = (val); __builtin_longjmp((void**)((buf).buffer), 1);}
 #define setjmp(buf) (windows_setjmp((void**)(buf.buffer)) ? (buf.retval) : 0)
 
-__attribute__((naked,returns_twice)) int windows_setjmp(void** buf);
+#define u3_prep_setjmp() asm volatile("" ::: "rbx", "rbp", "r12", "r13", "r14", "r15", "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15")
+
+__attribute__((naked,returns_twice,noinline)) int windows_setjmp(void** buf);
 
 #endif// _SETJMP_H

--- a/pkg/noun/platform/windows/setjmp.h
+++ b/pkg/noun/platform/windows/setjmp.h
@@ -16,10 +16,11 @@ typedef struct jmp_buf {
 //  spilling in the caller function so that it doesn't have to save the register
 //  file. We clobber caller-saved registers by calling a setjmp function and
 //  we clobber the rest manually
-#define u3_prep_setjmp() asm volatile("" ::: "rbx", "rbp", "r12", "r13", "r14", \
-                                             "r15", "xmm6", "xmm7", "xmm8",     \
-                                             "xmm9", "xmm10", "xmm11", "xmm12", \
-                                             "xmm13", "xmm14", "xmm15")
+#define u3_prep_setjmp() asm volatile("" ::: "rbx", "rbp", "rdi", "rsi", "rsp", \
+                                             "r12", "r13", "r14", "r15", "xmm6",\
+                                             "xmm7", "xmm8", "xmm9", "xmm10",   \
+                                             "xmm11", "xmm12", "xmm13", "xmm14",\
+                                             "xmm15")
 
 __attribute__((naked,returns_twice,noinline)) int windows_setjmp(void** buf);
 


### PR DESCRIPTION
Per [docs](https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp):
> ... this intrinsic forces register saving for the current function...

Maybe we should still call the builtin just to signal to the compiler that the registers ought to be saved?