### PR TITLE
nock: earlier shortcircuit for nonequality of a direct atom with a noun

### DIFF
--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -643,7 +643,10 @@ u3a_post_info(u3_post);
         */
           u3_weak
           u3a_gain(u3_weak som);
-#         define u3k(som) u3a_gain(som)
+#         define u3k(som) ({                                                    \
+            u3_noun __som = som;                                                \
+            ( c3y == u3a_is_cat(__som) ) ? __som : u3a_gain(__som);             \
+          })
 
         /* u3a_take(): gain, copying juniors.
         */
@@ -659,7 +662,10 @@ u3a_post_info(u3_post);
         */
           void
           u3a_lose(u3_weak som);
-#         define u3z(som) u3a_lose(som)
+#         define u3z(som) ({                                                    \
+            u3_noun __som = som;                                                \
+            ( c3y == u3a_is_cat(__som) ) ? (void)0 : u3a_lose(__som);           \
+          })
 
         /* u3a_wash(): wash all lazy mugs in subtree.  RETAIN.
         */

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -215,7 +215,9 @@
         #define u3r_sing(a, b) ({                                               \
           u3_noun __a = a;                                                      \
           u3_noun __b = b;                                                      \
-          ( __a == __b ) ? c3y : u3r_sing_imp(__a, __b);                        \
+          ( __a == __b ) ? c3y :                                                \
+          ( _(c3o(u3a_is_cat(__a), u3a_is_cat(__b))) ) ? c3n :                  \
+          u3r_sing_imp(__a, __b);                                               \
         })
 
       /* u3r_sing_c(): cord/C-string value equivalence.


### PR DESCRIPTION
When testing SKA transpiler output efficiency I noticed that some `u3r_sing` overhead could be removed by shortcurcuiting earlier if at least one of the arguments is a direct atom. This made hoon.hoon compilation 3-5% faster.