### PR TITLE
nock: earlier shortcircuit for pointer equality

### DIFF
--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -614,7 +614,7 @@ _cr_sing(u3_noun a, u3_noun b)
 /* u3r_sing(): Yes iff [a] and [b] are the same noun.
 */
 c3_o
-u3r_sing(u3_noun a, u3_noun b)
+u3r_sing_imp(u3_noun a, u3_noun b)
 {
   c3_o ret_o;
   u3t_on(euq_o);

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -210,7 +210,13 @@
       **   Unifies noun pointers on inner roads.
       */
         c3_o
-        u3r_sing(u3_noun a, u3_noun b);
+        u3r_sing_imp(u3_noun a, u3_noun b);
+
+        #define u3r_sing(a, b) ({                                               \
+          u3_noun __a = a;                                                      \
+          u3_noun __b = b;                                                      \
+          ( __a == __b ) ? c3y : u3r_sing_imp(__a, __b);                        \
+        })
 
       /* u3r_sing_c(): cord/C-string value equivalence.
       */


### PR DESCRIPTION
Made an Ackermann benchmark about 10% faster