### PR TITLE
jets: faster gas

### DIFF
--- a/pkg/noun/jets/a/max.c
+++ b/pkg/noun/jets/a/max.c
@@ -9,30 +9,7 @@
 u3_noun
 u3qa_max(u3_atom a, u3_atom b)
 {
-  if ( _(u3a_is_cat(a)) || _(u3a_is_cat(b)) )
-  {
-    return u3k(c3_max(a, b));
-  }
-
-  if (a == b) return u3k(a);
-
-  u3a_atom* a_u = u3a_to_ptr(a);
-  u3a_atom* b_u = u3a_to_ptr(b);
-
-  if (a_u->len_w != b_u->len_w)
-  {
-    return (a_u->len_w > b_u->len_w) ? u3k(a) : u3k(b);
-  }
-
-  c3_w* a_w = a_u->buf_w;
-  c3_w* b_w = b_u->buf_w;
-  for (c3_w i_w = a_u->len_w; i_w--;)
-  {
-    if (a_w[i_w] > b_w[i_w]) return u3k(a);
-    if (a_w[i_w] < b_w[i_w]) return u3k(b);
-  }
-
-  return u3k(a);
+  return ( u3r_comp(a, b) > 0 ) ? u3k(a) : u3k(b);
 }
 
 u3_noun

--- a/pkg/noun/jets/a/min.c
+++ b/pkg/noun/jets/a/min.c
@@ -9,32 +9,7 @@
 u3_noun
 u3qa_min(u3_atom a, u3_atom b)
 {
-  if ( _(u3a_is_cat(a)) || _(u3a_is_cat(b)) )
-  {
-    //  this will always return a direct atom, no refcount gain necessary
-    //
-    return c3_min(a, b);
-  }
-
-  if (a == b) return u3k(a);
-
-  u3a_atom* a_u = u3a_to_ptr(a);
-  u3a_atom* b_u = u3a_to_ptr(b);
-
-  if (a_u->len_w != b_u->len_w)
-  {
-    return (a_u->len_w < b_u->len_w) ? u3k(a) : u3k(b);
-  }
-
-  c3_w* a_w = a_u->buf_w;
-  c3_w* b_w = b_u->buf_w;
-  for (c3_w i_w = a_u->len_w; i_w--;)
-  {
-    if (a_w[i_w] < b_w[i_w]) return u3k(a);
-    if (a_w[i_w] > b_w[i_w]) return u3k(b);
-  }
-
-  return u3k(a);
+  return ( u3r_comp(a, b) < 0 ) ? u3k(a) : u3k(b);
 }
 
 u3_noun

--- a/pkg/noun/jets/c/mor.c
+++ b/pkg/noun/jets/c/mor.c
@@ -10,8 +10,8 @@
   u3qc_mor(u3_noun a,
            u3_noun b)
   {
-    c3_w c_w = u3r_mug(u3r_mug(a));
-    c3_w d_w = u3r_mug(u3r_mug(b));
+    c3_w c_w = u3r_mug_word(u3r_mug(a));
+    c3_w d_w = u3r_mug_word(u3r_mug(b));
 
     if ( c_w == d_w ) {
       return u3qc_dor(a, b);

--- a/pkg/noun/jets/d/by_gas.c
+++ b/pkg/noun/jets/d/by_gas.c
@@ -6,6 +6,51 @@
 
 #include "noun.h"
 
+//  RETAINS lit
+//
+static u3_noun
+_malt_fast(u3_noun lit)
+{
+  if ( u3_nul == lit ) return u3_nul;
+
+  u3_noun root = u3h(lit);
+  u3_noun rest = u3t(lit);
+  while ( u3_nul != rest ) {
+    u3_noun h = u3h(rest);
+    rest = u3t(rest);
+    //  this will pick last pair, given equal keys
+    if ( _(u3qc_mor(u3h(h), u3h(root))) ) {
+      root = h;
+    }
+  }
+  u3_noun part_l, part_r;
+  u3_noun *cur_l = &part_l, *cur_r = &part_r, *old, *item;
+  rest = lit;
+  while ( u3_nul != rest ) {
+    u3_noun h = u3h(rest);
+    rest = u3t(rest);
+    if ( c3y == u3r_sing(u3h(h), u3h(root)) ) continue;
+    if ( _(u3qc_gor(u3h(h), u3h(root))) ) {
+      old = cur_l;
+      *old = u3i_defcons(&item, &cur_l);
+      *item = u3k(h);
+    }
+    else {
+      old = cur_r;
+      *old = u3i_defcons(&item, &cur_r);
+      *item = u3k(h);
+    }
+  }
+  *cur_l = u3_nul;
+  *cur_r = u3_nul;
+
+  u3_noun l = _malt_fast(part_l);
+  u3_noun r = _malt_fast(part_r);
+  u3_noun out = u3nt(u3k(root), l, r);
+  u3z(part_l); u3z(part_r);
+  return out;
+}
+
 u3_noun
 u3qdb_gas(u3_noun a,
           u3_noun b)
@@ -14,6 +59,9 @@ u3qdb_gas(u3_noun a,
     return u3k(a);
   }
   else {
+    if ( u3_nul == a ) {
+      return _malt_fast(b);
+    }
     u3_noun i_b,  t_b,
             pi_b, qi_b;
     u3x_cell(b, &i_b, &t_b);

--- a/pkg/noun/jets/d/by_gas.c
+++ b/pkg/noun/jets/d/by_gas.c
@@ -13,35 +13,47 @@ _malt_fast(u3_noun lit)
 {
   if ( u3_nul == lit ) return u3_nul;
 
-  u3_noun root = u3h(lit);
-  u3_noun rest = u3t(lit);
+  u3_noun root = u3k(u3h(lit));
+  u3_noun i, temp, rest = u3k(u3t(lit));
   while ( u3_nul != rest ) {
-    u3_noun h = u3h(rest);
-    rest = u3t(rest);
+    i    = u3k(u3h(rest));
+
+    temp = u3k(u3t(rest));
+    u3z(rest);
+    rest = temp;
+
     //  this will pick last pair, given equal keys
-    if ( _(u3qc_mor(u3h(h), u3h(root))) ) {
-      root = h;
+    if ( _(u3qc_mor(u3h(i), u3h(root))) ) {
+      u3z(root);
+      root = i;
+    }
+    else {
+      u3z(i);
     }
   }
 
-  u3k(root);
-  
   u3_noun part_l, part_r;
   u3_noun *cur_l = &part_l, *cur_r = &part_r, *old, *item;
-  rest = lit;
+  rest = u3k(lit);
   while ( u3_nul != rest ) {
-    u3_noun h = u3h(rest);
-    rest = u3t(rest);
-    if ( c3y == u3r_sing(u3h(h), u3h(root)) ) continue;
-    if ( _(u3qc_gor(u3h(h), u3h(root))) ) {
+    i    = u3k(u3h(rest));
+
+    temp = u3k(u3t(rest));
+    u3z(rest);
+    rest = temp;
+
+    if ( c3y == u3r_sing(u3h(i), u3h(root)) ) {
+      u3z(i);
+    }
+    else if ( _(u3qc_gor(u3h(i), u3h(root))) ) {
       old = cur_l;
       *old = u3i_defcons(&item, &cur_l);
-      *item = u3k(h);
+      *item = i;
     }
     else {
       old = cur_r;
       *old = u3i_defcons(&item, &cur_r);
-      *item = u3k(h);
+      *item = i;
     }
   }
   *cur_l = u3_nul;

--- a/pkg/noun/jets/d/by_gas.c
+++ b/pkg/noun/jets/d/by_gas.c
@@ -23,6 +23,9 @@ _malt_fast(u3_noun lit)
       root = h;
     }
   }
+
+  u3k(root);
+  
   u3_noun part_l, part_r;
   u3_noun *cur_l = &part_l, *cur_r = &part_r, *old, *item;
   rest = lit;
@@ -46,7 +49,7 @@ _malt_fast(u3_noun lit)
 
   u3_noun l = _malt_fast(part_l);
   u3_noun r = _malt_fast(part_r);
-  u3_noun out = u3nt(u3k(root), l, r);
+  u3_noun out = u3nt(root, l, r);
   u3z(part_l); u3z(part_r);
   return out;
 }

--- a/pkg/noun/jets/d/in_gas.c
+++ b/pkg/noun/jets/d/in_gas.c
@@ -6,6 +6,42 @@
 
 #include "noun.h"
 
+//  RETAINS lit
+//
+static u3_noun
+_silt_fast(u3_noun lit)
+{
+  if ( u3_nul == lit ) return u3_nul;
+
+  u3_noun root = u3h(lit);
+  u3_noun rest = u3t(lit);
+  while ( u3_nul != rest ) {
+    u3_noun h = u3h(rest);
+    rest = u3t(rest);
+    if ( !_(u3qc_mor(root, h)) ) {
+      root = h;
+    }
+  }
+  u3_noun part_l = u3_nul, part_r = u3_nul;
+  rest = lit;
+  while ( u3_nul != rest ) {
+    u3_noun h = u3h(rest);
+    rest = u3t(rest);
+    if ( c3y == u3r_sing(h, root) ) continue;
+    if ( _(u3qc_gor(h, root)) ) {
+      part_l = u3nc(u3k(h), part_l);
+    }
+    else {
+      part_r = u3nc(u3k(h), part_r);
+    }
+  }
+  u3_noun l = _silt_fast(part_l);
+  u3_noun r = _silt_fast(part_r);
+  u3_noun out = u3nt(u3k(root), l, r);
+  u3z(part_l); u3z(part_r);
+  return out;
+}
+
 u3_noun
 u3qdi_gas(u3_noun a,
           u3_noun b)
@@ -14,6 +50,9 @@ u3qdi_gas(u3_noun a,
     return u3k(a);
   }
   else {
+    if ( u3_nul == a ) {
+      return _silt_fast(b);
+    }
     u3_noun i_b, t_b;
     u3x_cell(b, &i_b, &t_b);
 

--- a/pkg/noun/jets/d/in_gas.c
+++ b/pkg/noun/jets/d/in_gas.c
@@ -13,29 +13,41 @@ _silt_fast(u3_noun lit)
 {
   if ( u3_nul == lit ) return u3_nul;
 
-  u3_noun root = u3h(lit);
-  u3_noun rest = u3t(lit);
+  u3_noun root = u3k(u3h(lit));
+  u3_noun i, temp, rest = u3k(u3t(lit));
   while ( u3_nul != rest ) {
-    u3_noun h = u3h(rest);
-    rest = u3t(rest);
-    if ( !_(u3qc_mor(root, h)) ) {
-      root = h;
+    i    = u3k(u3h(rest));
+
+    temp = u3k(u3t(rest));
+    u3z(rest);
+    rest = temp;
+
+    if ( !_(u3qc_mor(root, i)) ) {
+      u3z(root);
+      root = i;
+    }
+    else {
+      u3z(i);
     }
   }
 
-  u3k(root);
-
   u3_noun part_l = u3_nul, part_r = u3_nul;
-  rest = lit;
+  rest = u3k(lit);
   while ( u3_nul != rest ) {
-    u3_noun h = u3h(rest);
-    rest = u3t(rest);
-    if ( c3y == u3r_sing(h, root) ) continue;
-    if ( _(u3qc_gor(h, root)) ) {
-      part_l = u3nc(u3k(h), part_l);
+    i    = u3k(u3h(rest));
+
+    temp = u3k(u3t(rest));
+    u3z(rest);
+    rest = temp;
+    
+    if ( c3y == u3r_sing(i, root) ) {
+      u3z(i);
+    }
+    else if ( _(u3qc_gor(i, root)) ) {
+      part_l = u3nc(i, part_l);
     }
     else {
-      part_r = u3nc(u3k(h), part_r);
+      part_r = u3nc(i, part_r);
     }
   }
   u3_noun l = _silt_fast(part_l);

--- a/pkg/noun/jets/d/in_gas.c
+++ b/pkg/noun/jets/d/in_gas.c
@@ -22,6 +22,9 @@ _silt_fast(u3_noun lit)
       root = h;
     }
   }
+
+  u3k(root);
+
   u3_noun part_l = u3_nul, part_r = u3_nul;
   rest = lit;
   while ( u3_nul != rest ) {
@@ -37,7 +40,7 @@ _silt_fast(u3_noun lit)
   }
   u3_noun l = _silt_fast(part_l);
   u3_noun r = _silt_fast(part_r);
-  u3_noun out = u3nt(u3k(root), l, r);
+  u3_noun out = u3nt(root, l, r);
   u3z(part_l); u3z(part_r);
   return out;
 }

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -1734,6 +1734,14 @@ u3r_mug_words(const c3_w* key_w, c3_w len_w)
   return u3r_mug_bytes((c3_y*)key_w, byt_w);
 }
 
+/* u3r_mug_word(): 31-bit nonzero MurmurHash3 of a single word.
+*/
+c3_l
+u3r_mug_word(c3_w key_w)
+{
+  return u3r_mug_words(&key_w, 1);
+}
+
 /* _cr_mug: stack frame for recording cell traversal
 **          !mug == head-frame
 */

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -152,6 +152,11 @@
         c3_l
         u3r_mug_words(const c3_w* key_w, c3_w len_w);
 
+      /* u3r_mug_word(): 31-bit nonzero MurmurHash3 of a single word.
+      */
+        c3_l
+        u3r_mug_word(c3_w key_w);
+
       /* u3r_mug(): statefully mug a noun with 31-bit murmur3.
       */
         c3_l


### PR DESCRIPTION
It always felt strange to me that `+silt/+malt` iterate over the list of elements in a loop, assembling an nlr-tree by putting one element at a time. Doing so may cause arbitrary reshuffling of nodes on every put, since there is no guarantee for the order of insertions relative to +gor/+mor orderings.

This PR adds a fast path for `+gas:by/+gas:in` if the input tree is empty. The fast path is basically quicksort, where the pivot is chosen by taking a "mor"-most element, and the partions are made with `+gor`.

Extra attention was payed to `+gas:by` jet to make sure that for each key only the last key-value pair is taken: order of partitions is preserved, and the last key-value pair is used as a pivot, keys being equal.

Tested by setting `ice` of jets to `c3n`, then booting and running the test suite.

When comparing performance I saw ~30% improvement for the fast path.