### PR TITLE
nock: don't save ford stuff if scrying is enabled

### DIFF
--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -2785,12 +2785,12 @@ _n_burn(u3n_prog* pog_u, u3_noun bus, c3_ys mov, c3_ys off)
       x   = _n_pep(mov, off);  // product
       top = _n_peek(off);
       o   = *top;
-      if ( u3z_memo_ford == u3h(o) ) {
+      if ( u3z_memo_ford == u3h(o) && ( 0 == u3R->ski.gul ) ) {
         u3z_save_m(u3h(o), 136 + c3__ford, u3t(o), x);
       }
       else if ( ( u3z_memo_toss == u3h(o) )
          ? ( &(u3H->rod_u) != u3R )
-         : ( 0 == u3R->ski.gul ) ) {  //  prevents userspace from persistence
+         : ( 0 == u3R->ski.gul ) ) {  //  prevents persistent memoization when scrying is avaliable
         u3z_save_m(u3h(o), 144 + c3__nock, u3t(o), x);
       }
       // XX can we still print?


### PR DESCRIPTION
Persistent memoization should only happen in kernelspace or when scrying is disabled. Currently there is no way to check the former so we use the latter condition.

Ford persistent caching should also check that scrying is disabled. Note that this PR depends on https://github.com/urbit/urbit/pull/7343, without it building would take forever.