### PR TITLE
pier: event 1 replay fix

### DIFF
--- a/pkg/noun/vortex.c
+++ b/pkg/noun/vortex.c
@@ -49,6 +49,18 @@ u3v_boot(u3_noun eve)
     u3_noun pro = u3m_soft(0, u3v_life, eve);
 
     if ( u3_blip != u3h(pro) ) {
+      u3_noun mot = u3h(pro);
+      if ( _(u3a_is_cat(mot)) ) {
+        c3_c mot_c[5] = {0};
+        mot_c[0] = (mot >>  0) & 0xff;
+        mot_c[1] = (mot >>  8) & 0xff;
+        mot_c[2] = (mot >> 16) & 0xff;
+        mot_c[3] = (mot >> 24) & 0xff;
+        fprintf(stderr, "boot: bail: %%%s\r\n", mot_c);
+      }
+      else {
+        fprintf(stderr, "boot: bail\r\n");
+      }
       u3z(pro);
       return c3n;
     }

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1364,6 +1364,9 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
     else if ( c3__leaf == u3h(tac) ) {
       _pier_dump_tape(fil_u, u3k(u3t(tac)));
     }
+    else {
+      fprintf(fil_u, "pier: malformed tank\r\n");
+    }
   }
   else {
     u3_noun low = u3dc("(slum soft wash)", u3nc(tab_l, col_l), u3k(tac));

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1350,10 +1350,18 @@ u3_pier_tank(c3_l tab_l, c3_w pri_w, u3_noun tac)
 
   c3_t bad_t = 0;
   //  if we have no arvo kernel and can't evaluate nock
-  //  only print %leaf tanks
+  //  only print %leaf tanks and bare cords
   //
   if ( 0 == u3A->roc ) {
-    if ( c3__leaf == u3h(tac) ) {
+    if ( _(u3a_is_atom(tac)) ) {
+      //  bare cord slog (e.g. %bout timing reports from _n_hilt_hind);
+      //  print the bytes directly.
+      //
+      c3_c* str_c = u3r_string(tac);
+      fprintf(fil_u, "%s", str_c);
+      c3_free(str_c);
+    }
+    else if ( c3__leaf == u3h(tac) ) {
       _pier_dump_tape(fil_u, u3k(u3t(tac)));
     }
   }


### PR DESCRIPTION
Prevents erroneous bailing when trying to slog a bare cord and `u3A->roc == 0`. Also adds a helpful mote to the print statement when bailing in `u3v_boot`.