### PR TITLE
meld: make dropping memo/ford persistent tables optional

### DIFF
--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -669,7 +669,7 @@ _conn_moor_poke(void* ptr_v, c3_d len_d, c3_y* byt_y)
         } break;
         case c3__meld: {
           _conn_send_noun(can_u, u3nc(u3k(rid), c3y));
-          u3_pier_meld(con_u->car_u.pir_u);
+          u3_pier_meld(con_u->car_u.pir_u, u3_nul);
         } break;
         case c3__pack: {
           _conn_send_noun(can_u, u3nc(u3k(rid), c3y));

--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -664,6 +664,12 @@ _conn_moor_poke(void* ptr_v, c3_d len_d, c3_y* byt_y)
     case c3__urth: {
       switch (dat) {
         default: {
+          u3_noun p;
+          if ( c3y == u3r_p(dat, c3__meld, &p) ) {
+            _conn_send_noun(can_u, u3nc(u3k(rid), c3y));
+            u3_pier_meld(con_u->car_u.pir_u, u3k(p));
+            break;
+          }
           err_i = -7; err_c = "urth-bad";
           goto _moor_poke_out;
         } break;

--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -1745,7 +1745,7 @@ _term_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
 
         case c3__meld: {
           ret_o = c3y;
-          u3_pier_meld(car_u->pir_u);
+          u3_pier_meld(car_u->pir_u, u3k(dat));
         } break;
 
         case c3__pack: {

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -769,14 +769,14 @@ u3_lord_save(u3_lord* god_u)
 /* u3_lord_meld(): globally deduplicate persistent state.
 */
 void
-u3_lord_meld(u3_lord* god_u)
+u3_lord_meld(u3_lord* god_u, u3_noun dat)
 {
   u3_writ* wit_u = _lord_writ_new(god_u);
   wit_u->typ_e = u3_writ_live;
 
   //  XX set callback
   //
-  _lord_send(god_u, u3nt(c3__live, c3__meld, u3_nul));
+  _lord_send(god_u, u3nt(c3__live, c3__meld, dat));
 }
 
 /* u3_lord_pack(): defragment persistent state.

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1866,8 +1866,12 @@ _cw_meld(c3_i argc, c3_c* argv[])
     { "swap-to",       required_argument, NULL, 8 },
     { "gc-early",      no_argument,       NULL, 9 },
     { "lmdb-map-size", required_argument, NULL, 10 },
+    { "memo-drop",     no_argument,       NULL, 11 },
+    { "ford-drop",     no_argument,       NULL, 12 },
     { NULL, 0, NULL, 0 }
   };
+
+  c3_o per_o = c3n, for_o = c3n;
 
   u3_Host.dir_c = _main_pier_run(argv[0]);
 
@@ -1908,6 +1912,16 @@ _cw_meld(c3_i argc, c3_c* argv[])
         break;
       }
 
+      case 11: {  //  memo-drop
+        per_o = c3y;
+        break;
+      }  
+
+      case 12: {  //  ford-drop
+        for_o = c3y;
+        break;
+      }
+
       case '?': {
         fprintf(stderr, "invalid argument\r\n");
         exit(1);
@@ -1939,7 +1953,7 @@ _cw_meld(c3_i argc, c3_c* argv[])
 
   u3_disk* log_u = _cw_load_pier(u3_Host.dir_c);
 
-  u3a_print_memory(stderr, "urbit: meld: gained", u3_meld_all(stderr));
+  u3a_print_memory(stderr, "urbit: meld: gained", u3_meld_all(stderr, per_o, for_o));
 
   u3m_save();
   u3_disk_exit(log_u);

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -655,10 +655,9 @@ _mars_work(u3_mars* mar_u, u3_noun jar)
     //  $%  [%live ?(%meld %pack) ~] :: XX rename
     //
     case c3__live: {
-      u3_noun com, nul;
+      u3_noun com, arg;
 
-      if ( (c3n == u3r_cell(dat, &com, &nul)) ||
-           (u3_nul != nul) )
+      if ( (c3n == u3r_cell(dat, &com, &arg)) )
       {
         u3z(jar);
         return c3n;
@@ -678,7 +677,7 @@ _mars_work(u3_mars* mar_u, u3_noun jar)
         case c3__meld: {
           c3_o per_o = c3n, for_o = c3n;
           u3_noun pers, ford;
-          if ( c3y == u3r_cell(dat, &pers, &ford) ) {
+          if ( c3y == u3r_cell(arg, &pers, &ford) ) {
             per_o = pers < 2 ? pers : per_o;
             for_o = ford < 2 ? ford : for_o;
           }

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -676,8 +676,15 @@ _mars_work(u3_mars* mar_u, u3_noun jar)
         } break;
 
         case c3__meld: {
+          c3_o per_o = c3n, for_o = c3n;
+          u3_noun pers, ford;
+          if ( c3y == u3r_cell(dat, &pers, &ford) ) {
+            per_o = pers < 2 ? pers : per_o;
+            for_o = ford < 2 ? ford : for_o;
+          }
           u3z(jar);
-          u3a_print_memory(stderr, "mars: meld: gained", u3_meld_all(stderr));
+          u3a_print_memory(stderr, "mars: meld: gained",
+            u3_meld_all(stderr, per_o, for_o));
         } break;
       }
 
@@ -1398,7 +1405,7 @@ u3_mars_play(u3_mars* mar_u, c3_d eve_d, c3_d sap_d)
           //  XX pack before meld?
           //
           if ( u3C.wag_w & u3o_auto_meld ) {
-            u3a_print_memory(stderr, "mars: meld: gained", u3_meld_all(stderr));
+            u3a_print_memory(stderr, "mars: meld: gained", u3_meld_all(stderr, c3y, c3n));
           }
           else {
             u3a_print_memory(stderr, "mars: pack: gained", u3m_pack());

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -677,9 +677,11 @@ _mars_work(u3_mars* mar_u, u3_noun jar)
         case c3__meld: {
           c3_o per_o = c3n, for_o = c3n;
           u3_noun pers, ford;
-          if ( c3y == u3r_cell(arg, &pers, &ford) ) {
-            per_o = pers < 2 ? pers : per_o;
-            for_o = ford < 2 ? ford : for_o;
+          if ( c3y == u3r_cell(arg, &pers, &ford)
+            && pers < 2
+            && ford < 2) {
+            per_o = pers;
+            for_o = ford;
           }
           u3z(jar);
           u3a_print_memory(stderr, "mars: meld: gained",

--- a/pkg/vere/melt.c
+++ b/pkg/vere/melt.c
@@ -198,15 +198,19 @@ u3_melt_all(FILE *fil_u)
 }
 
 c3_w
-u3_meld_all(FILE *fil_u)
+u3_meld_all(FILE *fil_u, c3_o per_o, c3_o for_o)
 {
   c3_w pre_w = u3a_open(u3R);
 
-  u3h_free(u3R->cax.per_p);
-  u3R->cax.per_p = u3h_new_cache(u3C.per_w);
+  if ( _(per_o) ) {
+    u3h_free(u3R->cax.per_p);
+    u3R->cax.per_p = u3h_new_cache(u3C.per_w);
+  }
 
-  u3h_free(u3R->cax.for_p);
-  u3R->cax.for_p = u3h_new_cache(u3C.per_w);
+  if ( _(for_o) ) {
+    u3h_free(u3R->cax.for_p);
+    u3R->cax.for_p = u3h_new_cache(u3C.per_w);
+  }
 
   (void)u3_melt_all(fil_u);
   (void)u3m_pack();

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1152,13 +1152,13 @@ u3_pier_save(u3_pier* pir_u)
 /* u3_pier_meld(): globally deduplicate persistent state.
 */
 void
-u3_pier_meld(u3_pier* pir_u)
+u3_pier_meld(u3_pier* pir_u, u3_noun dat)
 {
 #ifdef VERBOSE_PIER
   fprintf(stderr, "pier: (%" PRIu64 "): meld: plan\r\n", pir_u->god_u->eve_d);
 #endif
 
-  u3_lord_meld(pir_u->god_u);
+  u3_lord_meld(pir_u->god_u, dat);
 }
 
 /* u3_pier_pack(): defragment persistent state.

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -1027,7 +1027,7 @@
       /* u3_lord_meld(): globally deduplicate persistent state.
       */
         void
-        u3_lord_meld(u3_lord* god_u);
+        u3_lord_meld(u3_lord* god_u, u3_noun dat);
 
       /* u3_lord_pack(): defragment persistent state.
       */
@@ -1295,7 +1295,7 @@
       /* u3_pier_meld(): globally deduplicate persistent state.
       */
         void
-        u3_pier_meld(u3_pier* pir_u);
+        u3_pier_meld(u3_pier* pir_u, u3_noun dat);
 
       /* u3_pier_pack(): defragment persistent state.
       */

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -1476,6 +1476,6 @@
       /* u3_meld_all(): canonicalize persistent nouns and compact state.
       */
         c3_w
-        u3_meld_all(FILE*);
+        u3_meld_all(FILE*, c3_o, c3_o);
 
 #endif /* ifndef U3_VERE_H */


### PR DESCRIPTION
Adds arguments to `u3_meld_all` to control whether we free the persistent memoization buckets.

Adds `memo-drop` and `ford-drop` CLI arguments to free the buckets (they are retained by default).

Added argument parsing to `%meld` task: if an argument is a pair of loobeans then they are passed, otherwise fall back to not freeing the buckets.

NB: On automeld we free the persistent memo bucket but not the ford caches. Thoughts?