### PR TITLE
better variadic functions

### DIFF
--- a/pkg/noun/equality_tests.c
+++ b/pkg/noun/equality_tests.c
@@ -157,7 +157,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "test equality: ok\r\n");
   return 0;

--- a/pkg/noun/hashtable_tests.c
+++ b/pkg/noun/hashtable_tests.c
@@ -293,7 +293,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "test_hashtable: ok\r\n");
 

--- a/pkg/noun/imprison.c
+++ b/pkg/noun/imprison.c
@@ -761,7 +761,7 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
 
 /* u3i_molt():
 **
-**   Mutate `som` with a 0-terminated list of axis, noun pairs.
+**   Mutate `som` with a list of axis, noun pairs.
 **   Axes must be cats (31 bit).
 */
 

--- a/pkg/noun/imprison.c
+++ b/pkg/noun/imprison.c
@@ -790,14 +790,10 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
 **   Mutate `som` with a 0-terminated list of axis, noun pairs.
 **   Axes must be cats (31 bit).
 */
-  struct _molt_pair {
-    c3_w    axe_w;
-    u3_noun som;
-  };
 
   static c3_w
-  _molt_cut(c3_w               len_w,
-            struct _molt_pair* pms_m)
+  _molt_cut(c3_w       len_w,
+            molt_pair* pms_m)
   {
     c3_w i_w, cut_t, cut_w;
 
@@ -815,10 +811,10 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
     return cut_t ? cut_w : i_w;
   }
 
-  static u3_noun                            //  transfer
-  _molt_apply(u3_noun            som,       //  retain
-              c3_w               len_w,
-              struct _molt_pair* pms_m)     //  transfer
+  static u3_noun                    //  transfer
+  _molt_apply(u3_noun    som,       //  retain
+              c3_w       len_w,
+              molt_pair* pms_m)     //  transfer
   {
     if ( len_w == 0 ) {
       return u3k(som);
@@ -841,47 +837,10 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
   }
 
 u3_noun
-u3i_molt(u3_noun som, ...)
+u3i_vmolt(u3_noun som, molt_pair pairs[], c3_z len_z)
 {
-  va_list            ap;
-  c3_w               len_w;
-  struct _molt_pair* pms_m;
-  u3_noun            pro;
-
-  //  Count.
-  //
-  len_w = 0;
-  {
-    va_start(ap, som);
-    while ( 1 ) {
-      if ( 0 == va_arg(ap, c3_w) ) {
-        break;
-      }
-      va_arg(ap, u3_weak*);
-      len_w++;
-    }
-    va_end(ap);
-  }
-
-  u3_assert( 0 != len_w );
-  pms_m = alloca(len_w * sizeof(struct _molt_pair));
-
-  //  Install.
-  //
-  {
-    c3_w i_w;
-
-    va_start(ap, som);
-    for ( i_w = 0; i_w < len_w; i_w++ ) {
-      pms_m[i_w].axe_w = va_arg(ap, c3_w);
-      pms_m[i_w].som = va_arg(ap, u3_noun);
-    }
-    va_end(ap);
-  }
-
-  //  Apply.
-  //
-  pro = _molt_apply(som, len_w, pms_m);
+  u3_assert(len_z < c3_w_max);
+  u3_noun pro = _molt_apply(som, (c3_w)len_z, pairs);
   u3z(som);
   return pro;
 }

--- a/pkg/noun/imprison.c
+++ b/pkg/noun/imprison.c
@@ -687,43 +687,17 @@ u3i_tape(const c3_c* txt_c)
   } else return u3i_cell(*txt_c, u3i_tape(txt_c + 1));
 }
 
-/* u3i_list(): list from `u3_none`-terminated varargs.
+/* u3i_list(): build a list
 */
 u3_noun
-u3i_list(u3_weak som, ...)
+u3i_vlist(u3_noun* som, c3_z len_z)
 {
-  u3_noun  lit = u3_nul;
-  u3_noun* let = &lit;
-  u3_noun  *hed, *tel;
-  va_list  ap;
+  u3_noun lit = u3_nul;
 
-  if ( u3_none == som ) {
-    return lit;
-  }
-  else {
-    *let = u3i_defcons(&hed, &tel);
-    *hed = som;
-    let = tel;
+  while ( len_z-- ) {
+    lit = u3nc(som[len_z], lit);
   }
 
-  {
-    u3_noun tem;
-
-    va_start(ap, som);
-    while ( 1 ) {
-      if ( u3_none == (tem = va_arg(ap, u3_weak)) ) {
-        break;
-      }
-      else {
-        *let = u3i_defcons(&hed, &tel);
-        *hed = tem;
-        let = tel;
-      }
-    }
-    va_end(ap);
-  }
-
-  *let = u3_nul;
   return lit;
 }
 

--- a/pkg/noun/imprison.c
+++ b/pkg/noun/imprison.c
@@ -767,7 +767,7 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
 
   static c3_w
   _molt_cut(c3_w       len_w,
-            molt_pair* pms_m)
+            u3i_molt_pair* pms_m)
   {
     c3_w i_w, cut_t, cut_w;
 
@@ -788,7 +788,7 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
   static u3_noun                    //  transfer
   _molt_apply(u3_noun    som,       //  retain
               c3_w       len_w,
-              molt_pair* pms_m)     //  transfer
+              u3i_molt_pair* pms_m)     //  transfer
   {
     if ( len_w == 0 ) {
       return u3k(som);
@@ -811,7 +811,7 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
   }
 
 u3_noun
-u3i_vmolt(u3_noun som, molt_pair pairs[], c3_z len_z)
+u3i_vmolt(u3_noun som, u3i_molt_pair pairs[], c3_z len_z)
 {
   u3_assert(len_z < c3_w_max);
   u3_noun pro = _molt_apply(som, (c3_w)len_z, pairs);

--- a/pkg/noun/imprison.h
+++ b/pkg/noun/imprison.h
@@ -162,9 +162,10 @@
           u3_noun
           u3i_vlist(u3_noun* som, c3_z len_z);
 
-#         define u3i_list(...) u3i_vlist((u3_noun[]){__VA_ARGS__},  \
-            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof(u3_noun) )  \
-          )
+#         define u3i_list(...) ({                               \
+            u3_noun _args[] = {__VA_ARGS__};                    \
+            u3i_vlist(_args, sizeof(_args) / sizeof(u3_noun));  \
+          })
 
 #         define u3nl u3i_list
 
@@ -186,9 +187,9 @@
           u3_noun
           u3i_vmolt(u3_noun som, u3i_molt_pair pairs[], c3_z len_z);
 
-          #define u3i_molt(a, ...) u3i_vmolt(a,                                 \
-            (u3i_molt_pair[]){__VA_ARGS__},                                     \
-            ( sizeof((u3i_molt_pair[]){__VA_ARGS__}) / sizeof(u3i_molt_pair) )  \
-          )
+#         define u3i_molt(a, ...) ({                                      \
+            u3i_molt_pair _pairs[] = {__VA_ARGS__};                       \
+            u3i_vmolt(a, _pairs, sizeof(_pairs) / sizeof(u3i_molt_pair)); \
+          })
 
 #endif /* ifndef U3_IMPRISON_H */

--- a/pkg/noun/imprison.h
+++ b/pkg/noun/imprison.h
@@ -157,7 +157,7 @@
           u3_noun
           u3i_tape(const c3_c* txt_c);
 
-        /* u3i_list(): list from `u3_none`-terminated varargs.
+        /* u3i_list(): list from the arguments
         */
           u3_noun
           u3i_vlist(u3_noun* som, c3_z len_z);
@@ -178,7 +178,7 @@
 
         /* u3i_molt():
         **
-        **   Mutate `som` with a 0-terminated list of axis, noun pairs.
+        **   Mutate `som` with a list of axis, noun pairs.
         **   Axes must be cats (31 bit).
         */
           typedef struct {c3_w axe_w; u3_noun som;} u3i_molt_pair;

--- a/pkg/noun/imprison.h
+++ b/pkg/noun/imprison.h
@@ -160,7 +160,12 @@
         /* u3i_list(): list from `u3_none`-terminated varargs.
         */
           u3_noun
-          u3i_list(u3_weak som, ...);
+          u3i_vlist(u3_noun* som, c3_z len_z);
+
+#         define u3i_list(...) u3i_vlist((u3_noun[]){__VA_ARGS__},                      \
+            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof((u3_noun[]){__VA_ARGS__}[0]) )  \
+          )
+
 #         define u3nl u3i_list
 
         /* u3i_edit():

--- a/pkg/noun/imprison.h
+++ b/pkg/noun/imprison.h
@@ -181,14 +181,14 @@
         **   Mutate `som` with a 0-terminated list of axis, noun pairs.
         **   Axes must be cats (31 bit).
         */
-          typedef struct {c3_w axe_w; u3_noun som;} molt_pair;
+          typedef struct {c3_w axe_w; u3_noun som;} u3i_molt_pair;
 
           u3_noun
-          u3i_vmolt(u3_noun som, molt_pair pairs[], c3_z len_z);
+          u3i_vmolt(u3_noun som, u3i_molt_pair pairs[], c3_z len_z);
 
-          #define u3i_molt(a, ...) u3i_vmolt(a,                         \
-            (molt_pair[]){__VA_ARGS__},                                 \
-            ( sizeof((molt_pair[]){__VA_ARGS__}) / sizeof(molt_pair) )  \
+          #define u3i_molt(a, ...) u3i_vmolt(a,                                 \
+            (u3i_molt_pair[]){__VA_ARGS__},                                     \
+            ( sizeof((u3i_molt_pair[]){__VA_ARGS__}) / sizeof(u3i_molt_pair) )  \
           )
 
 #endif /* ifndef U3_IMPRISON_H */

--- a/pkg/noun/imprison.h
+++ b/pkg/noun/imprison.h
@@ -176,7 +176,14 @@
         **   Mutate `som` with a 0-terminated list of axis, noun pairs.
         **   Axes must be cats (31 bit).
         */
+          typedef struct {c3_w axe_w; u3_noun som;} molt_pair;
+
           u3_noun
-          u3i_molt(u3_noun som, ...);
+          u3i_vmolt(u3_noun som, molt_pair pairs[], c3_z len_z);
+
+          #define u3i_molt(a, ...) u3i_vmolt(a,                                             \
+            (molt_pair[]){__VA_ARGS__},                                                     \
+            ( sizeof((molt_pair[]){__VA_ARGS__}) / sizeof((molt_pair[]){__VA_ARGS__}[0]) )  \
+          )
 
 #endif /* ifndef U3_IMPRISON_H */

--- a/pkg/noun/imprison.h
+++ b/pkg/noun/imprison.h
@@ -162,8 +162,8 @@
           u3_noun
           u3i_vlist(u3_noun* som, c3_z len_z);
 
-#         define u3i_list(...) u3i_vlist((u3_noun[]){__VA_ARGS__},                      \
-            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof((u3_noun[]){__VA_ARGS__}[0]) )  \
+#         define u3i_list(...) u3i_vlist((u3_noun[]){__VA_ARGS__},  \
+            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof(u3_noun) )  \
           )
 
 #         define u3nl u3i_list
@@ -186,9 +186,9 @@
           u3_noun
           u3i_vmolt(u3_noun som, molt_pair pairs[], c3_z len_z);
 
-          #define u3i_molt(a, ...) u3i_vmolt(a,                                             \
-            (molt_pair[]){__VA_ARGS__},                                                     \
-            ( sizeof((molt_pair[]){__VA_ARGS__}) / sizeof((molt_pair[]){__VA_ARGS__}[0]) )  \
+          #define u3i_molt(a, ...) u3i_vmolt(a,                         \
+            (molt_pair[]){__VA_ARGS__},                                 \
+            ( sizeof((molt_pair[]){__VA_ARGS__}) / sizeof(molt_pair) )  \
           )
 
 #endif /* ifndef U3_IMPRISON_H */

--- a/pkg/noun/jets/a/add.c
+++ b/pkg/noun/jets/a/add.c
@@ -114,7 +114,7 @@ u3wa_add(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
        (c3n == u3ud(a)) ||
        (c3n == u3ud(b)) )
   {

--- a/pkg/noun/jets/a/div.c
+++ b/pkg/noun/jets/a/div.c
@@ -36,7 +36,7 @@ u3wa_div(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
        (c3n == u3ud(a)) ||
        (c3n == u3ud(b)) )
   {

--- a/pkg/noun/jets/a/gte.c
+++ b/pkg/noun/jets/a/gte.c
@@ -16,7 +16,7 @@ u3wa_gte(u3_noun cor)
 {
   u3_noun a, b;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}))
      || (c3n == u3ud(b))
      || (c3n == u3ud(a)) )
   {

--- a/pkg/noun/jets/a/gth.c
+++ b/pkg/noun/jets/a/gth.c
@@ -17,7 +17,7 @@ u3wa_gth(u3_noun cor)
 {
   u3_noun a, b;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}))
      || (c3n == u3ud(b))
      || (c3n == u3ud(a)) )
   {

--- a/pkg/noun/jets/a/lte.c
+++ b/pkg/noun/jets/a/lte.c
@@ -17,7 +17,7 @@ u3wa_lte(u3_noun cor)
 {
   u3_noun a, b;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}))
      || (c3n == u3ud(b))
      || (c3n == u3ud(a)) )
   {

--- a/pkg/noun/jets/a/lth.c
+++ b/pkg/noun/jets/a/lth.c
@@ -16,7 +16,7 @@ u3wa_lth(u3_noun cor)
 {
   u3_noun a, b;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}))
      || (c3n == u3ud(b))
      || (c3n == u3ud(a)) )
   {

--- a/pkg/noun/jets/a/max.c
+++ b/pkg/noun/jets/a/max.c
@@ -40,7 +40,7 @@ u3wa_max(u3_noun cor)
 {
   u3_noun a, b;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}))
      || (c3n == u3ud(b))
      || (c3n == u3ud(a)) )
   {

--- a/pkg/noun/jets/a/min.c
+++ b/pkg/noun/jets/a/min.c
@@ -42,7 +42,7 @@ u3wa_min(u3_noun cor)
 {
   u3_noun a, b;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}))
      || (c3n == u3ud(b))
      || (c3n == u3ud(a)) )
   {

--- a/pkg/noun/jets/a/mod.c
+++ b/pkg/noun/jets/a/mod.c
@@ -34,7 +34,7 @@ u3wa_mod(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
        (c3n == u3ud(a)) ||
        (c3n == u3ud(b)) )
   {

--- a/pkg/noun/jets/a/mul.c
+++ b/pkg/noun/jets/a/mul.c
@@ -47,7 +47,7 @@ u3wa_mul(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
        (c3n == u3ud(a)) ||
        (c3n == u3ud(b)) )
   {

--- a/pkg/noun/jets/a/sub.c
+++ b/pkg/noun/jets/a/sub.c
@@ -105,7 +105,7 @@ u3wa_sub(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
        (c3n == u3ud(b)) ||
        (c3n == u3ud(a)) )
   {

--- a/pkg/noun/jets/b/bind.c
+++ b/pkg/noun/jets/b/bind.c
@@ -21,7 +21,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qb_bind(a, b);

--- a/pkg/noun/jets/b/clap.c
+++ b/pkg/noun/jets/b/clap.c
@@ -26,9 +26,9 @@
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a,
-                              u3x_sam_6, &b,
-                              u3x_sam_7, &c, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a},
+                              {u3x_sam_6, &b},
+                              {u3x_sam_7, &c}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qb_clap(a, b, c);

--- a/pkg/noun/jets/b/find.c
+++ b/pkg/noun/jets/b/find.c
@@ -45,6 +45,6 @@ u3_noun
 u3wb_find(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qb_find(a, b);
 }

--- a/pkg/noun/jets/b/levy.c
+++ b/pkg/noun/jets/b/levy.c
@@ -43,7 +43,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qb_levy(a, b);

--- a/pkg/noun/jets/b/lien.c
+++ b/pkg/noun/jets/b/lien.c
@@ -43,7 +43,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qb_lien(a, b);

--- a/pkg/noun/jets/b/mate.c
+++ b/pkg/noun/jets/b/mate.c
@@ -24,7 +24,7 @@
   u3wb_mate(u3_noun cor)
   {
     u3_noun a, b;
-    u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+    u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
     return u3qb_mate(a, b);
   }
 

--- a/pkg/noun/jets/b/murn.c
+++ b/pkg/noun/jets/b/murn.c
@@ -49,6 +49,6 @@ u3_noun
 u3wb_murn(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qb_murn(a, b);
 }

--- a/pkg/noun/jets/b/reap.c
+++ b/pkg/noun/jets/b/reap.c
@@ -31,7 +31,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/b/reel.c
+++ b/pkg/noun/jets/b/reel.c
@@ -44,7 +44,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qb_reel(a, b);

--- a/pkg/noun/jets/b/roll.c
+++ b/pkg/noun/jets/b/roll.c
@@ -35,7 +35,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qb_roll(a, b);

--- a/pkg/noun/jets/b/scag.c
+++ b/pkg/noun/jets/b/scag.c
@@ -43,7 +43,7 @@ u3_noun
 u3wb_scag(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
 
   if ( (c3n == u3ud(a)) && (u3_nul != b) ) {
     return u3m_bail(c3__exit);

--- a/pkg/noun/jets/b/skid.c
+++ b/pkg/noun/jets/b/skid.c
@@ -57,6 +57,6 @@ u3_noun
 u3wb_skid(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qb_skid(a, b);
 }

--- a/pkg/noun/jets/b/skim.c
+++ b/pkg/noun/jets/b/skim.c
@@ -51,6 +51,6 @@ u3_noun
 u3wb_skim(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qb_skim(a, b);
 }

--- a/pkg/noun/jets/b/skip.c
+++ b/pkg/noun/jets/b/skip.c
@@ -51,6 +51,6 @@ u3_noun
 u3wb_skip(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qb_skip(a, b);
 }

--- a/pkg/noun/jets/b/slag.c
+++ b/pkg/noun/jets/b/slag.c
@@ -33,7 +33,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a) && u3_nul != b) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/b/snag.c
+++ b/pkg/noun/jets/b/snag.c
@@ -34,7 +34,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/b/sort.c
+++ b/pkg/noun/jets/b/sort.c
@@ -108,7 +108,7 @@ u3wb_sort(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) )
+  if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) )
   {
     return u3m_bail(c3__exit);
   }

--- a/pkg/noun/jets/b/turn.c
+++ b/pkg/noun/jets/b/turn.c
@@ -44,6 +44,6 @@ u3_noun
 u3wb_turn(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qb_turn(a, b);
 }

--- a/pkg/noun/jets/b/weld.c
+++ b/pkg/noun/jets/b/weld.c
@@ -35,7 +35,7 @@ u3_noun
 u3wb_weld(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qb_weld(a, b);
 }
 

--- a/pkg/noun/jets/c/aor.c
+++ b/pkg/noun/jets/c/aor.c
@@ -60,7 +60,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qc_aor(a, b);

--- a/pkg/noun/jets/c/c0n.c
+++ b/pkg/noun/jets/c/c0n.c
@@ -35,7 +35,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) )
     {

--- a/pkg/noun/jets/c/can.c
+++ b/pkg/noun/jets/c/can.c
@@ -74,7 +74,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) )
     {
       return u3m_bail(c3__fail);

--- a/pkg/noun/jets/c/cat.c
+++ b/pkg/noun/jets/c/cat.c
@@ -39,9 +39,9 @@
   {
     u3_noun a, b, c;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a,
-                                u3x_sam_6, &b,
-                                u3x_sam_7, &c, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a},
+                                {u3x_sam_6, &b},
+                                {u3x_sam_7, &c})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) ||
          (c3n == u3ud(c)) )

--- a/pkg/noun/jets/c/cut.c
+++ b/pkg/noun/jets/c/cut.c
@@ -51,10 +51,10 @@
   {
     u3_noun a, b, c, d;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2,  &a,
-                                u3x_sam_12, &b,
-                                u3x_sam_13, &c,
-                                u3x_sam_7,  &d, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2,  &a},
+                                {u3x_sam_12, &b},
+                                {u3x_sam_13, &c},
+                                {u3x_sam_7,  &d})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) ||
          (c3n == u3ud(c)) ||

--- a/pkg/noun/jets/c/dis.c
+++ b/pkg/noun/jets/c/dis.c
@@ -34,7 +34,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) )
     {

--- a/pkg/noun/jets/c/dor.c
+++ b/pkg/noun/jets/c/dor.c
@@ -40,7 +40,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qc_dor(a, b);

--- a/pkg/noun/jets/c/dvr.c
+++ b/pkg/noun/jets/c/dvr.c
@@ -34,7 +34,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) )
     {

--- a/pkg/noun/jets/c/end.c
+++ b/pkg/noun/jets/c/end.c
@@ -43,8 +43,8 @@ u3wc_end(u3_noun cor)
 {
   u3_atom bloq, step;
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a,
-                u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a},
+                {u3x_sam_3, &b});
   u3x_bite(a, &bloq, &step);
 
   return u3qc_end(bloq, step, u3x_atom(b));

--- a/pkg/noun/jets/c/gor.c
+++ b/pkg/noun/jets/c/gor.c
@@ -23,7 +23,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ) {
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qc_gor(a, b);

--- a/pkg/noun/jets/c/lsh.c
+++ b/pkg/noun/jets/c/lsh.c
@@ -44,8 +44,8 @@ u3wc_lsh(u3_noun cor)
 {
   u3_atom bloq, step;
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a,
-                u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a},
+                {u3x_sam_3, &b});
   u3x_bite(a, &bloq, &step);
 
   return u3qc_lsh(bloq, step, u3x_atom(b));

--- a/pkg/noun/jets/c/met.c
+++ b/pkg/noun/jets/c/met.c
@@ -30,7 +30,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(b)) ||
          (c3n == u3ud(a) && 0 != b) )
     {

--- a/pkg/noun/jets/c/mix.c
+++ b/pkg/noun/jets/c/mix.c
@@ -37,7 +37,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) )
     {

--- a/pkg/noun/jets/c/mor.c
+++ b/pkg/noun/jets/c/mor.c
@@ -23,7 +23,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ) {
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qc_mor(a, b);

--- a/pkg/noun/jets/c/muk.c
+++ b/pkg/noun/jets/c/muk.c
@@ -62,9 +62,9 @@ u3_noun
 u3wc_muk(u3_noun cor)
 {
   u3_noun sed, len, key;
-  u3x_mean(cor, u3x_sam_2, &sed,
-                u3x_sam_6, &len,
-                u3x_sam_7, &key, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &sed},
+                {u3x_sam_6, &len},
+                {u3x_sam_7, &key});
 
   if (  (c3n == u3ud(sed))
      || (c3n == u3ud(len))

--- a/pkg/noun/jets/c/peg.c
+++ b/pkg/noun/jets/c/peg.c
@@ -54,7 +54,7 @@ u3wc_peg(u3_noun cor)
 {
   u3_noun a, b;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
        (c3n == u3ud(b)) ||
        (c3n == u3ud(a) && b != 1) )
   {

--- a/pkg/noun/jets/c/po.c
+++ b/pkg/noun/jets/c/po.c
@@ -1360,7 +1360,7 @@ u3_noun
 u3wcp_ins(u3_noun cor)
 {
   u3_noun a;
-  u3x_mean(cor, u3x_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &a});
 
   if ( c3n == u3ud(a) ) {
     return u3m_bail(c3__fail);
@@ -1382,7 +1382,7 @@ u3_noun
 u3wcp_ind(u3_noun cor)
 {
   u3_noun a;
-  u3x_mean(cor, u3x_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &a});
 
   if ( c3n == u3ud(a) ) {
     return u3m_bail(c3__fail);
@@ -1396,7 +1396,7 @@ u3wcp_tos(u3_noun cor)
 {
   u3_noun a;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam, &a, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam, &a})) ||
        (c3n == u3ud(a)) ||
        (a >= 256) )
   {
@@ -1414,7 +1414,7 @@ u3wcp_tod(u3_noun cor)
 {
   u3_noun a;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam, &a, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam, &a})) ||
        (c3n == u3ud(a)) ||
        (a >= 256) )
   {

--- a/pkg/noun/jets/c/pow.c
+++ b/pkg/noun/jets/c/pow.c
@@ -27,7 +27,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/c/rap.c
+++ b/pkg/noun/jets/c/rap.c
@@ -74,7 +74,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/c/rep.c
+++ b/pkg/noun/jets/c/rep.c
@@ -210,8 +210,8 @@ u3wc_rep(u3_noun cor)
 {
   u3_atom bloq, step;
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a,
-                u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a},
+                {u3x_sam_3, &b});
   u3x_bite(a, &bloq, &step);
 
   return u3qc_rep(bloq, step, b);

--- a/pkg/noun/jets/c/rev.c
+++ b/pkg/noun/jets/c/rev.c
@@ -27,9 +27,9 @@
   {
     u3_noun boz, len, dat;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &boz,
-                               u3x_sam_6, &len,
-                               u3x_sam_7, &dat, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &boz},
+                               {u3x_sam_6, &len},
+                               {u3x_sam_7, &dat})) ||
          (c3n == u3ud(boz)) ||
          (c3n == u3ud(len)) ||
          (c3n == u3ud(dat)) )

--- a/pkg/noun/jets/c/rip.c
+++ b/pkg/noun/jets/c/rip.c
@@ -201,8 +201,8 @@ u3wc_rip(u3_noun cor)
 {
   u3_atom bloq, step;
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a,
-                u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a},
+                {u3x_sam_3, &b});
   u3x_bite(a, &bloq, &step);
 
   return u3qc_rip(bloq, step, u3x_atom(b));

--- a/pkg/noun/jets/c/rsh.c
+++ b/pkg/noun/jets/c/rsh.c
@@ -41,8 +41,8 @@ u3wc_rsh(u3_noun cor)
 {
   u3_atom bloq, step;
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a,
-                u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a},
+                {u3x_sam_3, &b});
   u3x_bite(a, &bloq, &step);
 
   return u3qc_rsh(bloq, step, u3x_atom(b));

--- a/pkg/noun/jets/c/sew.c
+++ b/pkg/noun/jets/c/sew.c
@@ -56,11 +56,11 @@ u3_weak
 u3wc_sew(u3_noun cor)
 {
   u3_noun a, b, c, d, e;
-  if ( (c3n == u3r_mean(cor, u3x_sam_2,  &a,
-                             u3x_sam_12, &b,
-                                    (c3_w)106, &c,
-                                    (c3_w)107, &d,
-                              u3x_sam_7, &e, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2,  &a},
+                             {u3x_sam_12, &b},
+                                    {106, &c},
+                                    {107, &d},
+                              {u3x_sam_7, &e})) ||
        (c3n == u3ud(a)) ||
        (c3n == u3ud(b)) ||
        (c3n == u3ud(c)) ||

--- a/pkg/noun/jets/c/swp.c
+++ b/pkg/noun/jets/c/swp.c
@@ -29,7 +29,7 @@ u3_noun
 u3wc_swp(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
 
   if (  (c3n == u3ud(a))
      || (c3n == u3ud(b)) )

--- a/pkg/noun/jets/d/by_all.c
+++ b/pkg/noun/jets/d/by_all.c
@@ -46,6 +46,6 @@ u3_noun
 u3wdb_all(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_all(a, b);
 }

--- a/pkg/noun/jets/d/by_any.c
+++ b/pkg/noun/jets/d/by_any.c
@@ -46,6 +46,6 @@ u3_noun
 u3wdb_any(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_any(a, b);
 }

--- a/pkg/noun/jets/d/by_bif.c
+++ b/pkg/noun/jets/d/by_bif.c
@@ -55,7 +55,7 @@ u3_noun
 u3wdb_bif(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_bif(a, b);
 }
 

--- a/pkg/noun/jets/d/by_del.c
+++ b/pkg/noun/jets/d/by_del.c
@@ -88,6 +88,6 @@ u3_noun
 u3wdb_del(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_del(a, b);
 }

--- a/pkg/noun/jets/d/by_dif.c
+++ b/pkg/noun/jets/d/by_dif.c
@@ -49,7 +49,7 @@ u3_noun
 u3wdb_dif(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_dif(a, b);
 }
 

--- a/pkg/noun/jets/d/by_gas.c
+++ b/pkg/noun/jets/d/by_gas.c
@@ -30,7 +30,7 @@ u3_noun
 u3wdb_gas(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_gas(a, b);
 }
 

--- a/pkg/noun/jets/d/by_get.c
+++ b/pkg/noun/jets/d/by_get.c
@@ -33,7 +33,7 @@ u3_noun
 u3wdb_get(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_get(a, b);
 }
 

--- a/pkg/noun/jets/d/by_has.c
+++ b/pkg/noun/jets/d/by_has.c
@@ -33,7 +33,7 @@ u3_noun
 u3wdb_has(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_has(a, b);
 }
 

--- a/pkg/noun/jets/d/by_int.c
+++ b/pkg/noun/jets/d/by_int.c
@@ -67,6 +67,6 @@ u3_noun
 u3wdb_int(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_int(a, b);
 }

--- a/pkg/noun/jets/d/by_jab.c
+++ b/pkg/noun/jets/d/by_jab.c
@@ -55,9 +55,9 @@ u3_noun
 u3wdb_jab(u3_noun cor)
 {
   u3_noun a, key, fun;
-  u3x_mean(cor, u3x_sam_2,   &key,
-                u3x_sam_3,   &fun,
-                u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam_2,   &key},
+                {u3x_sam_3,   &fun},
+                {u3x_con_sam, &a});
 
   return u3qdb_jab(a, key, fun);
 }

--- a/pkg/noun/jets/d/by_put.c
+++ b/pkg/noun/jets/d/by_put.c
@@ -85,9 +85,9 @@ u3_noun
 u3wdb_put(u3_noun cor)
 {
   u3_noun a, b, c;
-  u3x_mean(cor, u3x_sam_2,   &b,
-                u3x_sam_3,   &c,
-                u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam_2,   &b},
+                {u3x_sam_3,   &c},
+                {u3x_con_sam, &a});
   return u3qdb_put(a, b, c);
 }
 

--- a/pkg/noun/jets/d/by_run.c
+++ b/pkg/noun/jets/d/by_run.c
@@ -48,6 +48,6 @@ u3_noun
 u3wdb_run(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_run(a, b);
 }

--- a/pkg/noun/jets/d/by_uni.c
+++ b/pkg/noun/jets/d/by_uni.c
@@ -88,7 +88,7 @@ u3_noun
 u3wdb_uni(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_uni(a, b);
 }
 

--- a/pkg/noun/jets/d/by_urn.c
+++ b/pkg/noun/jets/d/by_urn.c
@@ -47,6 +47,6 @@ u3_noun
 u3wdb_urn(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdb_urn(a, b);
 }

--- a/pkg/noun/jets/d/in_bif.c
+++ b/pkg/noun/jets/d/in_bif.c
@@ -53,7 +53,7 @@ u3_noun
 u3wdi_bif(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_bif(a, b);
 }
 

--- a/pkg/noun/jets/d/in_del.c
+++ b/pkg/noun/jets/d/in_del.c
@@ -83,6 +83,6 @@ u3_noun
 u3wdi_del(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_del(a, b);
 }

--- a/pkg/noun/jets/d/in_dif.c
+++ b/pkg/noun/jets/d/in_dif.c
@@ -49,7 +49,7 @@ u3_noun
 u3wdi_dif(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_dif(a, b);
 }
 

--- a/pkg/noun/jets/d/in_gas.c
+++ b/pkg/noun/jets/d/in_gas.c
@@ -28,7 +28,7 @@ u3_noun
 u3wdi_gas(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_gas(a, b);
 }
 

--- a/pkg/noun/jets/d/in_has.c
+++ b/pkg/noun/jets/d/in_has.c
@@ -31,7 +31,7 @@ u3_noun
 u3wdi_has(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_has(a, b);
 }
 

--- a/pkg/noun/jets/d/in_int.c
+++ b/pkg/noun/jets/d/in_int.c
@@ -60,6 +60,6 @@ u3_noun
 u3wdi_int(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_int(a, b);
 }

--- a/pkg/noun/jets/d/in_put.c
+++ b/pkg/noun/jets/d/in_put.c
@@ -73,7 +73,7 @@ u3_noun
 u3wdi_put(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_put(a, b);
 }
 

--- a/pkg/noun/jets/d/in_rep.c
+++ b/pkg/noun/jets/d/in_rep.c
@@ -47,6 +47,6 @@ u3_noun
 u3wdi_rep(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_rep(a, b);
 }

--- a/pkg/noun/jets/d/in_run.c
+++ b/pkg/noun/jets/d/in_run.c
@@ -54,6 +54,6 @@ u3_noun
 u3wdi_run(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_run(a, b);
 }

--- a/pkg/noun/jets/d/in_tap.c
+++ b/pkg/noun/jets/d/in_tap.c
@@ -33,7 +33,7 @@ u3_noun
 u3wdi_tap(u3_noun cor)
 {
   u3_noun a;
-  u3x_mean(cor, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_con_sam, &a});
   return u3qdi_tap(a);
 }
 

--- a/pkg/noun/jets/d/in_uni.c
+++ b/pkg/noun/jets/d/in_uni.c
@@ -92,7 +92,7 @@ u3_noun
 u3wdi_uni(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul);
+  u3x_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a});
   return u3qdi_uni(a, b);
 }
 

--- a/pkg/noun/jets/e/adler.c
+++ b/pkg/noun/jets/e/adler.c
@@ -9,8 +9,8 @@
 static void _x_octs(u3_noun octs, u3_atom* p_octs, u3_atom* q_octs) {
 
   if (c3n == u3r_mean(octs,
-             (c3_w)2, p_octs,
-             (c3_w)3, q_octs, u3_nul)){
+             {2, p_octs},
+             {3, q_octs})){
     u3m_bail(c3__exit);
   }
 
@@ -121,7 +121,7 @@ u3we_adler32(u3_noun cor)
 {
   u3_noun octs;
 
-  u3x_mean(cor, u3x_sam, &octs, u3_nul);
+  u3x_mean(cor, {u3x_sam, &octs});
 
   return _qe_adler32(octs);
 }

--- a/pkg/noun/jets/e/aes_cbc.c
+++ b/pkg/noun/jets/e/aes_cbc.c
@@ -52,7 +52,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &c}, {60, &a}, {61, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -76,7 +76,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &c}, {60, &a}, {61, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -100,7 +100,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &c}, {60, &a}, {61, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -124,7 +124,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &c}, {60, &a}, {61, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -148,7 +148,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &c}, {60, &a}, {61, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -172,7 +172,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &c, (c3_w)60, &a, (c3_w)61, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &c}, {60, &a}, {61, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/aes_ecb.c
+++ b/pkg/noun/jets/e/aes_ecb.c
@@ -41,7 +41,7 @@ typedef int (*urcrypt_ecb)(c3_y*, c3_y[16], c3_y[16]);
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -64,7 +64,7 @@ typedef int (*urcrypt_ecb)(c3_y*, c3_y[16], c3_y[16]);
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -87,7 +87,7 @@ typedef int (*urcrypt_ecb)(c3_y*, c3_y[16], c3_y[16]);
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -110,7 +110,7 @@ typedef int (*urcrypt_ecb)(c3_y*, c3_y[16], c3_y[16]);
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -133,7 +133,7 @@ typedef int (*urcrypt_ecb)(c3_y*, c3_y[16], c3_y[16]);
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);
@@ -156,7 +156,7 @@ typedef int (*urcrypt_ecb)(c3_y*, c3_y[16], c3_y[16]);
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ) {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/aes_siv.c
+++ b/pkg/noun/jets/e/aes_siv.c
@@ -189,9 +189,9 @@ u3wea_siva_en(u3_noun cor)
 {
   u3_noun key, ads, txt;
 
-  if ( c3n == u3r_mean(cor, u3x_sam, &txt,
-                       u3x_con_sam_2, &key,
-                       u3x_con_sam_3, &ads, u3_nul) ||
+  if ( c3n == u3r_mean(cor, {u3x_sam, &txt},
+                       {u3x_con_sam_2, &key},
+                       {u3x_con_sam_3, &ads}) ||
        c3n == u3ud(key) ||
        c3n == u3ud(txt) ) {
     return u3m_bail(c3__exit);
@@ -223,11 +223,11 @@ u3wea_siva_de(u3_noun cor)
   u3_noun key, ads, iv, len, txt;
 
   if ( c3n == u3r_mean(cor,
-                       u3x_sam_2, &iv,
-                       u3x_sam_6, &len,
-                       u3x_sam_7, &txt,
-                       u3x_con_sam_2, &key,
-                       u3x_con_sam_3, &ads, u3_nul) ||
+                       {u3x_sam_2, &iv},
+                       {u3x_sam_6, &len},
+                       {u3x_sam_7, &txt},
+                       {u3x_con_sam_2, &key},
+                       {u3x_con_sam_3, &ads}) ||
        c3n == u3ud(key) ||
        c3n == u3ud(txt) ) {
     return u3m_bail(c3__exit);
@@ -257,9 +257,9 @@ u3wea_sivb_en(u3_noun cor)
 {
   u3_noun key, ads, txt;
 
-  if ( c3n == u3r_mean(cor, u3x_sam, &txt,
-                       u3x_con_sam_2, &key,
-                       u3x_con_sam_3, &ads, u3_nul) ||
+  if ( c3n == u3r_mean(cor, {u3x_sam, &txt},
+                       {u3x_con_sam_2, &key},
+                       {u3x_con_sam_3, &ads}) ||
        c3n == u3ud(key) ||
        c3n == u3ud(txt) ) {
     return u3m_bail(c3__exit);
@@ -291,11 +291,11 @@ u3wea_sivb_de(u3_noun cor)
   u3_noun key, ads, iv, len, txt;
 
   if ( c3n == u3r_mean(cor,
-                       u3x_sam_2, &iv,
-                       u3x_sam_6, &len,
-                       u3x_sam_7, &txt,
-                       u3x_con_sam_2, &key,
-                       u3x_con_sam_3, &ads, u3_nul) ||
+                       {u3x_sam_2, &iv},
+                       {u3x_sam_6, &len},
+                       {u3x_sam_7, &txt},
+                       {u3x_con_sam_2, &key},
+                       {u3x_con_sam_3, &ads}) ||
        c3n == u3ud(key) ||
        c3n == u3ud(txt) ) {
     return u3m_bail(c3__exit);
@@ -324,9 +324,9 @@ u3wea_sivc_en(u3_noun cor)
 {
   u3_noun key, ads, txt;
 
-  if ( c3n == u3r_mean(cor, u3x_sam, &txt,
-                       u3x_con_sam_2, &key,
-                       u3x_con_sam_3, &ads, u3_nul) ||
+  if ( c3n == u3r_mean(cor, {u3x_sam, &txt},
+                       {u3x_con_sam_2, &key},
+                       {u3x_con_sam_3, &ads}) ||
        c3n == u3ud(key) ||
        c3n == u3ud(txt) ) {
     return u3m_bail(c3__exit);
@@ -358,11 +358,11 @@ u3wea_sivc_de(u3_noun cor)
   u3_noun key, ads, iv, len, txt;
 
   if ( c3n == u3r_mean(cor,
-                       u3x_sam_2, &iv,
-                       u3x_sam_6, &len,
-                       u3x_sam_7, &txt,
-                       u3x_con_sam_2, &key,
-                       u3x_con_sam_3, &ads, u3_nul) ||
+                       {u3x_sam_2, &iv},
+                       {u3x_sam_6, &len},
+                       {u3x_sam_7, &txt},
+                       {u3x_con_sam_2, &key},
+                       {u3x_con_sam_3, &ads}) ||
        c3n == u3ud(key) ||
        c3n == u3ud(txt) ) {
     return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/argon2.c
+++ b/pkg/noun/jets/e/argon2.c
@@ -125,9 +125,9 @@
     // and then produces a gate. we jet that inner gate.
     // this does mean that the config params have gotten buried
     // pretty deep in the subject, hence the +510.
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &wmsg,
-                              u3x_sam_3, &wsat,
-                              (c3_w)510, &arg, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &wmsg},
+                              {u3x_sam_3, &wsat},
+                              {510, &arg}) ||
                 u3r_cell(wmsg, &wid, &dat) || u3ud(wid) || u3ud(dat) ||
                 u3r_cell(wsat, &wis, &sat) || u3ud(wis) || u3ud(sat) ||
                 //

--- a/pkg/noun/jets/e/base.c
+++ b/pkg/noun/jets/e/base.c
@@ -140,7 +140,7 @@ u3_noun
 u3we_en_base16(u3_noun cor)
 {
   u3_noun a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qe_en_base16(u3x_atom(a), u3x_atom(b));
 }
 

--- a/pkg/noun/jets/e/blake.c
+++ b/pkg/noun/jets/e/blake.c
@@ -44,9 +44,9 @@
             wid, dat,      // destructured msg
             wik, dak;      // destructured key
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &msg,
-                              u3x_sam_6, &key,
-                              u3x_sam_7, &out, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &msg},
+                              {u3x_sam_6, &key},
+                              {u3x_sam_7, &out}) ||
                 u3r_cell(msg, &wid, &dat) || u3ud(wid) || u3ud(dat) ||
                 u3r_cell(key, &wik, &dak) || u3ud(wik) || u3ud(dak) ||
                 u3ud(out) )
@@ -86,9 +86,9 @@
             wid, dat,        // destructured msg
             sam, key, flags; // context
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &out,
-                              u3x_sam_3, &msg,
-                              u3x_con_sam, &sam, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &out},
+                              {u3x_sam_3, &msg},
+                              {u3x_con_sam, &sam}) ||
                 u3ud(out) ||
                 u3r_cell(msg, &wid, &dat) || u3ud(wid) || u3ud(dat) ||
                 u3r_cell(sam, &key, &flags) || u3ud(key) || u3ud(flags) )
@@ -124,10 +124,10 @@
             wid, dat,          // destructured msg
             key, flags;        // context
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &counter,
-                              u3x_sam_3, &msg,
-                              u3x_con_sam_2, &key,
-                              u3x_con_sam_3, &flags, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &counter},
+                              {u3x_sam_3, &msg},
+                              {u3x_con_sam_2, &key},
+                              {u3x_con_sam_3, &flags}) ||
                 u3r_cell(msg, &wid, &dat) || u3ud(wid) || u3ud(dat) ||
                 u3ud(key) || u3ud(flags))
     {

--- a/pkg/noun/jets/e/bytestream.c
+++ b/pkg/noun/jets/e/bytestream.c
@@ -13,8 +13,8 @@ static void
 _x_octs(u3_noun octs, u3_atom* p_octs, u3_atom* q_octs) {
 
   if (c3n == u3r_mean(octs,
-             (c3_w)2, p_octs,
-             (c3_w)3, q_octs, u3_nul)){
+             {2, p_octs},
+             {3, q_octs})){
     u3m_bail(c3__exit);
   }
 
@@ -163,7 +163,7 @@ u3we_bytestream_cat_octs(u3_noun cor) {
 
   u3_noun octs_a, octs_b;
 
-  u3x_mean(cor, u3x_sam_2, &octs_a, u3x_sam_3, &octs_b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &octs_a}, {u3x_sam_3, &octs_b});
 
   return _qe_bytestream_cat_octs(octs_a, octs_b);
 
@@ -297,7 +297,7 @@ u3we_bytestream_can_octs(u3_noun cor)
 {
   u3_noun octs_list;
 
-  u3x_mean(cor, u3x_sam_1, &octs_list, u3_nul);
+  u3x_mean(cor, {u3x_sam_1, &octs_list});
 
   return _qe_bytestream_can_octs(octs_list);
 }
@@ -348,7 +348,7 @@ u3we_bytestream_skip_line(u3_noun cor)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(cor, u3x_sam_2, &pos, u3x_sam_3, &octs, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &pos}, {u3x_sam_3, &octs});
 
   return _qe_bytestream_skip_line(pos, octs);
 
@@ -409,9 +409,9 @@ u3we_bytestream_find_byte(u3_noun cor)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(cor, u3x_sam_2, &bat,
-                u3x_sam_6, &pos,
-                u3x_sam_7, &octs, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &bat},
+                {u3x_sam_6, &pos},
+                {u3x_sam_7, &octs});
 
   return _qe_bytestream_find_byte(bat, pos, octs);
 }
@@ -471,9 +471,9 @@ u3we_bytestream_seek_byte(u3_noun cor)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(cor, u3x_sam_2, &bat,
-                u3x_sam_6, &pos,
-                u3x_sam_7, &octs, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &bat},
+                {u3x_sam_6, &pos},
+                {u3x_sam_7, &octs});
 
   return _qe_bytestream_seek_byte(bat, pos, octs);
 }
@@ -526,8 +526,8 @@ u3we_bytestream_read_byte(u3_noun cor)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(cor, u3x_sam_2, &pos,
-                u3x_sam_3, &octs, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &pos},
+                {u3x_sam_3, &octs});
 
   return _qe_bytestream_read_byte(pos, octs);
 }
@@ -614,9 +614,9 @@ u3we_bytestream_read_octs(u3_noun cor)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(cor, u3x_sam_2, &n,
-                u3x_sam_6, &pos,
-                u3x_sam_7, &octs, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &n},
+                {u3x_sam_6, &pos},
+                {u3x_sam_7, &octs});
 
   return _qe_bytestream_read_octs(n, pos, octs);
 }
@@ -719,9 +719,9 @@ u3we_bytestream_chunk(u3_noun cor)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(cor, u3x_sam_2, &size,
-                u3x_sam_6, &pos,
-                u3x_sam_7, &octs, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &size},
+                {u3x_sam_6, &pos},
+                {u3x_sam_7, &octs});
 
   return _qe_bytestream_chunk(size, pos, octs);
 }
@@ -732,7 +732,7 @@ _qe_bytestream_extract(u3_noun sea, u3_noun rac)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(sea, (c3_w)2, &pos, (c3_w)3, &octs, u3_nul);
+  u3x_mean(sea, {2, &pos}, {3, &octs});
 
   c3_w pos_w;
 
@@ -766,7 +766,7 @@ _qe_bytestream_extract(u3_noun sea, u3_noun rac)
     u3_atom sip, ken;
     c3_w sip_w, ken_w;
 
-    u3x_mean(ext, (c3_w)2, &sip, (c3_w)3, &ken, u3_nul);
+    u3x_mean(ext, {2, &sip}, {3, &ken});
 
     if (c3n == u3r_safe_word(sip, &sip_w)) {
       // XX is u3z necessary here?
@@ -817,8 +817,8 @@ u3we_bytestream_extract(u3_noun cor)
   u3_noun sea;
   u3_noun rac;
 
-  u3x_mean(cor, u3x_sam_2, &sea,
-                u3x_sam_3, &rac, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &sea},
+                {u3x_sam_3, &rac});
 
   return _qe_bytestream_extract(sea, rac);
 }
@@ -829,7 +829,7 @@ _qe_bytestream_fuse_extract(u3_noun sea, u3_noun rac)
   u3_atom pos;
   u3_noun octs;
 
-  u3x_mean(sea, (c3_w)2, &pos, (c3_w)3, &octs, u3_nul);
+  u3x_mean(sea, {2, &pos}, {3, &octs});
 
   c3_w pos_w;
 
@@ -863,7 +863,7 @@ _qe_bytestream_fuse_extract(u3_noun sea, u3_noun rac)
     u3_atom sip, ken;
     c3_w sip_w, ken_w;
 
-    u3x_mean(ext, (c3_w)2, &sip, (c3_w)3, &ken, u3_nul);
+    u3x_mean(ext, {2, &sip}, {3, &ken});
 
     if (c3n == u3r_safe_word(sip, &sip_w)) {
       // XX is u3z necessary here?
@@ -918,8 +918,8 @@ u3we_bytestream_fuse_extract(u3_noun cor)
   u3_noun sea;
   u3_noun rac;
 
-  u3x_mean(cor, u3x_sam_2, &sea,
-                u3x_sam_3, &rac, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &sea},
+                {u3x_sam_3, &rac});
 
   return _qe_bytestream_fuse_extract(sea, rac);
 }
@@ -932,9 +932,9 @@ _qe_bytestream_need_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, (c3_w)2, &num,
-                 (c3_w)6, &bit,
-                 (c3_w)7, &bays, u3_nul);
+  u3x_mean(bits, {2, &num},
+                 {6, &bit},
+                 {7, &bays});
 
 
   c3_w n_w, num_w;
@@ -975,7 +975,7 @@ _qe_bytestream_need_bits(u3_atom n, u3_noun bits)
   u3_noun octs;
 
 
-  u3x_mean(bays, (c3_w)2, &pos, (c3_w)3, &octs, u3_nul);
+  u3x_mean(bays, {2, &pos}, {3, &octs});
 
   if (c3n == u3r_safe_word(pos, &pos_w)) {
     return u3_none;
@@ -1026,8 +1026,8 @@ u3we_bytestream_need_bits(u3_noun cor)
   u3_atom n;
   u3_noun bits;
 
-  u3x_mean(cor, u3x_sam_2, &n,
-                u3x_sam_3, &bits, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &n},
+                {u3x_sam_3, &bits});
 
   return _qe_bytestream_need_bits(n, bits);
 }
@@ -1039,9 +1039,9 @@ _qe_bytestream_drop_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, (c3_w)2, &num,
-                 (c3_w)6, &bit,
-                 (c3_w)7, &bays, u3_nul);
+  u3x_mean(bits, {2, &num},
+                 {6, &bit},
+                 {7, &bays});
 
   c3_w n_w, num_w;
   c3_d bit_d;
@@ -1077,8 +1077,8 @@ u3we_bytestream_drop_bits(u3_noun cor)
   u3_atom n;
   u3_noun bits;
 
-  u3x_mean(cor, u3x_sam_2, &n,
-                u3x_sam_3, &bits, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &n},
+                {u3x_sam_3, &bits});
 
   return _qe_bytestream_drop_bits(n, bits);
 }
@@ -1090,9 +1090,9 @@ _qe_bytestream_peek_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, (c3_w)2, &num,
-                 (c3_w)6, &bit,
-                 (c3_w)7, &bays, u3_nul);
+  u3x_mean(bits, {2, &num},
+                 {6, &bit},
+                 {7, &bays});
 
   c3_w n_w, num_w;
   c3_d bit_d;
@@ -1134,8 +1134,8 @@ u3we_bytestream_peek_bits(u3_noun cor)
   u3_atom n;
   u3_noun bits;
 
-  u3x_mean(cor, u3x_sam_2, &n,
-                u3x_sam_3, &bits, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &n},
+                {u3x_sam_3, &bits});
 
   return _qe_bytestream_peek_bits(n, bits);
 }
@@ -1147,9 +1147,9 @@ _qe_bytestream_read_bits(u3_atom n, u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, (c3_w)2, &num,
-                 (c3_w)6, &bit,
-                 (c3_w)7, &bays, u3_nul);
+  u3x_mean(bits, {2, &num},
+                 {6, &bit},
+                 {7, &bays});
 
   c3_w n_w, num_w;
   c3_d bit_d;
@@ -1196,8 +1196,8 @@ u3we_bytestream_read_bits(u3_noun cor)
   u3_atom n;
   u3_noun bits;
 
-  u3x_mean(cor, u3x_sam_2, &n,
-                u3x_sam_3, &bits, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &n},
+                {u3x_sam_3, &bits});
 
   return _qe_bytestream_read_bits(n, bits);
 }
@@ -1209,9 +1209,9 @@ _qe_bytestream_byte_bits(u3_noun bits)
   u3_atom num, bit;
   u3_noun bays;
 
-  u3x_mean(bits, (c3_w)2, &num,
-                 (c3_w)6, &bit,
-                 (c3_w)7, &bays, u3_nul);
+  u3x_mean(bits, {2, &num},
+                 {6, &bit},
+                 {7, &bays});
 
   c3_w num_w;
   c3_d bit_d;
@@ -1241,7 +1241,7 @@ u3we_bytestream_byte_bits(u3_noun cor)
 {
   u3_noun bits;
 
-  u3x_mean(cor, u3x_sam, &bits, u3_nul);
+  u3x_mean(cor, {u3x_sam, &bits});
 
   return _qe_bytestream_byte_bits(bits);
 }

--- a/pkg/noun/jets/e/ed_add_double_scalarmult.c
+++ b/pkg/noun/jets/e/ed_add_double_scalarmult.c
@@ -56,10 +56,10 @@
   {
     u3_noun a, b, c, d;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a,
-                               u3x_sam_6, &b,
-                               u3x_sam_14, &c,
-                               u3x_sam_15, &d, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a},
+                               {u3x_sam_6, &b},
+                               {u3x_sam_14, &c},
+                               {u3x_sam_15, &d})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) ||
          (c3n == u3ud(c)) ||

--- a/pkg/noun/jets/e/ed_add_scalarmult_scalarmult_base.c
+++ b/pkg/noun/jets/e/ed_add_scalarmult_scalarmult_base.c
@@ -52,9 +52,9 @@
   {
     u3_noun a, b, c;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a,
-                                u3x_sam_6, &b,
-                                u3x_sam_7, &c, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a},
+                                {u3x_sam_6, &b},
+                                {u3x_sam_7, &c})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) ||
          (c3n == u3ud(c)) )

--- a/pkg/noun/jets/e/ed_point_add.c
+++ b/pkg/noun/jets/e/ed_point_add.c
@@ -28,8 +28,8 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a,
-                               u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a},
+                               {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) )
     {

--- a/pkg/noun/jets/e/ed_scad.c
+++ b/pkg/noun/jets/e/ed_scad.c
@@ -36,9 +36,9 @@
   {
     u3_noun pub, sek, sca;
     if ( (c3n == u3r_mean(cor,
-                         u3x_sam_2, &pub,
-                         u3x_sam_6, &sek,
-                         u3x_sam_7, &sca, u3_nul)) ||
+                         {u3x_sam_2, &pub},
+                         {u3x_sam_6, &sek},
+                         {u3x_sam_7, &sca})) ||
          (c3n == u3ud(pub)) ||
          (c3n == u3ud(sek)) ||
          (c3n == u3ud(sca)) ) {
@@ -74,8 +74,8 @@
   {
     u3_noun sek, sca;
     if ( (c3n == u3r_mean(cor,
-                         u3x_sam_2, &sek,
-                         u3x_sam_3, &sca, u3_nul)) ||
+                         {u3x_sam_2, &sek},
+                         {u3x_sam_3, &sca})) ||
          (c3n == u3ud(sek)) ||
          (c3n == u3ud(sca)) ) {
       return u3m_bail(c3__exit);
@@ -110,8 +110,8 @@
   {
     u3_noun pub, sca;
     if ( (c3n == u3r_mean(cor,
-                         u3x_sam_2, &pub,
-                         u3x_sam_3, &sca, u3_nul)) ||
+                         {u3x_sam_2, &pub},
+                         {u3x_sam_3, &sca})) ||
          (c3n == u3ud(pub)) ||
          (c3n == u3ud(sca)) ) {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/ed_scalarmult.c
+++ b/pkg/noun/jets/e/ed_scalarmult.c
@@ -42,8 +42,8 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a,
-                               u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a},
+                               {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) )
     {

--- a/pkg/noun/jets/e/ed_shar.c
+++ b/pkg/noun/jets/e/ed_shar.c
@@ -30,7 +30,7 @@
   {
     u3_noun pub, sed;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &pub, u3x_sam_3, &sed, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &pub}, {u3x_sam_3, &sed})) ||
          (c3n == u3ud(pub)) ||
          (c3n == u3ud(sed)) )
     {
@@ -63,7 +63,7 @@
   {
     u3_noun pub, sek;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &pub, u3x_sam_3, &sek, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &pub}, {u3x_sam_3, &sek})) ||
          (c3n == u3ud(pub)) ||
          (c3n == u3ud(sek)) )
     {

--- a/pkg/noun/jets/e/ed_sign.c
+++ b/pkg/noun/jets/e/ed_sign.c
@@ -34,7 +34,7 @@
   {
     u3_noun msg, sed;
     u3_noun len, dat;
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &msg, u3x_sam_3, &sed, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &msg}, {u3x_sam_3, &sed}) ||
          c3n == u3r_cell(msg, &len, &dat) ||
          c3n == u3ud(sed) ||
          c3n == u3ud(len) ||
@@ -75,7 +75,7 @@
   {
     u3_noun msg, pub, sek;
     u3_noun len, dat;
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &msg, u3x_sam_6, &pub, u3x_sam_7, &sek, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &msg}, {u3x_sam_6, &pub}, {u3x_sam_7, &sek}) ||
          c3n == u3r_cell(msg, &len, &dat) ||
          c3n == u3ud(pub) ||
          c3n == u3ud(sek) ||
@@ -114,7 +114,7 @@
   {
     u3_noun msg, sed;
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &msg, u3x_sam_3, &sed, u3_nul) ||
+                         {u3x_sam_2, &msg}, {u3x_sam_3, &sed}) ||
          c3n == u3ud(msg) ||
          c3n == u3ud(sed) ) {
       return u3m_bail(c3__fail);
@@ -155,7 +155,7 @@
   {
     u3_noun msg, pub, sek;
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &msg, u3x_sam_6, &pub, u3x_sam_7, &sek, u3_nul) ||
+                         {u3x_sam_2, &msg}, {u3x_sam_6, &pub}, {u3x_sam_7, &sek}) ||
          c3n == u3ud(msg) ||
          c3n == u3ud(pub) ||
          c3n == u3ud(sek) ) {

--- a/pkg/noun/jets/e/ed_smac.c
+++ b/pkg/noun/jets/e/ed_smac.c
@@ -59,9 +59,9 @@
   {
     u3_noun a, b, c;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a,
-                               u3x_sam_6, &b,
-                               u3x_sam_7, &c, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a},
+                               {u3x_sam_6, &b},
+                               {u3x_sam_7, &c})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) ||
          (c3n == u3ud(c)) )

--- a/pkg/noun/jets/e/ed_veri.c
+++ b/pkg/noun/jets/e/ed_veri.c
@@ -34,8 +34,8 @@
     u3_noun sig, msg, pub;
     u3_noun len, dat;
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &sig, u3x_sam_6, &msg,
-                         u3x_sam_7, &pub, u3_nul) ||
+                         {u3x_sam_2, &sig}, {u3x_sam_6, &msg},
+                         {u3x_sam_7, &pub}) ||
          c3n == u3r_cell(msg, &len, &dat) ||
          (c3n == u3ud(sig)) ||
          (c3n == u3ud(pub)) ||
@@ -73,8 +73,8 @@
   {
     u3_noun a, b, c;
     if ( (c3n == u3r_mean(cor,
-                         u3x_sam_2, &a, u3x_sam_6, &b,
-                         u3x_sam_7, &c, u3_nul)) ||
+                         {u3x_sam_2, &a}, {u3x_sam_6, &b},
+                         {u3x_sam_7, &c})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) ||
          (c3n == u3ud(c)) ) {

--- a/pkg/noun/jets/e/hmac.c
+++ b/pkg/noun/jets/e/hmac.c
@@ -68,13 +68,13 @@
     u3_noun haj, boq, out, wik, key, wid, dat;
 
     // sample is [[haj boq out] [wik key] [wid dat]]
-    if ( (c3n == u3r_mean(cor, u3x_sam_4,  &haj,
-                               (c3_w)50,         &boq, // +<->-
-                               (c3_w)51,         &out, // +<->+
-                               u3x_sam_12, &wik,
-                               u3x_sam_13, &key,
-                               u3x_sam_14, &wid,
-                               u3x_sam_15, &dat, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_4,  &haj},
+                               {50,         &boq}, {// +<->-
+                               (c3_w)51,         &out}, {// +<->+
+                               u3x_sam_12, &wik},
+                               {u3x_sam_13, &key},
+                               {u3x_sam_14, &wid},
+                               {u3x_sam_15, &dat})) ||
          (c3n == u3ud(boq)) ||
          (c3n == u3a_is_cat(boq)) ||
          (c3n == u3ud(out)) ||

--- a/pkg/noun/jets/e/keccak.c
+++ b/pkg/noun/jets/e/keccak.c
@@ -28,7 +28,7 @@
   { \
     c3_w    len_w; \
     u3_noun len, tom; \
-    u3x_mean(cor, u3x_sam_2, &len, u3x_sam_3, &tom, u3_nul); \
+    u3x_mean(cor, {u3x_sam_2, &len}, {u3x_sam_3, &tom}); \
     return ( (c3n == u3ud(len)) || (c3n == u3ud(tom)) ) \
       ? u3m_bail(c3__exit) \
       : (!u3r_word_fit(&len_w, len)) \

--- a/pkg/noun/jets/e/mice.c
+++ b/pkg/noun/jets/e/mice.c
@@ -11,9 +11,8 @@ u3_noun
 u3we_mice(u3_noun cor) {
   u3_noun bus, fol;
 
-  if ( c3n == u3r_mean(cor, u3x_sam_2, &bus,
-                            u3x_sam_3, &fol,
-                            u3_nul) )
+  if ( c3n == u3r_mean(cor, {u3x_sam_2, &bus},
+                            {u3x_sam_3, &fol}) )
   {
     return u3m_bail(c3__exit);
   }

--- a/pkg/noun/jets/e/mink.c
+++ b/pkg/noun/jets/e/mink.c
@@ -10,10 +10,9 @@
   {
     u3_noun bus, fol, gul;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_4, &bus,
-                              u3x_sam_5, &fol,
-                              u3x_sam_3, &gul,
-                              u3_nul) )
+    if ( c3n == u3r_mean(cor, {u3x_sam_4, &bus},
+                              {u3x_sam_5, &fol},
+                              {u3x_sam_3, &gul}) )
     {
       return u3m_bail(c3__exit);
     }

--- a/pkg/noun/jets/e/parse.c
+++ b/pkg/noun/jets/e/parse.c
@@ -168,9 +168,9 @@
   {
     u3_noun van, raq, vex, sab;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &vex,
-                               u3x_sam_3, &sab,
-                               u3x_con, &van, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &vex},
+                               {u3x_sam_3, &sab},
+                               {u3x_con, &van})) ||
          (u3_none == (raq = u3r_at(u3x_sam, van))) )
     {
       return u3m_bail(c3__fail);
@@ -215,8 +215,8 @@
   {
     u3_noun van, cus, sef, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
-         (c3n == u3r_mean(van, u3x_sam_2, &cus, u3x_sam_3, &sef, u3_nul)) )
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
+         (c3n == u3r_mean(van, {u3x_sam_2, &cus}, {u3x_sam_3, &sef})) )
     {
       return u3m_bail(c3__fail);
     } else {
@@ -266,8 +266,8 @@
   {
     u3_noun van, poq, sef, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
-         (c3n == u3r_mean(van, u3x_sam_2, &poq, u3x_sam_3, &sef, u3_nul)) )
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
+         (c3n == u3r_mean(van, {u3x_sam_2, &poq}, {u3x_sam_3, &sef})) )
     {
       return u3m_bail(c3__fail);
     } else {
@@ -327,9 +327,9 @@
   {
     u3_noun van, raq, vex, sab;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &vex,
-                               u3x_sam_3, &sab,
-                               u3x_con, &van, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &vex},
+                               {u3x_sam_3, &sab},
+                               {u3x_con, &van})) ||
          (u3_none == (raq = u3r_at(u3x_sam, van))) )
     {
       return u3m_bail(c3__fail);
@@ -358,7 +358,7 @@
   {
     u3_noun van, huf, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
          (u3_none == (huf = u3r_at(u3x_sam, van))) )
     {
       return u3m_bail(c3__fail);
@@ -433,9 +433,9 @@
   {
     u3_noun van, bus, vex, sab;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &vex,
-                                u3x_sam_3, &sab,
-                                u3x_con, &van, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &vex},
+                                {u3x_sam_3, &sab},
+                                {u3x_con, &van})) ||
          (u3_none == (bus = u3r_at(u3x_sam, van))) )
     {
       return u3m_bail(c3__fail);
@@ -492,8 +492,8 @@
   {
     u3_noun van, hez, sef, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
-         (c3n == u3r_mean(van, u3x_sam_2, &hez, u3x_sam_3, &sef, u3_nul)) )
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
+         (c3n == u3r_mean(van, {u3x_sam_2, &hez}, {u3x_sam_3, &sef})) )
     {
       return u3m_bail(c3__fail);
     }
@@ -529,7 +529,7 @@
   {
     u3_noun van, daf, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
          (u3_none == (daf = u3r_at(u3x_sam, van))) )
     {
       return u3m_bail(c3__fail);
@@ -568,7 +568,7 @@
   {
     u3_noun van, bud, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
          (u3_none == (bud = u3r_at(u3x_sam, van))) )
     {
       return u3m_bail(c3__fail);
@@ -611,7 +611,7 @@
   {
     u3_noun vex, sab;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &vex, u3x_sam_3, &sab, u3_nul)) ) {
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &vex}, {u3x_sam_3, &sab})) ) {
       return u3m_bail(c3__exit);
     } else {
       return _cqe_pfix(vex, sab);
@@ -666,7 +666,7 @@
   {
     u3_noun vex, sab;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &vex, u3x_sam_3, &sab, u3_nul)) ) {
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &vex}, {u3x_sam_3, &sab})) ) {
       return u3m_bail(c3__exit);
     } else {
       return _cqe_plug(vex, sab);
@@ -702,7 +702,7 @@
   {
     u3_noun vex, sab;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &vex, u3x_sam_3, &sab, u3_nul)) ) {
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &vex}, {u3x_sam_3, &sab})) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qe_pose(vex, sab);
@@ -757,7 +757,7 @@
   {
     u3_noun vex, sab;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &vex, u3x_sam_3, &sab, u3_nul)) ) {
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &vex}, {u3x_sam_3, &sab})) ) {
       return u3m_bail(c3__exit);
     } else {
       return _cqe_sfix(vex, sab);
@@ -801,7 +801,7 @@
   {
     u3_noun van, zep, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
          (u3_none == (zep = u3r_at(u3x_sam, van))) )
     {
       return u3m_bail(c3__fail);
@@ -848,8 +848,8 @@
   {
     u3_noun van, gob, sef, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
-         (c3n == u3r_mean(van, u3x_sam_2, &gob, u3x_sam_3, &sef, u3_nul)) )
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
+         (c3n == u3r_mean(van, {u3x_sam_2, &gob}, {u3x_sam_3, &sef})) )
     {
       return u3m_bail(c3__fail);
     } else {
@@ -943,7 +943,7 @@
   {
     u3_noun con, hel, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &con, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &con})) ||
          (u3_none == (hel = u3r_at(2, con))) )
     {
       return u3m_bail(c3__fail);
@@ -1035,11 +1035,10 @@
   {
     u3_noun van, rud, raq, fel, tub;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam, &tub, u3x_con, &van, u3_nul)) ||
-         (c3n == u3r_mean(van, u3x_sam_2, &rud,
-                               u3x_sam_6, &raq,
-                               u3x_sam_7, &fel,
-                               u3_nul)) )
+    if ( (c3n == u3r_mean(cor, {u3x_sam, &tub}, {u3x_con, &van})) ||
+         (c3n == u3r_mean(van, {u3x_sam_2, &rud},
+                               {u3x_sam_6, &raq},
+                               {u3x_sam_7, &fel})) )
     {
       return u3m_bail(c3__fail);
     } else {

--- a/pkg/noun/jets/e/rd.c
+++ b/pkg/noun/jets/e/rd.c
@@ -73,7 +73,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -105,7 +105,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -137,7 +137,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -169,7 +169,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -232,7 +232,7 @@
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_6, &b, u3x_sam_7, &c, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_6, &b}, {u3x_sam_7, &c}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ||
          c3n == u3ud(c) )
@@ -262,7 +262,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -291,7 +291,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -320,7 +320,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -349,7 +349,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -378,7 +378,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {

--- a/pkg/noun/jets/e/rh.c
+++ b/pkg/noun/jets/e/rh.c
@@ -73,7 +73,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -105,7 +105,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -137,7 +137,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -169,7 +169,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -232,7 +232,7 @@
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_6, &b, u3x_sam_7, &c, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_6, &b}, {u3x_sam_7, &c}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ||
          c3n == u3ud(c) )
@@ -262,7 +262,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -291,7 +291,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -320,7 +320,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -349,7 +349,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -378,7 +378,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {

--- a/pkg/noun/jets/e/ripe.c
+++ b/pkg/noun/jets/e/ripe.c
@@ -32,8 +32,8 @@
   {
     u3_noun wid, dat;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &wid,
-                               u3x_sam_3, &dat, u3_nul) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &wid},
+                               {u3x_sam_3, &dat}) ||
                  u3ud(wid) || u3ud(dat))
        )
     {

--- a/pkg/noun/jets/e/rq.c
+++ b/pkg/noun/jets/e/rq.c
@@ -85,7 +85,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -123,7 +123,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -161,7 +161,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -199,7 +199,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -274,7 +274,7 @@
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_6, &b, u3x_sam_7, &c, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_6, &b}, {u3x_sam_7, &c}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ||
          c3n == u3ud(c) )
@@ -308,7 +308,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -341,7 +341,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -374,7 +374,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -407,7 +407,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -440,7 +440,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {

--- a/pkg/noun/jets/e/rs.c
+++ b/pkg/noun/jets/e/rs.c
@@ -73,7 +73,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -105,7 +105,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -137,7 +137,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -169,7 +169,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -232,7 +232,7 @@
   {
     u3_noun a, b, c;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_6, &b, u3x_sam_7, &c, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_6, &b}, {u3x_sam_7, &c}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) ||
          c3n == u3ud(c) )
@@ -262,7 +262,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -291,7 +291,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -320,7 +320,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -349,7 +349,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {
@@ -378,7 +378,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul) ||
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||
          c3n == u3ud(a) ||
          c3n == u3ud(b) )
     {

--- a/pkg/noun/jets/e/rub.c
+++ b/pkg/noun/jets/e/rub.c
@@ -74,7 +74,7 @@
   {
     u3_noun a, b;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b})) ||
          (c3n == u3ud(a)) ||
          (c3n == u3ud(b)) )
     {

--- a/pkg/noun/jets/e/scot.c
+++ b/pkg/noun/jets/e/scot.c
@@ -25,6 +25,6 @@ u3_noun
 u3we_scot(u3_noun cor)
 {
   u3_atom a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qe_scot(u3x_atom(a), u3x_atom(b));
 }

--- a/pkg/noun/jets/e/scow.c
+++ b/pkg/noun/jets/e/scow.c
@@ -26,6 +26,6 @@ u3_noun
 u3we_scow(u3_noun cor)
 {
   u3_atom a, b;
-  u3x_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, u3_nul);
+  u3x_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b});
   return u3qe_scow(u3x_atom(a), u3x_atom(b));
 }

--- a/pkg/noun/jets/e/secp.c
+++ b/pkg/noun/jets/e/secp.c
@@ -127,9 +127,8 @@ u3we_sign(u3_noun cor)
   u3_noun has, prv;
 
   if ( (c3n == u3r_mean(cor,
-                        u3x_sam_2,  &has,
-                        u3x_sam_3,  &prv,
-                        u3_nul)) ||
+                        {u3x_sam_2,  &has},
+                        {u3x_sam_3,  &prv})) ||
        (c3n == u3ud(has)) ||
        (c3n == u3ud(prv))) {
     return u3m_bail(c3__exit);
@@ -169,11 +168,10 @@ u3we_reco(u3_noun cor)
     siv, sir, sis;  /* signature: v, r, s */
 
   if ( (c3n == u3r_mean(cor,
-                        u3x_sam_2,   &has,
-                        u3x_sam_6,   &siv,
-                        u3x_sam_14,  &sir,
-                        u3x_sam_15,  &sis,
-                        u3_nul)) ||
+                        {u3x_sam_2,   &has},
+                        {u3x_sam_6,   &siv},
+                        {u3x_sam_14,  &sir},
+                        {u3x_sam_15,  &sis})) ||
        (c3n == u3ud(has)) ||
        (c3n == u3ud(siv)) ||
        (c3n == u3ud(sir)) ||
@@ -208,9 +206,8 @@ u3we_make(u3_noun cor)
 {
   u3_noun has, prv;
   if ( (c3n == u3r_mean(cor,
-                        u3x_sam_2,  &has,
-                        u3x_sam_3,  &prv,
-                        u3_nul)) ||
+                        {u3x_sam_2,  &has},
+                        {u3x_sam_3,  &prv})) ||
        (c3n == u3ud(has)) ||
        (c3n == u3ud(prv)) ) {
     return u3m_bail(c3__exit);
@@ -251,10 +248,9 @@ u3we_sosi(u3_noun cor)
   u3_noun key, mes, aux;
 
   if ( (c3n == u3r_mean(cor,
-                        u3x_sam_2,  &key,
-                        u3x_sam_6,  &mes,
-                        u3x_sam_7,  &aux,
-                        u3_nul)) ||
+                        {u3x_sam_2,  &key},
+                        {u3x_sam_6,  &mes},
+                        {u3x_sam_7,  &aux})) ||
        (c3n == u3ud(key)) ||
        (c3n == u3ud(mes)) ||
        (c3n == u3ud(aux)) )
@@ -292,10 +288,9 @@ u3we_sove(u3_noun cor)
   u3_noun pub, mes, sig;
 
   if ( (c3n == u3r_mean(cor,
-                        u3x_sam_2,  &pub,
-                        u3x_sam_6,  &mes,
-                        u3x_sam_7,  &sig,
-                        u3_nul)) ||
+                        {u3x_sam_2,  &pub},
+                        {u3x_sam_6,  &mes},
+                        {u3x_sam_7,  &sig})) ||
        (c3n == u3ud(pub)) ||
        (c3n == u3ud(mes)) ||
        (c3n == u3ud(sig)) )

--- a/pkg/noun/jets/e/sha1.c
+++ b/pkg/noun/jets/e/sha1.c
@@ -28,7 +28,7 @@
   {
     u3_noun wid, dat;
 
-    if ( (c3n == u3r_mean(cor, u3x_sam_2, &wid, u3x_sam_3, &dat, u3_nul)) ||
+    if ( (c3n == u3r_mean(cor, {u3x_sam_2, &wid}, {u3x_sam_3, &dat})) ||
          (c3n == u3ud(wid)) ||
          (c3n == u3ud(dat)) )
     {

--- a/pkg/noun/jets/e/shax.c
+++ b/pkg/noun/jets/e/shax.c
@@ -186,7 +186,7 @@
   {
     u3_noun a, b;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &b, u3x_con_sam, &a, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam, &b}, {u3x_con_sam, &a}) ) {
       return u3m_bail(c3__exit);
     } else {
       return u3qeo_raw(a, b);

--- a/pkg/noun/jets/e/slaw.c
+++ b/pkg/noun/jets/e/slaw.c
@@ -451,8 +451,8 @@ u3we_slaw(u3_noun cor)
   u3_noun mod;
   u3_noun txt;
 
-  if (c3n == u3r_mean(cor, u3x_sam_2, &mod,
-                      u3x_sam_3, &txt, u3_nul)) {
+  if (c3n == u3r_mean(cor, {u3x_sam_2, &mod},
+                      {u3x_sam_3, &txt})) {
     return u3m_bail(c3__exit);
   }
 

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -1911,19 +1911,18 @@ _get_state(u3_noun hint, u3_noun seed, lia_state* sat_u)
     u3_noun susp_list;
 
     if ( c3n == u3r_mean(get,
-        (c3_w)2,   &yil_previous,
-        (c3_w)6,   &queue,
-        (c3_w)56,  &p_box_buffer,
-        (c3_w)57,  &q_box_buffer,
-        (c3_w)29,  &pad_box,
-        (c3_w)120, &p_mem_buffer,
-        (c3_w)121, &q_mem_buffer,
-        (c3_w)61,  &stack_offset,
-        (c3_w)62,  &runtime_offset,
-        (c3_w)126, &lia_shop,
-        (c3_w)254, &acc,
-        (c3_w)255, &susp_list,
-        u3_nul)
+        {2,   &yil_previous},
+        {6,   &queue},
+        {56,  &p_box_buffer},
+        {57,  &q_box_buffer},
+        {29,  &pad_box},
+        {120, &p_mem_buffer},
+        {121, &q_mem_buffer},
+        {61,  &stack_offset},
+        {62,  &runtime_offset},
+        {126, &lia_shop},
+        {254, &acc},
+        {255, &susp_list})
     )
     {
       return u3m_bail(c3__fail);

--- a/pkg/noun/jets/f/cell.c
+++ b/pkg/noun/jets/f/cell.c
@@ -21,7 +21,7 @@
   {
     u3_noun hed, tal;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &hed, u3x_sam_3, &tal, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &hed}, {u3x_sam_3, &tal}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_cell(hed, tal);

--- a/pkg/noun/jets/f/comb.c
+++ b/pkg/noun/jets/f/comb.c
@@ -62,7 +62,7 @@
   {
     u3_noun mal, buz;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &mal, u3x_sam_3, &buz, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &mal}, {u3x_sam_3, &buz}) ) {
       return u3_none;
     } else {
       return u3qf_comb(mal, buz);

--- a/pkg/noun/jets/f/cons.c
+++ b/pkg/noun/jets/f/cons.c
@@ -46,7 +46,7 @@
   {
     u3_noun vur, sed;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &vur, u3x_sam_3, &sed, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &vur}, {u3x_sam_3, &sed}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_cons(vur, sed);

--- a/pkg/noun/jets/f/core.c
+++ b/pkg/noun/jets/f/core.c
@@ -34,7 +34,7 @@
   {
     u3_noun pac, con;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &pac, u3x_sam_3, &con, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &pac}, {u3x_sam_3, &con}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_core(pac, con);

--- a/pkg/noun/jets/f/face.c
+++ b/pkg/noun/jets/f/face.c
@@ -22,7 +22,7 @@
   {
     u3_noun sag, tip;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &sag, u3x_sam_3, &tip, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &sag}, {u3x_sam_3, &tip}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_face(sag, tip);

--- a/pkg/noun/jets/f/fine.c
+++ b/pkg/noun/jets/f/fine.c
@@ -25,9 +25,9 @@
   {
     u3_noun fuv, lup, mar;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &fuv,
-                              u3x_sam_6, &lup,
-                              u3x_sam_7, &mar, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &fuv},
+                              {u3x_sam_6, &lup},
+                              {u3x_sam_7, &mar}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_fine(fuv, lup, mar);

--- a/pkg/noun/jets/f/fitz.c
+++ b/pkg/noun/jets/f/fitz.c
@@ -64,7 +64,7 @@ u3wf_fitz(u3_noun cor)
 {
   u3_noun yaz, wix;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam_2, &yaz, u3x_sam_3, &wix, u3_nul)) ||
+  if ( (c3n == u3r_mean(cor, {u3x_sam_2, &yaz}, {u3x_sam_3, &wix})) ||
        (c3n == u3ud(yaz)) ||
        (c3n == u3ud(wix)) )
   {

--- a/pkg/noun/jets/f/flan.c
+++ b/pkg/noun/jets/f/flan.c
@@ -39,7 +39,7 @@
   {
     u3_noun bos, nif;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &bos, u3x_sam_3, &nif, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &bos}, {u3x_sam_3, &nif}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_flan(bos, nif);

--- a/pkg/noun/jets/f/flor.c
+++ b/pkg/noun/jets/f/flor.c
@@ -39,7 +39,7 @@
   {
     u3_noun bos, nif;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &bos, u3x_sam_3, &nif, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &bos}, {u3x_sam_3, &nif}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_flor(bos, nif);

--- a/pkg/noun/jets/f/fork.c
+++ b/pkg/noun/jets/f/fork.c
@@ -62,7 +62,7 @@
   {
     u3_noun yed;
 
-    if ( c3n == u3r_mean(cor, u3x_sam, &yed, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam, &yed}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_fork(yed);

--- a/pkg/noun/jets/f/help.c
+++ b/pkg/noun/jets/f/help.c
@@ -22,7 +22,7 @@
   {
     u3_noun sag, tip;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &sag, u3x_sam_3, &tip, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &sag}, {u3x_sam_3, &tip}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_help(sag, tip);

--- a/pkg/noun/jets/f/hint.c
+++ b/pkg/noun/jets/f/hint.c
@@ -23,7 +23,7 @@
   {
     u3_noun sag, tip;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &sag, u3x_sam_3, &tip, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &sag}, {u3x_sam_3, &tip}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_hint(sag, tip);

--- a/pkg/noun/jets/f/look.c
+++ b/pkg/noun/jets/f/look.c
@@ -126,7 +126,7 @@
   {
     u3_noun cog, dab;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &cog, u3x_sam_3, &dab, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &cog}, {u3x_sam_3, &dab}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_look(cog, dab);

--- a/pkg/noun/jets/f/loot.c
+++ b/pkg/noun/jets/f/loot.c
@@ -125,7 +125,7 @@
   {
     u3_noun cog, dom;
 
-    if ( c3n == u3r_mean(cor, u3x_sam_2, &cog, u3x_sam_3, &dom, u3_nul) ) {
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &cog}, {u3x_sam_3, &dom}) ) {
       return u3m_bail(c3__fail);
     } else {
       return u3qf_loot(cog, dom);

--- a/pkg/noun/jets/f/ut_crop.c
+++ b/pkg/noun/jets/f/ut_crop.c
@@ -10,7 +10,7 @@ u3wfu_crop(u3_noun cor)
 {
   u3_noun bat, sut, ref, van;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam, &ref}, {u3x_con, &van}))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {

--- a/pkg/noun/jets/f/ut_fish.c
+++ b/pkg/noun/jets/f/ut_fish.c
@@ -10,7 +10,7 @@ u3wfu_fish(u3_noun cor)
 {
   u3_noun bat, sut, axe, van;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam, &axe, u3x_con, &van, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam, &axe}, {u3x_con, &van}))
      || (c3n == u3ud(axe))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )

--- a/pkg/noun/jets/f/ut_fuse.c
+++ b/pkg/noun/jets/f/ut_fuse.c
@@ -10,7 +10,7 @@ u3wfu_fuse(u3_noun cor)
 {
   u3_noun bat, sut, ref, van;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam, &ref}, {u3x_con, &van}))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {

--- a/pkg/noun/jets/f/ut_mint.c
+++ b/pkg/noun/jets/f/ut_mint.c
@@ -10,9 +10,9 @@ u3wfu_mint(u3_noun cor)
 {
   u3_noun bat, sut, gol, gen, van;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &gol,
-                              u3x_sam_3, &gen,
-                              u3x_con, &van, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &gol},
+                              {u3x_sam_3, &gen},
+                              {u3x_con, &van}))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {

--- a/pkg/noun/jets/f/ut_mull.c
+++ b/pkg/noun/jets/f/ut_mull.c
@@ -10,10 +10,10 @@ u3wfu_mull(u3_noun cor)
 {
   u3_noun bat, sut, gol, dox, gen, van;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam_2, &gol,
-                              u3x_sam_6, &dox,
-                              u3x_sam_7, &gen,
-                              u3x_con, &van, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam_2, &gol},
+                              {u3x_sam_6, &dox},
+                              {u3x_sam_7, &gen},
+                              {u3x_con, &van}))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {

--- a/pkg/noun/jets/f/ut_nest.c
+++ b/pkg/noun/jets/f/ut_nest.c
@@ -12,12 +12,12 @@ u3wfu_nest_dext(u3_noun dext_core)
   u3_noun bat, sut, ref, van, seg, reg, gil;
 
   if (  (u3_none == (nest_in_core = u3r_at(3, dext_core)))
-     || (c3n == u3r_mean(nest_in_core, u3x_sam_2, &seg,
-                                       u3x_sam_6, &reg,
-                                       u3x_sam_7, &gil,
-                                       u3x_con, &nest_core, u3_nul))
-     || (c3n == u3r_mean(nest_core, u3x_sam_3, &ref,
-                                    u3x_con, &van, u3_nul))
+     || (c3n == u3r_mean(nest_in_core, {u3x_sam_2, &seg},
+                                       {u3x_sam_6, &reg},
+                                       {u3x_sam_7, &gil},
+                                       {u3x_con, &nest_core}))
+     || (c3n == u3r_mean(nest_core, {u3x_sam_3, &ref},
+                                    {u3x_con, &van}))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {

--- a/pkg/noun/jets/f/ut_redo.c
+++ b/pkg/noun/jets/f/ut_redo.c
@@ -10,7 +10,7 @@ u3wfu_redo(u3_noun cor)
 {
   u3_noun bat, sut, ref, van;
 
-  if (  (c3n == u3r_mean(cor, u3x_sam, &ref, u3x_con, &van, u3_nul))
+  if (  (c3n == u3r_mean(cor, {u3x_sam, &ref}, {u3x_con, &van}))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {

--- a/pkg/noun/jets/f/ut_rest.c
+++ b/pkg/noun/jets/f/ut_rest.c
@@ -10,7 +10,7 @@ u3wfu_rest(u3_noun cor)
 {
   u3_noun bat, sut, leg, van;
 
-  if ( (c3n == u3r_mean(cor, u3x_sam, &leg, u3x_con, &van, u3_nul))
+  if ( (c3n == u3r_mean(cor, {u3x_sam, &leg}, {u3x_con, &van}))
      || (u3_none == (bat = u3r_at(u3x_bat, van)))
      || (u3_none == (sut = u3r_at(u3x_sam, van))) )
   {

--- a/pkg/noun/jets/i/lagoon.c
+++ b/pkg/noun/jets/i/lagoon.c
@@ -2151,11 +2151,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2198,11 +2197,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2245,11 +2243,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2292,11 +2289,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2339,11 +2335,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2385,9 +2380,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -2427,9 +2421,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -2465,9 +2458,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -2503,9 +2495,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -2541,9 +2532,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -2580,9 +2570,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -2619,9 +2608,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -2658,11 +2646,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2700,11 +2687,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2742,11 +2728,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2784,11 +2769,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -2825,10 +2809,9 @@
     u3_noun x_meta, x_data, n;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_3, &n,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_3, &n}) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(n) )
     {
@@ -2861,10 +2844,9 @@
     u3_noun x_meta, x_data, n;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_3, &n,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_3, &n}) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(n) )
     {
@@ -2897,10 +2879,9 @@
     u3_noun x_meta, x_data, n;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_3, &n,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_3, &n}) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(n) )
     {
@@ -2933,10 +2914,9 @@
     u3_noun x_meta, x_data, n;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_3, &n,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_3, &n}) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(n) )
     {
@@ -2969,10 +2949,9 @@
     u3_noun x_meta, x_data, n;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_3, &n,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_3, &n}) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(n) )
     {
@@ -3006,11 +2985,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3r_sing(x_meta, y_meta) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
@@ -3052,9 +3030,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -3084,11 +3061,10 @@
     u3_noun x_meta, a, b, n, rnd;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_12, &a,
-                         u3x_sam_13, &b,
-                         u3x_sam_7, &n,
-                         u3_nul))
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_12, &a},
+                         {u3x_sam_13, &b},
+                         {u3x_sam_7, &n}))
     {
       return u3m_bail(c3__exit);
     } else {
@@ -3127,11 +3103,10 @@
     u3_noun x_meta, a, b, d, rnd;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_12, &a,
-                         u3x_sam_13, &b,
-                         u3x_sam_7, &d,
-                         u3_nul))
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_12, &a},
+                         {u3x_sam_13, &b},
+                         {u3x_sam_7, &d}))
     {
       return u3m_bail(c3__exit);
     } else {
@@ -3203,9 +3178,8 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
@@ -3237,20 +3211,18 @@
     u3_noun x_meta, x_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_2, &x_meta,
-                         u3x_sam_3, &x_data,
-                         u3_nul) ||
+                         {u3x_sam_2, &x_meta},
+                         {u3x_sam_3, &x_data}) ||
          c3n == u3ud(x_data) )
     {
       return u3m_bail(c3__exit);
     } else {
       u3_noun x_shape, x_bloq, x_kind, x_tail;
       if ( c3n == u3r_mean(x_meta,
-                            (c3_w)2, &x_shape,
-                            (c3_w)6, &x_bloq,
-                           (c3_w)14, &x_kind,
-                           (c3_w)15, &x_tail,
-                            u3_nul)
+                            {2, &x_shape},
+                            {6, &x_bloq},
+                           {14, &x_kind},
+                           {15, &x_tail})
          )
       {
         return u3m_bail(c3__exit);
@@ -3276,11 +3248,10 @@
             y_meta, y_data;
 
     if ( c3n == u3r_mean(cor,
-                         u3x_sam_4, &x_meta,
-                         u3x_sam_5, &x_data,
-                         u3x_sam_6, &y_meta,
-                         u3x_sam_7, &y_data,
-                         u3_nul) ||
+                         {u3x_sam_4, &x_meta},
+                         {u3x_sam_5, &x_data},
+                         {u3x_sam_6, &y_meta},
+                         {u3x_sam_7, &y_data}) ||
          c3n == u3ud(x_data) ||
          c3n == u3ud(y_data) )
     {

--- a/pkg/noun/jets_tests.c
+++ b/pkg/noun/jets_tests.c
@@ -987,7 +987,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "test jets: ok\r\n");
   return 0;

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1503,7 +1503,7 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
         u3a_print_memory(stderr, "execute: top", u3R->all.max_w);
       }
 #endif
-      u3m_grab(pro, u3_none);
+      u3m_grab(pro);
     }
 
     /* Revert to external signal regime.
@@ -1622,7 +1622,7 @@ u3m_soft_cax(u3_funq fun_f,
     */
 #ifdef U3_MEMORY_DEBUG
     if ( u3C.wag_h & u3o_debug_ram ) {
-      u3m_grab(pro, u3_none);
+      u3m_grab(pro);
     }
 #endif
 
@@ -1730,7 +1730,7 @@ u3m_soft_run(u3_noun gul,
     */
 #ifdef U3_MEMORY_DEBUG
     if ( u3C.wag_h & u3o_debug_ram ) {
-      u3m_grab(pro, u3_none);
+      u3m_grab(pro);
     }
 #endif
 
@@ -2663,7 +2663,7 @@ u3m_boot(c3_c* dir_c, size_t len_i)
   */
   if ( (c3n == nuu_o) && (u3C.wag_h & u3o_check_corrupt) ) {
     u3l_log("boot: gc requested");
-    u3m_grab(u3_none);
+    u3m_grab();
     u3C.wag_h &= ~u3o_check_corrupt;
     u3l_log("boot: gc complete");
   }

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1867,30 +1867,19 @@ u3m_mark_mute(void)
   c3_free(arr_u);
 }
 
-/* u3m_grab(): garbage-collect the world, plus extra roots.
+/* u3m_vgrab(): garbage-collect the world, plus extra roots.
 */
 void
-u3m_grab(u3_noun som, ...)   // terminate with u3_none
+u3m_vgrab(u3_noun* som, c3_z len_z)
 {
   // u3h_free(u3R->cax.har_p);
   // u3R->cax.har_p = u3h_new();
 
   u3a_mark_init();
-  {
-    va_list vap;
-    u3_noun tur;
-
-    va_start(vap, som);
-
-    if ( som != u3_none ) {
-      u3a_mark_noun(som);
-
-      while ( u3_none != (tur = va_arg(vap, u3_noun)) ) {
-        u3a_mark_noun(tur);
-      }
-    }
-    va_end(vap);
+  for (c3_z i_z = 0; i_z < len_z; i_z++) {
+    u3a_mark_noun(som[i_z]);
   }
+
   u3m_mark_mute();
   u3a_sweep();
 }

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -174,9 +174,10 @@
         void
         u3m_vgrab(u3_noun* som, c3_z len_z);
 
-        #define u3m_grab(...) u3m_vgrab((u3_noun[]){__VA_ARGS__},   \
-            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof(u3_noun) )  \
-          )
+#       define u3m_grab(...) ({                               \
+          u3_noun _args[] = {__VA_ARGS__};                    \
+          u3m_vgrab(_args, sizeof(_args) / sizeof(u3_noun));  \
+          })
 
       /* u3m_water(): produce high and low watermarks.  Asserts u3R == u3H.
       */

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -172,7 +172,11 @@
       /* u3m_grab(): garbage-collect the world, plus extra roots.
       */
         void
-        u3m_grab(u3_noun som, ...);   // terminate with u3_none
+        u3m_vgrab(u3_noun* som, c3_z len_z);
+
+        #define u3m_grab(...) u3m_vgrab((u3_noun[]){__VA_ARGS__},                       \
+            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof((u3_noun[]){__VA_ARGS__}[0]) )  \
+          )
 
       /* u3m_water(): produce high and low watermarks.  Asserts u3R == u3H.
       */

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -174,8 +174,8 @@
         void
         u3m_vgrab(u3_noun* som, c3_z len_z);
 
-        #define u3m_grab(...) u3m_vgrab((u3_noun[]){__VA_ARGS__},                       \
-            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof((u3_noun[]){__VA_ARGS__}[0]) )  \
+        #define u3m_grab(...) u3m_vgrab((u3_noun[]){__VA_ARGS__},   \
+            ( sizeof((u3_noun[]){__VA_ARGS__}) / sizeof(u3_noun) )  \
           )
 
       /* u3m_water(): produce high and low watermarks.  Asserts u3R == u3H.

--- a/pkg/noun/nock_tests.c
+++ b/pkg/noun/nock_tests.c
@@ -76,7 +76,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "test meme: ok\r\n");
   return 0;

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -147,8 +147,8 @@ u3r_at(u3_atom a, u3_noun b)
 **   Axes must be sorted in tree order.
 */
   static c3_w
-  _mean_cut(c3_w       len_w,
-            mean_pair* prs_m)
+  _mean_cut(c3_w           len_w,
+            u3r_mean_pair* prs_m)
   {
     c3_w i_w, cut_t, cut_w;
 
@@ -167,9 +167,9 @@ u3r_at(u3_atom a, u3_noun b)
   }
 
   static c3_o
-  _mean_extract(u3_noun    som,
-                c3_w       len_w,
-                mean_pair* prs_m)
+  _mean_extract(u3_noun        som,
+                c3_w           len_w,
+                u3r_mean_pair* prs_m)
   {
     if ( len_w == 0 ) {
       return c3y;
@@ -192,7 +192,7 @@ u3r_at(u3_atom a, u3_noun b)
   }
 
 c3_o
-u3r_vmean(u3_noun a, mean_pair pairs[], c3_z len_z)
+u3r_vmean(u3_noun a, u3r_mean_pair pairs[], c3_z len_z)
 {
   u3_assert(len_z < c3_w_max);
   return _mean_extract(a, (c3_w)len_z, pairs);

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -146,14 +146,9 @@ u3r_at(u3_atom a, u3_noun b)
 **   Attempt to deconstruct `a` by axis, noun pairs; 0 terminates.
 **   Axes must be sorted in tree order.
 */
-  struct _mean_pair {
-    c3_w    axe_w;
-    u3_noun* som;
-  };
-
   static c3_w
   _mean_cut(c3_w               len_w,
-            struct _mean_pair* prs_m)
+            mean_pair* prs_m)
   {
     c3_w i_w, cut_t, cut_w;
 
@@ -174,7 +169,7 @@ u3r_at(u3_atom a, u3_noun b)
   static c3_o
   _mean_extract(u3_noun            som,
                 c3_w               len_w,
-                struct _mean_pair* prs_m)
+                mean_pair* prs_m)
   {
     if ( len_w == 0 ) {
       return c3y;
@@ -197,61 +192,10 @@ u3r_at(u3_atom a, u3_noun b)
   }
 
 c3_o
-u3r_vmean(u3_noun som, va_list ap)
+u3r_vmean(u3_noun a, mean_pair pairs[], c3_z len_z)
 {
-  va_list            aq;
-  c3_w               len_w;
-  struct _mean_pair* prs_m;
-
-  u3_assert(u3_none != som);
-
-  //  traverse copy of va_list for alloca
-  //
-  va_copy(aq, ap);
-  len_w = 0;
-
-  while ( 1 ) {
-    if ( 0 == va_arg(aq, c3_w) ) {
-      break;
-    }
-    va_arg(aq, u3_noun*);
-    len_w++;
-  }
-
-  va_end(aq);
-
-  u3_assert( 0 != len_w );
-  prs_m = alloca(len_w * sizeof(struct _mean_pair));
-
-  //  traverse va_list and extract args
-  //
-  {
-    c3_w i_w;
-
-    for ( i_w = 0; i_w < len_w; i_w++ ) {
-      prs_m[i_w].axe_w = va_arg(ap, c3_w);
-      prs_m[i_w].som = va_arg(ap, u3_noun*);
-    }
-
-    va_end(ap);
-  }
-
-  //  extract axis from som
-  //
-  return _mean_extract(som, len_w, prs_m);
-}
-
-c3_o
-u3r_mean(u3_noun som, ...)
-{
-  c3_o    ret_o;
-  va_list ap;
-
-  va_start(ap, som);
-  ret_o = u3r_vmean(som, ap);
-  va_end(ap);
-
-  return ret_o;
+  u3_assert(len_z < UINT32_MAX);
+  return _mean_extract(a, (c3_w)len_z, pairs);
 }
 
 //  stack frame for tracking noun comparison and unification

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -143,7 +143,7 @@ u3r_at(u3_atom a, u3_noun b)
 
 /* u3r_mean():
 **
-**   Attempt to deconstruct `a` by axis, noun pairs; 0 terminates.
+**   Attempt to deconstruct `a` by axis, noun pairs.
 **   Axes must be sorted in tree order.
 */
   static c3_w

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -147,7 +147,7 @@ u3r_at(u3_atom a, u3_noun b)
 **   Axes must be sorted in tree order.
 */
   static c3_w
-  _mean_cut(c3_w               len_w,
+  _mean_cut(c3_w       len_w,
             mean_pair* prs_m)
   {
     c3_w i_w, cut_t, cut_w;
@@ -167,8 +167,8 @@ u3r_at(u3_atom a, u3_noun b)
   }
 
   static c3_o
-  _mean_extract(u3_noun            som,
-                c3_w               len_w,
+  _mean_extract(u3_noun    som,
+                c3_w       len_w,
                 mean_pair* prs_m)
   {
     if ( len_w == 0 ) {
@@ -194,7 +194,7 @@ u3r_at(u3_atom a, u3_noun b)
 c3_o
 u3r_vmean(u3_noun a, mean_pair pairs[], c3_z len_z)
 {
-  u3_assert(len_z < UINT32_MAX);
+  u3_assert(len_z < c3_w_max);
   return _mean_extract(a, (c3_w)len_z, pairs);
 }
 

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -115,14 +115,14 @@
       **   Attempt to deconstruct `a` by axis, noun pairs; 0 terminates.
       **   Axes must be sorted in tree order.
       */
-        typedef struct {c3_w axe_w; u3_noun* som;} mean_pair;
+        typedef struct {c3_w axe_w; u3_noun* som;} u3r_mean_pair;
 
         c3_o
-        u3r_vmean(u3_noun a, mean_pair pairs[], c3_z len_z);
+        u3r_vmean(u3_noun a, u3r_mean_pair pairs[], c3_z len_z);
 
-        #define u3r_mean(a, ...) u3r_vmean(a,                           \
-            (mean_pair[]){__VA_ARGS__},                                 \
-            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof(mean_pair) )  \
+        #define u3r_mean(a, ...) u3r_vmean(a,                                   \
+            (u3r_mean_pair[]){__VA_ARGS__},                                     \
+            ( sizeof((u3r_mean_pair[]){__VA_ARGS__}) / sizeof(u3r_mean_pair) )  \
           )
 
       /* u3r_mug_both(): Join two mugs.

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -115,10 +115,15 @@
       **   Attempt to deconstruct `a` by axis, noun pairs; 0 terminates.
       **   Axes must be sorted in tree order.
       */
+        typedef struct {c3_w axe_w; u3_noun* som;} mean_pair;
+
         c3_o
-        u3r_vmean(u3_noun a, va_list ap);
-        c3_o
-        u3r_mean(u3_noun a, ...);
+        u3r_vmean(u3_noun a, mean_pair pairs[], c3_z len_z);
+
+        #define u3r_mean(a, ...) u3r_vmean(a,                                               \
+            (mean_pair[]){__VA_ARGS__},                                                     \
+            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof((mean_pair[]){__VA_ARGS__}[0]) )  \
+          )
 
       /* u3r_mug_both(): Join two mugs.
       */

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -120,10 +120,10 @@
         c3_o
         u3r_vmean(u3_noun a, u3r_mean_pair pairs[], c3_z len_z);
 
-        #define u3r_mean(a, ...) u3r_vmean(a,                                   \
-            (u3r_mean_pair[]){__VA_ARGS__},                                     \
-            ( sizeof((u3r_mean_pair[]){__VA_ARGS__}) / sizeof(u3r_mean_pair) )  \
-          )
+#       define u3r_mean(a, ...) ({                                      \
+          u3r_mean_pair _pairs[] = {__VA_ARGS__};                       \
+          u3r_vmean(a, _pairs, sizeof(_pairs) / sizeof(u3r_mean_pair)); \
+        })
 
       /* u3r_mug_both(): Join two mugs.
       */

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -120,9 +120,9 @@
         c3_o
         u3r_vmean(u3_noun a, mean_pair pairs[], c3_z len_z);
 
-        #define u3r_mean(a, ...) u3r_vmean(a,                                               \
-            (mean_pair[]){__VA_ARGS__},                                                     \
-            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof((mean_pair[]){__VA_ARGS__}[0]) )  \
+        #define u3r_mean(a, ...) u3r_vmean(a,                           \
+            (mean_pair[]){__VA_ARGS__},                                 \
+            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof(mean_pair) )  \
           )
 
       /* u3r_mug_both(): Join two mugs.

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -112,7 +112,7 @@
 
       /* u3r_mean():
       **
-      **   Attempt to deconstruct `a` by axis, noun pairs; 0 terminates.
+      **   Attempt to deconstruct `a` by axis, noun pairs.
       **   Axes must be sorted in tree order.
       */
         typedef struct {c3_w axe_w; u3_noun* som;} u3r_mean_pair;

--- a/pkg/noun/retrieve_tests.c
+++ b/pkg/noun/retrieve_tests.c
@@ -1152,7 +1152,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "retrieve_tests: ok\n");
 

--- a/pkg/noun/serial_tests.c
+++ b/pkg/noun/serial_tests.c
@@ -257,7 +257,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "test jam: ok\r\n");
   return 0;

--- a/pkg/noun/urth.c
+++ b/pkg/noun/urth.c
@@ -419,7 +419,7 @@ _cu_realloc(FILE* fil_u, ur_root_t** tor_u, ur_nvec_t* doc_u)
   //
   c3_h wag_h = u3C.wag_h;
   u3C.wag_h |= u3o_debug_ram;
-  u3m_grab(u3_none);
+  u3m_grab();
   u3C.wag_h  = wag_h;
 
   //  re-establish warm jet state

--- a/pkg/noun/xtract.c
+++ b/pkg/noun/xtract.c
@@ -18,16 +18,9 @@ u3x_loob(u3_noun a);
 **   Axes must be sorted in tree order.
 */
 void
-u3x_mean(u3_noun som, ...)
+u3x_vmean(u3_noun a, mean_pair pairs[], c3_z len_z)
 {
-  c3_o    ret_o;
-  va_list ap;
-
-  va_start(ap, som);
-  ret_o = u3r_vmean(som, ap);
-  va_end(ap);
-
-  if ( c3n == ret_o ) {
+  if ( c3n == u3r_vmean(a, pairs, len_z) ) {
     u3m_bail(c3__exit);
   }
 }

--- a/pkg/noun/xtract.c
+++ b/pkg/noun/xtract.c
@@ -14,7 +14,7 @@ u3x_loob(u3_noun a);
 
 /* u3x_mean():
 **
-**   Attempt to deconstruct `a` by axis, noun pairs; 0 terminates.
+**   Attempt to deconstruct `a` by axis, noun pairs.
 **   Axes must be sorted in tree order.
 */
 void

--- a/pkg/noun/xtract.c
+++ b/pkg/noun/xtract.c
@@ -18,7 +18,7 @@ u3x_loob(u3_noun a);
 **   Axes must be sorted in tree order.
 */
 void
-u3x_vmean(u3_noun a, mean_pair pairs[], c3_z len_z)
+u3x_vmean(u3_noun a, u3r_mean_pair pairs[], c3_z len_z)
 {
   if ( c3n == u3r_vmean(a, pairs, len_z) ) {
     u3m_bail(c3__exit);

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "allocate.h"
 #include "manage.h"
+#include "retrieve.h"
 
   /**  Constants.
   **/
@@ -157,6 +158,11 @@
       **   Axes must be sorted in tree order.
       */
         void
-        u3x_mean(u3_noun a, ...);
+        u3x_vmean(u3_noun a, mean_pair pairs[], c3_z len_z);
+
+        #define u3x_mean(a, ...) u3x_vmean(a,                                               \
+            (mean_pair[]){__VA_ARGS__},                                                     \
+            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof((mean_pair[]){__VA_ARGS__}[0]) )  \
+          )
 
 #endif /* ifndef U3_XTRACT_H */

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -158,11 +158,11 @@
       **   Axes must be sorted in tree order.
       */
         void
-        u3x_vmean(u3_noun a, mean_pair pairs[], c3_z len_z);
+        u3x_vmean(u3_noun a, u3r_mean_pair pairs[], c3_z len_z);
 
-        #define u3x_mean(a, ...) u3x_vmean(a,                           \
-            (mean_pair[]){__VA_ARGS__},                                 \
-            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof(mean_pair) )  \
+        #define u3x_mean(a, ...) u3x_vmean(a,                                   \
+            (u3r_mean_pair[]){__VA_ARGS__},                                     \
+            ( sizeof((u3r_mean_pair[]){__VA_ARGS__}) / sizeof(u3r_mean_pair) )  \
           )
 
 #endif /* ifndef U3_XTRACT_H */

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -160,9 +160,9 @@
         void
         u3x_vmean(u3_noun a, u3r_mean_pair pairs[], c3_z len_z);
 
-        #define u3x_mean(a, ...) u3x_vmean(a,                                   \
-            (u3r_mean_pair[]){__VA_ARGS__},                                     \
-            ( sizeof((u3r_mean_pair[]){__VA_ARGS__}) / sizeof(u3r_mean_pair) )  \
-          )
+#       define u3x_mean(a, ...) ({                                      \
+          u3r_mean_pair _pairs[] = {__VA_ARGS__};                       \
+          u3x_vmean(a, _pairs, sizeof(_pairs) / sizeof(u3r_mean_pair)); \
+        })
 
 #endif /* ifndef U3_XTRACT_H */

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -154,7 +154,7 @@
 
       /* u3x_mean():
       **
-      **   Attempt to deconstruct `a` by axis, noun pairs; 0 terminates.
+      **   Attempt to deconstruct `a` by axis, noun pairs.
       **   Axes must be sorted in tree order.
       */
         void

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -160,9 +160,9 @@
         void
         u3x_vmean(u3_noun a, mean_pair pairs[], c3_z len_z);
 
-        #define u3x_mean(a, ...) u3x_vmean(a,                                               \
-            (mean_pair[]){__VA_ARGS__},                                                     \
-            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof((mean_pair[]){__VA_ARGS__}[0]) )  \
+        #define u3x_mean(a, ...) u3x_vmean(a,                           \
+            (mean_pair[]){__VA_ARGS__},                                 \
+            ( sizeof((mean_pair[]){__VA_ARGS__}) / sizeof(mean_pair) )  \
           )
 
 #endif /* ifndef U3_XTRACT_H */

--- a/pkg/vere/ames_tests.c
+++ b/pkg/vere/ames_tests.c
@@ -95,7 +95,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "ames okeedokee\n");
   return 0;

--- a/pkg/vere/benchmarks.c
+++ b/pkg/vere/benchmarks.c
@@ -459,7 +459,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   return 0;
 }

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -869,8 +869,7 @@ u3_disk_info(u3_disk* log_u)
 {
   u3_noun lit = u3i_list(
     u3_pier_mase("live",        log_u->liv_o),
-    u3_pier_mase("event", u3i_chub(log_u->dun_d)),
-    u3_none);
+    u3_pier_mase("event", u3i_chub(log_u->dun_d)));
 
   //  XX revise, include batches
   //
@@ -880,8 +879,7 @@ u3_disk_info(u3_disk* log_u)
         c3__save,
         u3i_list(
           u3_pier_mase("save-start", u3i_chub(log_u->put_u.ext_u->eve_d)),
-          u3_pier_mase("save-final", u3i_chub(log_u->put_u.ent_u->eve_d)),
-          u3_none)),
+          u3_pier_mase("save-final", u3i_chub(log_u->put_u.ent_u->eve_d)))),
       lit);
   }
 

--- a/pkg/vere/hamt_test.c
+++ b/pkg/vere/hamt_test.c
@@ -129,7 +129,7 @@ main(int argc, char* argv[])
 
   u3h_free(pit_p);
 
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "test unix: ok\r\n");
   return 0;

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2821,8 +2821,7 @@ _ames_io_info(u3_auto* car_u)
     u3_pier_mase("crashed",          u3i_chub(sam_u->sat_u.fal_d)),
     u3_pier_mase("evil",             u3i_chub(sam_u->sat_u.vil_d)),
     u3_pier_mase("lane-scry-fails",  u3i_chub(sam_u->sat_u.saw_d)),
-    u3_pier_mase("cached-lanes",     u3i_half(u3h_wyt(sam_u->lax_p))),
-    u3_none);
+    u3_pier_mase("cached-lanes",     u3i_half(u3h_wyt(sam_u->lax_p))));
 }
 
 /* _ames_io_slog(): print status info.

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -517,8 +517,7 @@ _conn_read_peel(u3_conn* con_u, u3_noun dat)
                    u3nc(c3__quic, u3_nul),
                    u3nc(c3__port,
                         u3i_list((u3_noun)c3__ames, (u3_noun)c3__htls, (u3_noun)c3__http, u3_none)),
-                   u3nc(c3__v, u3_nul), u3nc(c3__who, u3_nul),
-                   u3_none));
+                   u3nc(c3__v, u3_nul), u3nc(c3__who, u3_nul)));
       } break;
       //  simple health check.
       //

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -516,7 +516,7 @@ _conn_read_peel(u3_conn* con_u, u3_noun dat)
                    u3nc(c3__mass, u3_nul),
                    u3nc(c3__quic, u3_nul),
                    u3nc(c3__port,
-                        u3i_list((u3_noun)c3__ames, (u3_noun)c3__htls, (u3_noun)c3__http, u3_none)),
+                        u3i_list(c3__ames, c3__htls, c3__http)),
                    u3nc(c3__v, u3_nul), u3nc(c3__who, u3_nul)));
       } break;
       //  simple health check.

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1610,8 +1610,7 @@ _http_spin_accept(h2o_handler_t* han_u, h2o_req_t* rec_u)
                           u3nc(u3i_string("Cache-Control"),
                                u3i_string("no-cache")),
                           u3nc(u3i_string("Connection"),
-                               u3i_string("keep-alive")),
-                          u3_none);
+                               u3i_string("keep-alive")));
 
     _http_start_respond(req_u, 200, hed, u3_nul, c3n);
 
@@ -1646,8 +1645,7 @@ _http_seq_accept(h2o_handler_t* han_u, h2o_req_t* rec_u)
                           u3nc(u3i_string("Cache-Control"),
                                u3i_string("no-cache")),
                           u3nc(u3i_string("Connection"),
-                               u3i_string("keep-alive")),
-                          u3_none);
+                               u3i_string("keep-alive")));
 
     _http_start_respond(req_u, 200, hed, u3_nul, c3n);
 
@@ -2831,8 +2829,7 @@ _http_stream_slog(void* vop_p, c3_w pri_w, u3_noun tan)
     if ( c3y == u3a_is_atom(tan) ) {
       u3_noun lin = u3i_list(u3i_string("data:"),
                              u3k(tan),
-                             (u3_noun)c3_s2('\n', '\n'),
-                             u3_none);
+                             c3_s2('\n', '\n'));
       u3_atom txt = u3qc_rap(3, lin);
       data = u3nt(u3_nul, u3r_met(3, txt), txt);
       u3z(lin);
@@ -2861,8 +2858,7 @@ _http_stream_slog(void* vop_p, c3_w pri_w, u3_noun tan)
         while ( u3_nul != low ) {
           u3_noun lin = u3i_list(u3i_string("data:"),
                                  u3qc_rap(3, u3h(low)),
-                                 (u3_noun)c3_s2('\n', '\n'),
-                                 u3_none);
+                                 c3_s2('\n', '\n'));
           paz = u3kb_weld(paz, lin);
           low = u3t(low);
         }
@@ -2933,8 +2929,7 @@ _http_spin_timer_cb(uv_timer_t* tim_u)
       u3_noun tan = u3i_string(buf_c);
       u3_noun lin = u3i_list(u3i_string("data:"),
                              tan,
-                             (u3_noun)c3_s2('\n', '\n'),
-                             u3_none);
+                             c3_s2('\n', '\n'));
       u3_atom txt = u3qc_rap(3, lin);
       u3_noun dat = u3nt(u3_nul, u3r_met(3, txt), txt);
 
@@ -3135,8 +3130,7 @@ _http_io_info(u3_auto* car_u)
   }
   res = u3i_list(
     u3_pier_mase("instance", htd_u->sev_l),
-    u3_pier_mase("open-slogstreams", u3i_word(sec_w)),
-    u3_none);
+    u3_pier_mase("open-slogstreams", u3i_word(sec_w)));
 
   while ( 0 != htp_u ) {
     res = u3nc(
@@ -3147,8 +3141,7 @@ _http_io_info(u3_auto* car_u)
           u3_pier_mase("loopback",    htp_u->lop),
           u3_pier_mase("live",        htp_u->liv),
           u3_pier_mase("port",        htp_u->por_s),
-          u3_pier_mase("connections", htp_u->coq_l),
-          u3_none)),
+          u3_pier_mase("connections", htp_u->coq_l))),
       res);
     htp_u = htp_u->nex_u;
   }

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -2133,7 +2133,7 @@ _mesa_req_pact_init(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u, u3_p
   u3_noun her = u3dc("scot", c3__p, u3_ship_to_noun(nam_u->her_u));
   u3_noun rut = u3dc("scot", c3__uv, u3i_bytes(32, root));
   u3_noun pax = _mesa_encode_path(nam_u->pat_s, (c3_y*)nam_u->pat_c);
-  u3_noun sky = u3i_list(typ, her, aut, rut, pax, u3_none);
+  u3_noun sky = u3i_list(typ, her, aut, rut, pax);
   u3_mesa_cb_data* ver_u = c3_malloc(sizeof(u3_mesa_cb_data));
   ver_u->sam_u = sam_u;
   ver_u->nam_u = req_u->pic_u->pac_u.pek_u.nam_u;

--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -1327,7 +1327,7 @@ _term_it_show_tour(u3_utty* uty_u,
   }
 
   {
-    u3_noun tub = u3i_list(u3nc(u3nt(u3_nul, u3_nul, u3_nul), lin), u3_none);
+    u3_noun tub = u3i_list(u3nc(u3nt(u3_nul, u3_nul, u3_nul), lin));
     _term_it_save_stub(uty_u, tub);
   }
 

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -936,8 +936,7 @@ u3_lord_info(u3_lord* god_u)
       u3_pier_mase("live",  god_u->liv_o),
       u3_pier_mase("event", u3i_chub(god_u->eve_d)),
       u3_pier_mase("queue", u3i_half(god_u->dep_h)),
-      u3_newt_moat_info(&god_u->out_u),
-      u3_none));
+      u3_newt_moat_info(&god_u->out_u)));
 }
 
 /* u3_lord_slog(): print status info.

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1546,8 +1546,7 @@ _mars_wyrd_card(c3_m nam_m, c3_h ver_h, c3_l sev_l)
                u3nc(c3__lull, VERE_LULL),
                u3nc(c3__arvo, VERE_ARVO),
                u3nc(c3__hoon, VERE_HOON),
-               u3nc(c3__nock, VERE_NOCK),
-               u3_none);
+               u3nc(c3__nock, VERE_NOCK));
   }
   //  XX speculative!
   //

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -119,7 +119,7 @@ _mars_grab(u3_noun sac, c3_o pri_o)
 {
   if ( u3_nul == sac) {
     if ( u3C.wag_h & (u3o_debug_ram | u3o_check_corrupt) ) {
-      u3m_grab(sac, u3_none);
+      u3m_grab(sac);
     }
     return u3_nul;
   }

--- a/pkg/vere/newt.c
+++ b/pkg/vere/newt.c
@@ -305,8 +305,7 @@ u3_newt_moat_info(u3_moat* mot_u)
   }
   return u3_pier_mass(
     c3__moat,
-    u3i_list(u3_pier_mase("pending-inbound", u3i_half(len_w)),
-             u3_none));
+    u3i_list(u3_pier_mase("pending-inbound", u3i_half(len_w))));
 }
 
 /* u3_newt_moat_slog(); print status info.

--- a/pkg/vere/newt_tests.c
+++ b/pkg/vere/newt_tests.c
@@ -567,7 +567,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "test_newt: ok\n");
 

--- a/pkg/vere/noun_tests.c
+++ b/pkg/vere/noun_tests.c
@@ -1093,7 +1093,7 @@ _test_cells()
     }
 
     a2 = 0;
-    u3r_mean(q, (c3_w)2, &a2, u3_nul);
+    u3r_mean(q, {2, &a2});
     if (a2 != a){
       printf("*** _test_cells: complicated (via u3r_list) a\n");
     }
@@ -1573,7 +1573,7 @@ _test_imprison_complex()
     u3_noun hacked = u3i_edit(q, axis, newval);
 
     u3_noun read_1;
-    u3r_mean(hacked, axis, &read_1, u3_nul);
+    u3r_mean(hacked, {axis, &read_1});
 
     if (newval != read_1){
       printf("*** u3i_edit 1\n");
@@ -1610,7 +1610,7 @@ _test_imprison_complex()
 
     u3_noun read_1;
     u3_noun read_2;
-    u3r_mean(hacked, axis_1, &read_1, axis_2, &read_2, u3_nul);
+    u3r_mean(hacked, {axis_1, &read_1}, {axis_2, &read_2});
 
     if (newval_1 != read_1){
       printf("*** u3i_molt 1\n");

--- a/pkg/vere/noun_tests.c
+++ b/pkg/vere/noun_tests.c
@@ -2182,7 +2182,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   //  XX the following tests leak memory
   //  fix and move to _test_noun()

--- a/pkg/vere/noun_tests.c
+++ b/pkg/vere/noun_tests.c
@@ -1606,7 +1606,7 @@ _test_imprison_complex()
     u3_noun axis_2 = 6;
     u3_noun newval_2 = 777;
 
-    u3_noun hacked = u3i_molt(q, axis_1, newval_1, axis_2, newval_2, u3_nul);
+    u3_noun hacked = u3i_molt(q, {axis_1, newval_1}, {axis_2, newval_2});
 
     u3_noun read_1;
     u3_noun read_2;

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -838,8 +838,7 @@ _pier_wyrd_card(u3_pier* pir_u)
                      u3nc(c3__lull, VERE_LULL),  //  XX from both king and serf?
                      u3nc(c3__arvo, 235),        //  XX from both king and serf?
                      u3nc(c3__hoon, 136),        //  god_u->hon_y
-                     u3nc(c3__nock, 4),          //  god_u->noc_y
-                     u3_none);
+                     u3nc(c3__nock, 4));         //  god_u->noc_y
   return u3nt(c3__wyrd, u3nc(sen, ver), kel);
 }
 

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1017,8 +1017,7 @@ u3_pier_info(u3_pier* pir_u)
     c3__pier,
     u3i_list(
       nat,
-      u3_lord_info(pir_u->god_u),
-      u3_none));
+      u3_lord_info(pir_u->god_u)));
 }
 
 /* u3_pier_slog(): print status info.

--- a/pkg/vere/xmas_tests.c
+++ b/pkg/vere/xmas_tests.c
@@ -52,7 +52,7 @@ main(int argc, char* argv[])
 
   //  GC
   //
-  u3m_grab(u3_none);
+  u3m_grab();
 
   fprintf(stderr, "xmas okeedokee\n");
   return 0;


### PR DESCRIPTION
`va` stuff appears to be error-prone and hard to debug when it comes to vere64 rewrite. One missing cast is enough to cause input argument corruption.

This PR changes most of our variadic functions to functions that take an array and a `c3_z` length + a variadic macro wrapper.

I target vere64 because the change mostly concerns that branch, to make @matthew-levan life simpler when it comes to merges.