### PR TITLE
add casts in callsites of variadic functions

### DIFF
--- a/pkg/noun/jets/c/sew.c
+++ b/pkg/noun/jets/c/sew.c
@@ -58,8 +58,8 @@ u3wc_sew(u3_noun cor)
   u3_noun a, b, c, d, e;
   if ( (c3n == u3r_mean(cor, u3x_sam_2,  &a,
                              u3x_sam_12, &b,
-                                    106, &c,
-                                    107, &d,
+                                    (c3_w)106, &c,
+                                    (c3_w)107, &d,
                               u3x_sam_7, &e, u3_nul)) ||
        (c3n == u3ud(a)) ||
        (c3n == u3ud(b)) ||

--- a/pkg/noun/jets/e/adler.c
+++ b/pkg/noun/jets/e/adler.c
@@ -9,8 +9,8 @@
 static void _x_octs(u3_noun octs, u3_atom* p_octs, u3_atom* q_octs) {
 
   if (c3n == u3r_mean(octs,
-             2, p_octs,
-             3, q_octs, u3_nul)){
+             (c3_w)2, p_octs,
+             (c3_w)3, q_octs, u3_nul)){
     u3m_bail(c3__exit);
   }
 

--- a/pkg/noun/jets/e/aes_cbc.c
+++ b/pkg/noun/jets/e/aes_cbc.c
@@ -52,7 +52,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, 60, &a, 61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -76,7 +76,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, 60, &a, 61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -100,7 +100,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, 60, &a, 61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -124,7 +124,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, 60, &a, 61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -148,7 +148,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, 60, &a, 61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -172,7 +172,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, 60, &a, 61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/bytestream.c
+++ b/pkg/noun/jets/e/bytestream.c
@@ -13,8 +13,8 @@ static void
 _x_octs(u3_noun octs, u3_atom* p_octs, u3_atom* q_octs) {
 
   if (c3n == u3r_mean(octs,
-             2, p_octs,
-             3, q_octs, u3_nul)){
+             (c3_w)2, p_octs,
+             (c3_w)3, q_octs, u3_nul)){
     u3m_bail(c3__exit);
   }
 
@@ -732,7 +732,7 @@ _qe_bytestream_extract(u3_noun sea, u3_noun rac)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(sea, 2, &pos, 3, &octs, u3_nul);
+  u3x_mean(sea, (c3_w)2, &pos, (c3_w)3, &octs, u3_nul);
 
   c3_w pos_w;
 
@@ -766,7 +766,7 @@ _qe_bytestream_extract(u3_noun sea, u3_noun rac)
     u3_atom sip, ken;
     c3_w sip_w, ken_w;
 
-    u3x_mean(ext, 2, &sip, 3, &ken, u3_nul);
+    u3x_mean(ext, (c3_w)2, &sip, (c3_w)3, &ken, u3_nul);
 
     if (c3n == u3r_safe_word(sip, &sip_w)) {
       // XX is u3z necessary here?
@@ -829,7 +829,7 @@ _qe_bytestream_fuse_extract(u3_noun sea, u3_noun rac)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(sea, 2, &pos, 3, &octs, u3_nul);
+  u3x_mean(sea, (c3_w)2, &pos, (c3_w)3, &octs, u3_nul);
 
   c3_w pos_w;
 
@@ -863,7 +863,7 @@ _qe_bytestream_fuse_extract(u3_noun sea, u3_noun rac)
     u3_atom sip, ken;
     c3_w sip_w, ken_w;
 
-    u3x_mean(ext, 2, &sip, 3, &ken, u3_nul);
+    u3x_mean(ext, (c3_w)2, &sip, (c3_w)3, &ken, u3_nul);
 
     if (c3n == u3r_safe_word(sip, &sip_w)) {
       // XX is u3z necessary here?
@@ -932,9 +932,9 @@ _qe_bytestream_need_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, 2, &num,
-                 6, &bit,
-                 7, &bays, u3_nul);
+  u3x_mean(bits, (c3_w)2, &num,
+                 (c3_w)6, &bit,
+                 (c3_w)7, &bays, u3_nul);
 
 
   c3_w n_w, num_w;
@@ -975,7 +975,7 @@ _qe_bytestream_need_bits(u3_atom n, u3_noun bits)
   u3_noun octs;
 
 
-  u3x_mean(bays, 2, &pos, 3, &octs, u3_nul);
+  u3x_mean(bays, (c3_w)2, &pos, (c3_w)3, &octs, u3_nul);
 
   if (c3n == u3r_safe_word(pos, &pos_w)) {
     return u3_none;
@@ -1039,9 +1039,9 @@ _qe_bytestream_drop_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, 2, &num,
-                 6, &bit,
-                 7, &bays, u3_nul);
+  u3x_mean(bits, (c3_w)2, &num,
+                 (c3_w)6, &bit,
+                 (c3_w)7, &bays, u3_nul);
 
   c3_w n_w, num_w;
   c3_d bit_d;
@@ -1090,9 +1090,9 @@ _qe_bytestream_peek_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, 2, &num,
-                 6, &bit,
-                 7, &bays, u3_nul);
+  u3x_mean(bits, (c3_w)2, &num,
+                 (c3_w)6, &bit,
+                 (c3_w)7, &bays, u3_nul);
 
   c3_w n_w, num_w;
   c3_d bit_d;
@@ -1147,9 +1147,9 @@ _qe_bytestream_read_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, 2, &num,
-                 6, &bit,
-                 7, &bays, u3_nul);
+  u3x_mean(bits, (c3_w)2, &num,
+                 (c3_w)6, &bit,
+                 (c3_w)7, &bays, u3_nul);
 
   c3_w n_w, num_w;
   c3_d bit_d;
@@ -1209,9 +1209,9 @@ _qe_bytestream_byte_bits(u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, 2, &num,
-                 6, &bit,
-                 7, &bays, u3_nul);
+  u3x_mean(bits, (c3_w)2, &num,
+                 (c3_w)6, &bit,
+                 (c3_w)7, &bays, u3_nul);
 
   c3_w num_w;
   c3_d bit_d;

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -1911,19 +1911,19 @@ _get_state(u3_noun hint, u3_noun seed, lia_state* sat_u)
     u3_noun susp_list;
 
     if ( c3n == u3r_mean(get,
-        2,   &yil_previous,
-        6,   &queue,
-        56,  &p_box_buffer,
-        57,  &q_box_buffer,
-        29,  &pad_box,
-        120, &p_mem_buffer,
-        121, &q_mem_buffer,
-        61,  &stack_offset,
-        62,  &runtime_offset,
-        126, &lia_shop,
-        254, &acc,
-        255, &susp_list,
-        0) 
+        (c3_w)2,   &yil_previous,
+        (c3_w)6,   &queue,
+        (c3_w)56,  &p_box_buffer,
+        (c3_w)57,  &q_box_buffer,
+        (c3_w)29,  &pad_box,
+        (c3_w)120, &p_mem_buffer,
+        (c3_w)121, &q_mem_buffer,
+        (c3_w)61,  &stack_offset,
+        (c3_w)62,  &runtime_offset,
+        (c3_w)126, &lia_shop,
+        (c3_w)254, &acc,
+        (c3_w)255, &susp_list,
+        u3_nul)
     )
     {
       return u3m_bail(c3__fail);

--- a/pkg/noun/jets/i/lagoon.c
+++ b/pkg/noun/jets/i/lagoon.c
@@ -3246,10 +3246,10 @@
     } else {
       u3_noun x_shape, x_bloq, x_kind, x_tail;
       if ( c3n == u3r_mean(x_meta,
-                            2, &x_shape,
-                            6, &x_bloq,
-                           14, &x_kind,
-                           15, &x_tail,
+                            (c3_w)2, &x_shape,
+                            (c3_w)6, &x_bloq,
+                           (c3_w)14, &x_kind,
+                           (c3_w)15, &x_tail,
                             u3_nul)
          )
       {

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -516,7 +516,7 @@ _conn_read_peel(u3_conn* con_u, u3_noun dat)
                    u3nc(c3__mass, u3_nul),
                    u3nc(c3__quic, u3_nul),
                    u3nc(c3__port,
-                        u3i_list(c3__ames, c3__htls, c3__http, u3_none)),
+                        u3i_list((u3_noun)c3__ames, (u3_noun)c3__htls, (u3_noun)c3__http, u3_none)),
                    u3nc(c3__v, u3_nul), u3nc(c3__who, u3_nul),
                    u3_none));
       } break;

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -2831,7 +2831,7 @@ _http_stream_slog(void* vop_p, c3_w pri_w, u3_noun tan)
     if ( c3y == u3a_is_atom(tan) ) {
       u3_noun lin = u3i_list(u3i_string("data:"),
                              u3k(tan),
-                             c3_s2('\n', '\n'),
+                             (u3_noun)c3_s2('\n', '\n'),
                              u3_none);
       u3_atom txt = u3qc_rap(3, lin);
       data = u3nt(u3_nul, u3r_met(3, txt), txt);
@@ -2861,7 +2861,7 @@ _http_stream_slog(void* vop_p, c3_w pri_w, u3_noun tan)
         while ( u3_nul != low ) {
           u3_noun lin = u3i_list(u3i_string("data:"),
                                  u3qc_rap(3, u3h(low)),
-                                 c3_s2('\n', '\n'),
+                                 (u3_noun)c3_s2('\n', '\n'),
                                  u3_none);
           paz = u3kb_weld(paz, lin);
           low = u3t(low);
@@ -2933,7 +2933,7 @@ _http_spin_timer_cb(uv_timer_t* tim_u)
       u3_noun tan = u3i_string(buf_c);
       u3_noun lin = u3i_list(u3i_string("data:"),
                              tan,
-                             c3_s2('\n', '\n'),
+                             (u3_noun)c3_s2('\n', '\n'),
                              u3_none);
       u3_atom txt = u3qc_rap(3, lin);
       u3_noun dat = u3nt(u3_nul, u3r_met(3, txt), txt);

--- a/pkg/vere/noun_tests.c
+++ b/pkg/vere/noun_tests.c
@@ -1093,7 +1093,7 @@ _test_cells()
     }
 
     a2 = 0;
-    u3r_mean(q, 2, &a2, u3_nul);
+    u3r_mean(q, (c3_w)2, &a2, u3_nul);
     if (a2 != a){
       printf("*** _test_cells: complicated (via u3r_list) a\n");
     }


### PR DESCRIPTION
We have to cast all literals inside of our variadic function calls, otherwise the values might get packed too tightly. Encountered some hard-to-debug issues when testing Vere64 on Windows.

Our variadic functions make me sad... 