### PR TITLE
nock: %drop hint to discard ford caches

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1525,6 +1525,14 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
   */
   u3z(arg);
 
+  /* Clear build caches if needed.
+  */
+  if ( !u3R->par_p && (u3C.wag_w & u3o_free_ford) ) {
+    u3h_free(u3R->cax.for_p);
+    u3R->cax.for_p = u3h_new_cache(u3C.per_w);
+    u3C.wag_w &= ~(c3_w)u3o_free_ford;
+  }
+
   /* Return the product.
   */
   return pro;

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1032,6 +1032,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
       case c3__nara:
       case c3__hela:
       case c3__loop:
+      case c3__drop:
       case c3__bout: {
         u3_noun fen = u3_nul;
         c3_w  nef_w = _n_comp(&fen, nef, los_o, c3n);
@@ -1918,6 +1919,11 @@ _n_hilt_fore(u3_noun hin, u3_noun bus, u3_noun* out)
       u3_atom per = u3i_word(u3h_count(u3R->cax.per_p));
       u3h_discount(u3R->cax.per_p);
       *out = u3i_cell(tag, u3i_cell(har, per));
+    } break;
+
+    case c3__drop: {
+      u3C.wag_w |= u3o_free_ford;
+      *out = u3_nul;
     } break;
 
     case c3__loop: {

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -47,6 +47,7 @@
         u3o_toss          = 1 << 13,          //  reclaim often
         u3o_leak_crash    = 1 << 14,          //  crash if leak when gc
         u3o_yolo          = 1 << 15,          //  no brakes!
+        u3o_free_ford     = 1 << 16,          //  free ford caches when done
       };
 
   /** Globals.


### PR DESCRIPTION
This PR adds (again) a `%drop` hint to discard ford caches. This time the caches are discarded at the late-most time, when we are returning from the top-level wrapper.