### PR TITLE
Trim stracktrace on `bail:meme`

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -285,26 +285,39 @@ _cm_stack_unwind(c3_l sig_l)
   u3_noun tax;
 
   if ( c3__meme == sig_l ) {
-    u3_noun xat = u3R->bug.tax;
+    //  heuristic: if we crash with %meme then our stacktrace might be too big
+    //  to copy, so we trim it.
+    //
+    //  we abuse the fact that the cells in the stacktrace list are not
+    //  structurally shared with anything else
+    //  we also use the fact that the mug hashes of the stacktrace list
+    //  do not matter (since this is a nondeterministic crash, so the
+    //  stacktrace won't get materialized as a product of the outer
+    //  computation), thus we are allowed to edit the noun in place.
+    //
+    u3_noun beg = u3R->bug.tax;
+    //  512 is from +mook to make things more consistent
+    //
     for (c3_w i_w = 0; i_w < 512; i_w++) {
-      if ( u3_nul == xat ) break;
-      xat = u3t(xat);
+      if ( u3_nul == beg ) break;
+      beg = u3t(beg);
     }
 
-    if ( u3_nul != xat ) {
-      //  heuristic: if we crash with %meme then our stacktrace might be too big
-      //  to copy, so we trim it.
-      //
-      //  we abuse the fact that the cells in the stacktrace list are not
-      //  structurally shared with anything else
-      //  we also use the fact that the mug hashes of the stacktrace list
-      //  do not matter (since this is a nondeterministic crash, so the
-      //  stacktrace won't get materialized as a product of the outer
-      //  computation), thus we are allowed to edit the noun in place.
-      //
-      u3a_cell* pom_u = u3a_to_ptr(xat);
-      u3z(pom_u->tel);
-      pom_u->tel = u3nc(u3nc(c3__mean, u3i_string("meme: trace")), u3_nul);
+    if ( u3_nul != beg ) {
+      u3_noun end = u3R->bug.tax, xat = beg;
+      c3_w len_w = 0;
+      while (u3_nul != xat) {
+        xat = u3t(xat);
+        end = u3t(end);
+        len_w++;
+      }
+
+      if (len_w > 512) {
+        u3k(end);
+        u3a_cell* beg_u = u3a_to_ptr(beg);
+        u3z(beg_u->tel);
+        beg_u->tel = u3nc(u3nc(c3__mean, u3i_string("meme: trace")), end);
+      }
     }
   }
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -280,9 +280,33 @@ _cm_stack_recover(u3a_road* rod_u)
 /* _cm_stack_unwind(): unwind to the top level, preserving all frames.
 */
 static u3_noun
-_cm_stack_unwind(void)
+_cm_stack_unwind(c3_l sig_l)
 {
   u3_noun tax;
+
+  if ( c3__meme == sig_l ) {
+    u3_noun xat = u3R->bug.tax;
+    for (c3_w i_w = 0; i_w < 512; i_w++) {
+      if ( u3_nul == xat ) break;
+      xat = u3t(xat);
+    }
+
+    if ( u3_nul != xat ) {
+      //  heuristic: if we crash with %meme then our stacktrace might be too big
+      //  to copy, so we trim it.
+      //
+      //  we abuse the fact that the cells in the stacktrace list are not
+      //  structurally shared with anything else
+      //  we also use the fact that the mug hashes of the stacktrace list
+      //  do not matter (since this is a nondeterministic crash, so the
+      //  stacktrace won't get materialized as a product of the outer
+      //  computation), thus we are allowed to edit the noun in place.
+      //
+      u3a_cell* pom_u = u3a_to_ptr(xat);
+      u3z(pom_u->tel);
+      pom_u->tel = u3nc(u3nc(c3__mean, u3i_string("meme: trace")), u3_nul);
+    }
+  }
 
   while ( u3R != &(u3H->rod_u) ) {
     u3_noun yat = u3m_love(u3R->bug.tax);
@@ -359,7 +383,7 @@ _cm_signal_recover(c3_l sig_l, u3_noun arg)
       }
     }
 #else
-    tax = _cm_stack_unwind();
+    tax = _cm_stack_unwind(sig_l);
 #endif
     pro = u3nt(3, sig_l, tax);
     _cm_signal_reset();


### PR DESCRIPTION
@midden-fabler noticed that the runtime process would occasionaly get aborted if a `bail:meme` involved large stacktrace - it would be too big to copy out in `_cm_stack_unwind`, causing us to `bail:meme` on the home road again.

This PR adds stack trace trimming on the deepmost road if we crash with `meme` moat and the stacktrace happens to be bigger than 1024 frames. It stitches up the beginning and the ending parts with `[%mean 'meme: trace']` which would typically get cut off by `+mook` anyway. Such operations on the stacktrace are safe for the nondeterministic crashes, as documented in the comment.

Note: for this to work `end` must be a subnoun of `beg`, which should be true considering the comparisons I used.