### PR TITLE
u3: fix return type in hashtable trim when missing key

### DIFF
--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -474,7 +474,7 @@ _ch_trim_node(u3h_root* har_u, u3h_slot* sot_w, c3_w lef_w, c3_w rem_w)
 
   if ( !BIT_SET(map_w, bit_w) ) {
     har_u->arm_u.mug_w = _ch_skip_slot(har_u->arm_u.mug_w, lef_w);
-    return c3n;
+    return u3_none;
   }
 
   rem_w = CUT_END(rem_w, lef_w);


### PR DESCRIPTION
This PR fixes a bug in hashtable trimming (introduced while refactoring in 98bcfaaa9d8f5c13ee32ba27914e220bf5247ad8). The wrong sentinel value was returned for a missing key in an intermediate node (`c3n` instead of `u3_none`), making it appear incorrectly that a value had been trimmed and causing the hashtable entry-count to be wrongly decremented. This was effectively a space leak in the capped-cache variants of our HAMTs (ie, the persistent memoization cache), corrected only by melding.