### PR TITLE
cttp: stream outbound %progress per chunk via stream flag

### DIFF
--- a/pkg/vere/io/cttp.c
+++ b/pkg/vere/io/cttp.c
@@ -32,6 +32,7 @@
     h2o_http1client_t* cli_u;           //  h2o client
     u3_csat            sat_e;           //  connection state
     c3_o               sec;             //  yes == https
+    c3_o               str_o;           //  yes == streaming mode
     c3_w               ipf_w;           //  IP
     c3_c*              ipf_c;           //  IP (string)
     c3_c*              hot_c;           //  host
@@ -542,7 +543,7 @@ _cttp_creq_free(u3_creq* ceq_u)
  *   We start with the (?? - JB)
  */
 static u3_creq*
-_cttp_creq_new(u3_cttp* ctp_u, c3_l num_l, u3_noun hes)
+_cttp_creq_new(u3_cttp* ctp_u, c3_l num_l, u3_noun hes, c3_o str_o)
 {
   u3_creq* ceq_u = c3_calloc(sizeof(*ceq_u));
 
@@ -551,6 +552,8 @@ _cttp_creq_new(u3_cttp* ctp_u, c3_l num_l, u3_noun hes)
     u3z(hes);
     return 0;
   }
+
+  ceq_u->str_o = str_o;
 
   //  parse the url out of the new style url passed to us.
   //
@@ -727,6 +730,56 @@ _cttp_http_client_receive(u3_creq* ceq_u, c3_w sas_w, u3_noun mes, u3_noun uct)
   u3_auto_plan(&ctp_u->car_u, u3_ovum_init(0, c3__i, wir, cad));
 }
 
+/* _cttp_http_client_send: dispatch a pre-built http-event for a request
+*/
+static void
+_cttp_http_client_send(u3_creq* ceq_u, u3_noun evt)
+{
+  u3_cttp* ctp_u = ceq_u->ctp_u;
+  u3_noun wir = u3nt(u3i_string("http-client"),
+                     u3dc("scot", c3__uv, ctp_u->sev_l),
+                     u3_nul);
+  u3_noun cad = u3nt(u3i_string("receive"), ceq_u->num_l, evt);
+  u3_auto_plan(&ctp_u->car_u, u3_ovum_init(0, c3__i, wir, cad));
+}
+
+/* _cttp_creq_send_start_open: %start with no body, complete=%.n (stream)
+*/
+static void
+_cttp_creq_send_start_open(u3_creq* ceq_u)
+{
+  u3_cres* res_u = ceq_u->res_u;
+  //  [%start [sas hed] ~ %.n]
+  u3_noun evt = u3nq(u3i_string("start"),
+                     u3nc(res_u->sas_w, u3k(res_u->hed)),
+                     u3_nul,
+                     c3n);
+  _cttp_http_client_send(ceq_u, evt);
+}
+
+/* _cttp_creq_send_chunk: %continue with chunk, complete=%.n (stream)
+*/
+static void
+_cttp_creq_send_chunk(u3_creq* ceq_u, size_t len, const c3_y* dat_y)
+{
+  u3_noun oct = u3nc((c3_w)len, u3i_bytes((c3_w)len, dat_y));
+  //  [%continue [~ oct] %.n]
+  u3_noun evt = u3nt(u3i_string("continue"),
+                     u3nc(u3_nul, oct),
+                     c3n);
+  _cttp_http_client_send(ceq_u, evt);
+}
+
+/* _cttp_creq_send_end: %continue empty, complete=%.y (stream EOS)
+*/
+static void
+_cttp_creq_send_end(u3_creq* ceq_u)
+{
+  //  [%continue ~ %.y]
+  u3_noun evt = u3nt(u3i_string("continue"), u3_nul, c3y);
+  _cttp_http_client_send(ceq_u, evt);
+}
+
 /* _cttp_creq_fail(): dispatch error response
 */
 static void
@@ -771,6 +824,18 @@ _cttp_creq_on_body(h2o_http1client_t* cli_u, const c3_c* err_c)
 
   h2o_buffer_t* buf_u = cli_u->sock->input;
 
+  if ( c3y == ceq_u->str_o ) {
+    if ( buf_u->size ) {
+      _cttp_creq_send_chunk(ceq_u, buf_u->size, (c3_y*)buf_u->bytes);
+      h2o_buffer_consume(&cli_u->sock->input, buf_u->size);
+    }
+    if ( h2o_http1client_error_is_eos == err_c ) {
+      _cttp_creq_send_end(ceq_u);
+      _cttp_creq_free(ceq_u);
+    }
+    return 0;
+  }
+
   if ( buf_u->size ) {
     _cttp_cres_fire_body(ceq_u->res_u,
                          _cttp_bod_new(buf_u->size, buf_u->bytes));
@@ -802,6 +867,19 @@ _cttp_creq_on_head(h2o_http1client_t* cli_u, const c3_c* err_c, c3_i ver_i,
 
   _cttp_cres_new(ceq_u, (c3_w)sas_i);
   ceq_u->res_u->hed = _cttp_heds_to_noun(hed_u, hed_t);
+
+  if ( c3y == ceq_u->str_o ) {
+    //  fire %start now (empty body, not complete) so iris records headers
+    _cttp_creq_send_start_open(ceq_u);
+
+    if ( h2o_http1client_error_is_eos == err_c ) {
+      //  zero-byte response: emit terminating %continue and clean up
+      _cttp_creq_send_end(ceq_u);
+      _cttp_creq_free(ceq_u);
+      return 0;
+    }
+    return _cttp_creq_on_body;
+  }
 
   if ( h2o_http1client_error_is_eos == err_c ) {
     _cttp_creq_respond(ceq_u);
@@ -997,21 +1075,26 @@ _cttp_ef_http_client(u3_cttp* ctp_u, u3_noun tag, u3_noun dat)
   c3_o     ret_o;
 
   if ( c3y == u3r_sing_c("request", tag) ) {
-    u3_noun num, req;
+    u3_noun num, req, str;
     c3_l  num_l;
+    c3_o  str_o;
 
-    if (  (c3n == u3r_cell(dat, &num, &req))
-       || (c3n == u3r_safe_word(num, &num_l)) )
+    if (  (c3n == u3r_trel(dat, &num, &req, &str))
+       || (c3n == u3r_safe_word(num, &num_l))
+       || ((c3y != str) && (c3n != str)) )
     {
       u3l_log("cttp: strange request");
       ret_o = c3n;
     }
-    else if ( (ceq_u = _cttp_creq_new(ctp_u, num_l, u3k(req))) ) {
-      _cttp_creq_start(ceq_u);
-      ret_o = c3y;
-    }
     else {
-      ret_o = c3n;
+      str_o = (c3y == str) ? c3y : c3n;
+      if ( (ceq_u = _cttp_creq_new(ctp_u, num_l, u3k(req), str_o)) ) {
+        _cttp_creq_start(ceq_u);
+        ret_o = c3y;
+      }
+      else {
+        ret_o = c3n;
+      }
     }
   }
   else if ( c3y == u3r_sing_c("cancel-request", tag) ) {

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1525,7 +1525,7 @@ u3_mars_work(u3_mars* mar_u)
 }
 
 #define VERE_NAME  "vere"
-#define VERE_ZUSE  408
+#define VERE_ZUSE  407
 #define VERE_LULL  320
 #define VERE_ARVO  234
 #define VERE_HOON  135
@@ -1920,7 +1920,7 @@ u3_mars_boot(u3_mars* mar_u, c3_d len_d, c3_y* hun_y)
   //  XX source kelvin from args?
   //
   inp_u.ver_u.nam_m = c3__zuse;
-  inp_u.ver_u.ver_w = 408;
+  inp_u.ver_u.ver_w = 407;
 
   gettimeofday(&inp_u.tim_u, 0);
   c3_rand(inp_u.eny_w);

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -707,7 +707,7 @@ _pier_wyrd_fail(u3_pier* pir_u, u3_ovum* egg_u, u3_noun lud)
 //  XX organizing version constants
 //
 #define VERE_NAME  "vere"
-#define VERE_ZUSE  408
+#define VERE_ZUSE  407
 #define VERE_LULL  320
 
 /* _pier_wyrd_aver(): check for %wend effect and version downgrade. RETAIN


### PR DESCRIPTION
## Summary

Implements per-chunk `%progress` delivery for outbound HTTP requests handled by `cttp`.

When the iris `%request` gift arrives with `stream=%.y`, `cttp`:
- fires a `%start` with empty body and `complete=%.n` on header receipt (so iris records the response-header)
- fires a `%continue` per h2o body callback with the chunk and `complete=%.n`
- fires a terminating `%continue` with empty body and `complete=%.y` on EOS

Default `stream=%.n` preserves the existing buffered path — a single `%start` with the full body and `complete=%.y`.

## Wire-format change

The iris `%request` gift to the `%i` driver gains a trailing `stream=?` field. `_cttp_ef_http_client` now parses a 3-tuple `[num req str]` instead of `[num req]`. This is a coordinated change with **urbit/urbit#7342**.

`VERE_ZUSE` bumped 408 → 407 in both `pkg/vere/mars.c` and `pkg/vere/pier.c` to match the lull/iris bump.

## Cannot land until

The companion arvo PR — **urbit/urbit#7342** — is in. This vere PR can be reviewed in parallel but the kelvin assertion will refuse to boot against an unupgraded arvo.

## Motivating use case

`%llmproxy`, an Urbit desk that proxies LLM inference to a local Ollama backend. Ollama streams responses as newline-delimited JSON; without `%progress` support the node agent must buffer the full response before forwarding anything over Ames.

## Test plan

- [x] Buffered regression — `*outbound-config:iris` (default `stream=%.n`) → single `%finished` with full body, no `%progress`
- [x] Streaming — `outbound-config:iris(stream %.y)` → `%progress` per h2o body callback, then `%finished` with empty body
- [x] Verified end-to-end on a fakezod with a local Python chunked HTTP server emitting random hex chunks of varied sizes

## Follow-ons

- `%cancel` support for in-flight streaming requests (still unimplemented)
- Non-durable `%progress` injection (avoid event-log writes on a hot streaming path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
