### PR TITLE
jets: avoid reallocation in aes-cbc

### DIFF
--- a/pkg/noun/jets/e/aes_cbc.c
+++ b/pkg/noun/jets/e/aes_cbc.c
@@ -10,31 +10,30 @@
  * the ECB functions, which truncate them, hence the raw u3r_bytes unpacking.
  */
 
-typedef int (*urcrypt_cbc)(c3_y**,
-                           size_t*,
-                           c3_y*,
-                           c3_y*,
-                           urcrypt_realloc_t);
+typedef int (*urcrypt_cbc)(c3_y*, size_t, c3_y*, c3_y*);
 
   static u3_atom
   _cqea_cbc_help(c3_y* key_y, u3_atom iv, u3_atom msg, urcrypt_cbc low_f)
   {
-    u3_atom ret;
-    c3_w    met_w;
-    c3_y    iv_y[16];
-    c3_y*   msg_y = u3r_bytes_all(&met_w, msg);
-    size_t  len = met_w;
+    c3_y     iv_y[16];
+    //  message length in 16-byte (bloq 7) blocks; cbc always processes at least
+    //  one block (the hoon pads an empty message to a single zero block)
+    c3_d     len_d = c3_max(1, u3r_met(7, msg));
+    u3i_slab sab_u;
 
     u3r_bytes(0, 16, iv_y, iv);
-    if ( 0 != (*low_f)(&msg_y, &len, key_y, iv_y, &u3a_realloc) ) {
-      ret = u3_none;
-    }
-    else {
-      ret = u3i_bytes(len, msg_y);
-    }
-    u3a_free(msg_y);
 
-    return ret;
+    //  read/write buffer holding [msg] little-endian, zero-padded to a 16-byte
+    //  block boundary (bloq 7), passed to urcrypt's unsafe (no realloc)
+    //  interface, which operates in place.
+    //
+    u3i_slab_from(&sab_u, msg, 7, len_d);
+
+    //  the only error is a non-block-aligned length, ruled out by construction
+    //
+    u3_assert( 0 == (*low_f)(sab_u.buf_y, (c3_z)sab_u.len_w << 2, key_y, iv_y) );
+
+    return u3i_slab_mint(&sab_u);
   }
 
   static u3_atom
@@ -44,7 +43,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     c3_y key_y[16];
     u3r_bytes(0, 16, key_y, key);
-    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbca_en);
+    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbca_en_unsafe);
   }
 
   u3_noun
@@ -68,7 +67,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     c3_y key_y[16];
     u3r_bytes(0, 16, key_y, key);
-    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbca_de);
+    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbca_de_unsafe);
   }
 
   u3_noun
@@ -92,7 +91,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     c3_y key_y[24];
     u3r_bytes(0, 24, key_y, key);
-    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcb_en);
+    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcb_en_unsafe);
   }
 
   u3_noun
@@ -116,7 +115,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     c3_y key_y[24];
     u3r_bytes(0, 24, key_y, key);
-    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcb_de);
+    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcb_de_unsafe);
   }
 
   u3_noun
@@ -140,7 +139,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     c3_y key_y[32];
     u3r_bytes(0, 32, key_y, key);
-    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcc_en);
+    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcc_en_unsafe);
   }
 
   u3_noun
@@ -164,7 +163,7 @@ typedef int (*urcrypt_cbc)(c3_y**,
   {
     c3_y key_y[32];
     u3r_bytes(0, 32, key_y, key);
-    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcc_de);
+    return _cqea_cbc_help(key_y, iv, msg, &urcrypt_aes_cbcc_de_unsafe);
   }
 
   u3_noun


### PR DESCRIPTION
This PR uses the unsafe aes-cbc interface from urbit/urcrypt#22 avoid reallocating buffers for padding (and further reducing allocations with the slab api). It also fixes a jet mismatch in the handling of empty messages (by setting the minimum `bloq=7` length of the input to `1`). The appropriate test cases are in urbit/urbit#7357