### PR TITLE
windows: change calling convention for our setjmp

### DIFF
--- a/pkg/noun/platform/windows/setjmp.c
+++ b/pkg/noun/platform/windows/setjmp.c
@@ -3,19 +3,23 @@
 // write our own. See https://github.com/llvm/llvm-project/pull/186843 for
 // details.
 
-__attribute__((naked,returns_twice))
+#ifdef U3_CPU_aarch64
+#error "aarch64 has different calling convention with preserve_none"
+#else
+__attribute__((naked,returns_twice,preserve_none))
 int windows_setjmp(void** buf)
 {
   // We store the frame pointer, instruction pointer and stack pointer into the
   // buffer. Note that we can keep using __builtin_longjmp because we store
   // exactly what it expects.
     __asm(
-          "mov %rbp, 0(%rcx)\n"
+          "mov %rbp, 0(%r12)\n"
           "mov (%rsp), %rax\n"
-          "mov %rax,  8(%rcx)\n"
+          "mov %rax,  8(%r12)\n"
           "lea 8(%rsp), %rax\n"
-          "mov %rax,  16(%rcx)\n"
+          "mov %rax,  16(%r12)\n"
           "xor %eax, %eax\n"
           "ret\n"
     );
 }
+#endif

--- a/pkg/noun/platform/windows/setjmp.h
+++ b/pkg/noun/platform/windows/setjmp.h
@@ -12,6 +12,6 @@ typedef struct jmp_buf {
 #define longjmp(buf, val) {(buf).retval = (val); __builtin_longjmp((void**)((buf).buffer), 1);}
 #define setjmp(buf) (windows_setjmp((void**)(buf.buffer)) ? (buf.retval) : 0)
 
-__attribute__((naked,returns_twice)) int windows_setjmp(void** buf);
+__attribute__((naked,returns_twice,preserve_none)) int windows_setjmp(void** buf);
 
 #endif// _SETJMP_H


### PR DESCRIPTION
During discussion at https://github.com/llvm/llvm-project/issues/188494 it was pointed out to me that instead of trying to use `__builtin_setjmp` I should just change the calling convention for our setjmp.

Tested on Windows with `ReleaseFast` build, Arvo tests ran fine.