### PR TITLE
ford: drop caches more granularly

### DIFF
--- a/pkg/c3/defs.h
+++ b/pkg/c3/defs.h
@@ -81,8 +81,16 @@
 
     /* Min and max.
     */
-#     define c3_max(x, y) ( ((x) > (y)) ? (x) : (y) )
-#     define c3_min(x, y) ( ((x) < (y)) ? (x) : (y) )
+#     define c3_max(x, y) ({  \
+        typeof(x) _x = x;     \
+        typeof(y) _y = y;     \
+        (_x > _y) ? _x : _y;  \
+      })
+#     define c3_min(x, y) ({  \
+        typeof(x) _x = x;     \
+        typeof(y) _y = y;     \
+        (_x < _y) ? _x : _y;  \
+      })
 
 
 //! Round up/down (respectively).

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -124,6 +124,8 @@ static uint8_t Sigstk[SIGSTKSZ];
 #include "veh_handler.h"
 #endif
 
+static c3_w u3m_Ford_fresh_road_depth_w = 0;
+
 #if 0
 /* _cm_punt(): crudely print trace.
 */
@@ -1332,6 +1334,16 @@ u3m_timer_pop(void)
   _m_renew_now();
 }
 
+c3_w
+u3m_road_depth(void)
+{
+  c3_w dep_w = 0;
+  for (u3a_road* r_u = u3R; r_u->par_p; r_u = u3to(u3a_road, r_u->par_p)) {
+    dep_w++;
+  }
+  return dep_w;
+}
+
 /* u3m_love(): return product from leap.
 */
 u3_noun
@@ -1373,6 +1385,19 @@ u3m_love(u3_noun pro)
   u3a_drop_heap(u3R->cap_p, u3R->ear_p);
   u3R->cap_p = u3R->ear_p;
   u3R->ear_p = 0;
+
+  //  free stale ford caches
+  //  NB: apparently this needs to be done after u3h_take, otherwise double
+  //  frees are possible, resulting in bail: foul
+  //
+  {
+    c3_w dep_w = u3m_road_depth();
+    if ( dep_w < u3m_Ford_fresh_road_depth_w ) {
+      u3h_free(u3R->cax.for_p);
+      u3R->cax.for_p = u3h_new_cache(u3C.per_w);
+      u3m_Ford_fresh_road_depth_w = dep_w;
+    }
+  }
 
   //  integrate junior caches
   //
@@ -1465,6 +1490,9 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
    */
   _cm_signal_deep();
 
+  u3_assert(u3R == &u3H->rod_u);
+  u3m_Ford_fresh_road_depth_w = 0;
+
   if ( 0 != (sig_l = rsignal_setjmp(u3_Signal)) ) {
     //  reinitialize trace state
     //
@@ -1524,14 +1552,6 @@ u3m_soft_top(c3_w    mil_w,                     //  timer ms
   /* Free the argument.
   */
   u3z(arg);
-
-  /* Clear build caches if needed.
-  */
-  if ( !u3R->par_p && (u3C.wag_w & u3o_free_ford) ) {
-    u3h_free(u3R->cax.for_p);
-    u3R->cax.for_p = u3h_new_cache(u3C.per_w);
-    u3C.wag_w &= ~(c3_w)u3o_free_ford;
-  }
 
   /* Return the product.
   */

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -11,6 +11,8 @@
 #include "version.h"
 #include "rsignal.h"
 
+extern c3_w u3m_Ford_fresh_road_depth_w;
+
     /** System management.
     **/
       /* u3m_boot(): start the u3 system. return next event, starting from 1.
@@ -113,6 +115,9 @@
       */
         u3_noun
         u3m_love(u3_noun pro);
+
+        c3_w
+        u3m_road_depth(void);
 
       /* u3m_soft(): system soft wrapper.  unifies unix and nock errors.
       **

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1922,7 +1922,7 @@ _n_hilt_fore(u3_noun hin, u3_noun bus, u3_noun* out)
     } break;
 
     case c3__drop: {
-      u3m_Ford_fresh_road_depth_w = u3m_road_depth();
+      u3m_Ford_fresh_road_depth_w = c3_max(u3m_road_depth(), u3m_Ford_fresh_road_depth_w);
       u3h_free(u3R->cax.for_p);
       u3R->cax.for_p = u3h_new_cache(u3C.per_w);
       *out = u3_nul;

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1922,7 +1922,9 @@ _n_hilt_fore(u3_noun hin, u3_noun bus, u3_noun* out)
     } break;
 
     case c3__drop: {
-      u3C.wag_w |= u3o_free_ford;
+      u3m_Ford_fresh_road_depth_w = u3m_road_depth();
+      u3h_free(u3R->cax.for_p);
+      u3R->cax.for_p = u3h_new_cache(u3C.per_w);
       *out = u3_nul;
     } break;
 

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -47,7 +47,6 @@
         u3o_toss          = 1 << 13,          //  reclaim often
         u3o_leak_crash    = 1 << 14,          //  crash if leak when gc
         u3o_yolo          = 1 << 15,          //  no brakes!
-        u3o_free_ford     = 1 << 16,          //  free ford caches when done
       };
 
   /** Globals.

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -758,7 +758,6 @@ _mars_post(u3_mars* mar_u)
 
   if ( mar_u->fag_w & _mars_fag_vega ) {
     u3h_trim_to(u3R->cax.per_p, u3h_wyt(u3R->cax.per_p) / 2);
-    u3h_trim_to(u3R->cax.for_p, u3h_wyt(u3R->cax.for_p) / 2);
     u3m_reclaim();
   }
 


### PR DESCRIPTION
Adds a global variable that tracks the road depth at which the ford cache was freed.

In top-level wrapper set it to zero (might be set to non-zero value by ^C-ing during kernel upgrade).

On `%drop` set it to current road depth and free current Ford table.

On leaving the road check if the caches are old by comparing the variable against current road depth, freeing the caches if they are old. Note the comment on the operation order.