### PR TITLE
unix: per-file desk auto-sync (%wath/%wend)

### DIFF
--- a/pkg/c3/motes.h
+++ b/pkg/c3/motes.h
@@ -1309,6 +1309,7 @@
 #   define c3__warn   c3_s4('w','a','r','n')
 #   define c3__warx   c3_s4('w','a','r','x')
 #   define c3__wash   c3_s4('w','a','s','h')
+#   define c3__wath   c3_s4('w','a','t','h')
 #   define c3__watt   c3_s4('w','a','t','t')
 #   define c3__way    c3_s3('w','a','y')
 #   define c3__weak   c3_s4('w','e','a','k')

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -99,12 +99,21 @@ struct _u3_unix;
     }* ent_u;                           //  entry array
   } u3_usyc;
 
+/* u3_umug: a persisted mug-cache entry.
+*/
+  typedef struct _u3_umug {
+    c3_c*             pax_c;            //  absolute unix path
+    c3_w              mug_w;            //  mug of content at last sync
+  } u3_umug;
+
 /* u3_ufil: synchronized mount point.
 */
   typedef struct _u3_umon {
     u3_udir          dir_u;             //  root directory, must be first
     c3_c*            nam_c;             //  mount point name
     c3_o             syn_o;             //  auto-sync (fs-event watch) on
+    u3_umug*         lod_u;             //  mug cache loaded from disk
+    c3_w             lod_w;             //  entries in lod_u
     struct _u3_umon* nex_u;             //  internal list
   } u3_umon;
 
@@ -145,6 +154,21 @@ _unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u);
 
 static void
 _unix_drop_mugs(u3_unix* unx_u, u3_umon* mon_u);
+
+static u3_umon*
+_unix_node_mount(u3_unix* unx_u, u3_unod* nod_u);
+
+static void
+_unix_seed_mug(struct _u3_unix* unx_u, u3_ufil* fil_u);
+
+static void
+_unix_free_lod(u3_umon* mon_u);
+
+static void
+_unix_lod_del(struct _u3_unix* unx_u, u3_ufil* fil_u);
+
+static void
+_unix_lod_put(u3_umon* mon_u, const c3_c* pax_c, c3_w mug_w);
 
 /* u3_unix_cane(): true iff (unix) path is canonical.
 */
@@ -632,6 +656,8 @@ _unix_get_mount_point(u3_unix* unx_u, u3_noun mon)
     mon_u = c3_malloc(sizeof(u3_umon));
     mon_u->nam_c = nam_c;
     mon_u->syn_o = c3n;
+    mon_u->lod_u = NULL;
+    mon_u->lod_w = 0;
     mon_u->dir_u.dir = c3y;
     mon_u->dir_u.dry = c3n;
     mon_u->dir_u.pax_c = strdup(unx_u->pax_c);
@@ -845,6 +871,7 @@ _unix_free_node(u3_unix* unx_u, u3_unod* nod_u, c3_t del_t)
   else {
     can = u3nc(u3nc(_unix_string_to_path(unx_u, nod_u->pax_c), u3_nul),
                u3_nul);
+    _unix_lod_del(unx_u, (u3_ufil *)nod_u);
     _unix_free_file((u3_ufil *)nod_u, del_t);
   }
 
@@ -870,6 +897,7 @@ _unix_free_mount_point(u3_unix* unx_u, u3_umon* mon_u, c3_t del_t)
   }
 
   _unix_watch_disarm(&mon_u->dir_u);
+  _unix_free_lod(mon_u);
 
   c3_free(mon_u->dir_u.pax_c);
   c3_free(mon_u->nam_c);
@@ -952,6 +980,7 @@ _unix_watch_file(u3_unix* unx_u, u3_ufil* fil_u, u3_udir* par_u, c3_c* pax_c)
   if ( par_u ) {
     fil_u->nex_u = par_u->kid_u;
     par_u->kid_u = (u3_unod*) fil_u;
+    _unix_seed_mug(unx_u, fil_u);
   }
 }
 
@@ -1338,22 +1367,22 @@ _unix_mug_pax(u3_unix* unx_u, u3_umon* mon_u, const c3_c* suf_c)
 
 #define SYNC_MUG_HEAD "vere-sync-mug-v1"
 
-/* _unix_save_mugs_dir(): write mug cache lines for a directory tree.
+/* _unix_fold_mugs_dir(): merge a directory tree's mugs into the cache.
 */
 static void
-_unix_save_mugs_dir(FILE* fil_u, u3_udir* dir_u, c3_w bas_w)
+_unix_fold_mugs_dir(u3_umon* mon_u, u3_udir* dir_u)
 {
   u3_unod* nod_u;
 
   for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
     if ( c3y == nod_u->dir ) {
-      _unix_save_mugs_dir(fil_u, (u3_udir*)nod_u, bas_w);
+      _unix_fold_mugs_dir(mon_u, (u3_udir*)nod_u);
     }
     else {
       u3_ufil* fic_u = (u3_ufil*)nod_u;
 
       if ( fic_u->gum_w ) {
-        fprintf(fil_u, "%08x %s\n", fic_u->gum_w, fic_u->pax_c + bas_w + 1);
+        _unix_lod_put(mon_u, fic_u->pax_c, fic_u->gum_w);
       }
     }
   }
@@ -1361,6 +1390,10 @@ _unix_save_mugs_dir(FILE* fil_u, u3_udir* dir_u, c3_w bas_w)
 
 /* _unix_save_mugs(): persist a mount point's synced mugs, so that
 **                    a post-restart scan only sends real changes.
+**
+**  the node tree is built lazily, so it may cover only part of the
+**  mount; tree state is merged into the cache loaded at startup
+**  (updated as files are deleted) rather than replacing it.
 */
 static void
 _unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u)
@@ -1368,6 +1401,8 @@ _unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u)
   c3_c* pax_c = _unix_mug_pax(unx_u, mon_u, "");
   c3_c* tmp_c = _unix_mug_pax(unx_u, mon_u, ".tmp");
   FILE* fil_u = fopen(tmp_c, "w");
+  c3_w  bas_w = strlen(unx_u->pax_c);
+  c3_w  i_w;
 
   if ( !fil_u ) {
     u3l_log("unix: can't write mug cache %s: %s", tmp_c, strerror(errno));
@@ -1376,8 +1411,15 @@ _unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u)
     return;
   }
 
+  _unix_fold_mugs_dir(mon_u, &mon_u->dir_u);
+
   fprintf(fil_u, "%s\n", SYNC_MUG_HEAD);
-  _unix_save_mugs_dir(fil_u, &mon_u->dir_u, strlen(unx_u->pax_c));
+
+  for ( i_w = 0; i_w < mon_u->lod_w; i_w++ ) {
+    fprintf(fil_u, "%08x %s\n",
+            mon_u->lod_u[i_w].mug_w,
+            mon_u->lod_u[i_w].pax_c + bas_w + 1);
+  }
 
   if ( fclose(fil_u) || (0 != rename(tmp_c, pax_c)) ) {
     u3l_log("unix: can't save mug cache %s: %s", pax_c, strerror(errno));
@@ -1399,7 +1441,35 @@ _unix_drop_mugs(u3_unix* unx_u, u3_umon* mon_u)
   c3_free(pax_c);
 }
 
-/* _unix_load_mugs(): seed gum_w from the persisted mug cache.
+/* _unix_lod_cmp(): mug cache comparator, by path.
+*/
+static c3_i
+_unix_lod_cmp(const void* lef_v, const void* rit_v)
+{
+  return strcmp(((const u3_umug*)lef_v)->pax_c,
+                ((const u3_umug*)rit_v)->pax_c);
+}
+
+/* _unix_free_lod(): free a mount point's loaded mug cache.
+*/
+static void
+_unix_free_lod(u3_umon* mon_u)
+{
+  c3_w i_w;
+
+  for ( i_w = 0; i_w < mon_u->lod_w; i_w++ ) {
+    c3_free(mon_u->lod_u[i_w].pax_c);
+  }
+  c3_free(mon_u->lod_u);
+  mon_u->lod_u = NULL;
+  mon_u->lod_w = 0;
+}
+
+/* _unix_load_mugs(): load the persisted mug cache for a mount point.
+**
+**  the node tree is built lazily by scans, so entries can't be
+**  applied here; they're kept on the mount point and consulted as
+**  file nodes are created (_unix_watch_file).
 */
 static void
 _unix_load_mugs(u3_unix* unx_u, u3_umon* mon_u)
@@ -1408,6 +1478,9 @@ _unix_load_mugs(u3_unix* unx_u, u3_umon* mon_u)
   FILE* fil_u = fopen(pax_c, "r");
   c3_c  lin_c[8192];
   c3_w  bas_w = strlen(unx_u->pax_c);
+  c3_w  siz_w = 0;
+
+  _unix_free_lod(mon_u);
 
   if ( !fil_u ) {
     c3_free(pax_c);
@@ -1432,36 +1505,126 @@ _unix_load_mugs(u3_unix* unx_u, u3_umon* mon_u)
       lin_c[--len_w] = '\0';
     }
 
-    //  "%08x <path>": malformed lines abort the load; mugs already
-    //  applied are only hints, so this is safe
+    //  "%08x <path>": a malformed line discards the whole cache,
+    //  which safely degrades to a full reconciliation
     //
     if ( (len_w < 10) || (' ' != lin_c[8])
        || (1 != sscanf(lin_c, "%8x", &mug_w)) )
     {
       u3l_log("unix: discarding malformed mug cache %s", pax_c);
+      _unix_free_lod(mon_u);
       break;
     }
 
     rel_c = lin_c + 9;
 
+    if ( mon_u->lod_w == siz_w ) {
+      siz_w = siz_w ? (2 * siz_w) : 256;
+      mon_u->lod_u = c3_realloc(mon_u->lod_u, siz_w * sizeof(u3_umug));
+    }
+
     {
       c3_w  abs_w = bas_w + 1 + strlen(rel_c) + 1;
       c3_c* abs_c = c3_malloc(abs_w);
-      u3_unod* nod_u;
 
       snprintf(abs_c, abs_w, "%s/%s", unx_u->pax_c, rel_c);
-      nod_u = _unix_find_node(&mon_u->dir_u, abs_c);
-
-      if ( nod_u && (c3n == nod_u->dir) ) {
-        ((u3_ufil*)nod_u)->gum_w = mug_w;
-      }
-
-      c3_free(abs_c);
+      mon_u->lod_u[mon_u->lod_w].pax_c = abs_c;
+      mon_u->lod_u[mon_u->lod_w].mug_w = mug_w;
+      mon_u->lod_w++;
     }
+  }
+
+  if ( mon_u->lod_w ) {
+    qsort(mon_u->lod_u, mon_u->lod_w, sizeof(u3_umug), _unix_lod_cmp);
   }
 
   fclose(fil_u);
   c3_free(pax_c);
+}
+
+/* _unix_seed_mug(): seed a new file node's mug from the loaded cache.
+*/
+static void
+_unix_seed_mug(u3_unix* unx_u, u3_ufil* fil_u)
+{
+  u3_umon* mon_u = _unix_node_mount(unx_u, (u3_unod*)fil_u);
+  u3_umug  key_u;
+  u3_umug* fon_u;
+
+  if ( !mon_u || !mon_u->lod_w ) {
+    return;
+  }
+
+  key_u.pax_c = fil_u->pax_c;
+  fon_u = bsearch(&key_u, mon_u->lod_u, mon_u->lod_w,
+                  sizeof(u3_umug), _unix_lod_cmp);
+
+  if ( fon_u ) {
+    fil_u->gum_w = fon_u->mug_w;
+  }
+}
+
+/* _unix_lod_put(): update or insert a mug cache entry.
+*/
+static void
+_unix_lod_put(u3_umon* mon_u, const c3_c* pax_c, c3_w mug_w)
+{
+  u3_umug key_u;
+  c3_w    i_w;
+
+  key_u.pax_c = (c3_c*)pax_c;
+
+  if ( mon_u->lod_w ) {
+    u3_umug* fon_u = bsearch(&key_u, mon_u->lod_u, mon_u->lod_w,
+                             sizeof(u3_umug), _unix_lod_cmp);
+    if ( fon_u ) {
+      fon_u->mug_w = mug_w;
+      return;
+    }
+  }
+
+  //  insert, keeping the array sorted
+  //
+  mon_u->lod_u = c3_realloc(mon_u->lod_u,
+                            (1 + mon_u->lod_w) * sizeof(u3_umug));
+
+  for ( i_w = mon_u->lod_w;
+        i_w && (0 < strcmp(mon_u->lod_u[i_w - 1].pax_c, pax_c));
+        i_w-- )
+  {
+    mon_u->lod_u[i_w] = mon_u->lod_u[i_w - 1];
+  }
+
+  mon_u->lod_u[i_w].pax_c = strdup(pax_c);
+  mon_u->lod_u[i_w].mug_w = mug_w;
+  mon_u->lod_w++;
+}
+
+/* _unix_lod_del(): remove a deleted file from its mount's mug cache.
+*/
+static void
+_unix_lod_del(u3_unix* unx_u, u3_ufil* fil_u)
+{
+  u3_umon* mon_u = _unix_node_mount(unx_u, (u3_unod*)fil_u);
+  u3_umug  key_u;
+  u3_umug* fon_u;
+
+  if ( !mon_u || !mon_u->lod_w ) {
+    return;
+  }
+
+  key_u.pax_c = fil_u->pax_c;
+  fon_u = bsearch(&key_u, mon_u->lod_u, mon_u->lod_w,
+                  sizeof(u3_umug), _unix_lod_cmp);
+
+  if ( fon_u ) {
+    c3_w i_w = fon_u - mon_u->lod_u;
+
+    c3_free(fon_u->pax_c);
+    memmove(fon_u, fon_u + 1,
+            (mon_u->lod_w - i_w - 1) * sizeof(u3_umug));
+    mon_u->lod_w--;
+  }
 }
 
 static u3_noun _unix_update_node(u3_unix* unx_u, u3_unod* nod_u);
@@ -2112,8 +2275,8 @@ u3_unix_ef_hill(u3_unix* unx_u, u3_noun hil)
 
   for ( mon = hil; c3y == u3du(mon); mon = u3t(mon) ) {
     u3_umon* mon_u = _unix_get_mount_point(unx_u, u3k(u3h(mon)));
-    _unix_scan_mount_point(unx_u, mon_u);
     _unix_load_mugs(unx_u, mon_u);
+    _unix_scan_mount_point(unx_u, mon_u);
   }
 
   unx_u->car_u.liv_o = c3y;

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -1480,7 +1480,16 @@ _unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u)
             mon_u->lod_u[i_w].pax_c + bas_w + 1);
   }
 
-  if ( fclose(fil_u) || (0 != rename(tmp_c, pax_c)) ) {
+  //  atomically replace the previous cache.  mingw's rename() fails
+  //  if the destination exists, so use MoveFileEx on windows.
+  //
+#ifdef U3_OS_windows
+  if ( fclose(fil_u)
+    || !MoveFileExA(tmp_c, pax_c, MOVEFILE_REPLACE_EXISTING) )
+#else
+  if ( fclose(fil_u) || (0 != rename(tmp_c, pax_c)) )
+#endif
+  {
     u3l_log("unix: can't save mug cache %s: %s", pax_c, strerror(errno));
     c3_unlink(tmp_c);
   }

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -112,6 +112,7 @@ struct _u3_unix;
 */
   typedef struct _u3_usyc {
     struct _u3_unix*  unx_u;            //  driver backpointer
+    c3_c*             nam_c;            //  mount point name
     c3_w              len_w;            //  entries used
     c3_w              siz_w;            //  entries allocated
     struct _u3_usye {
@@ -190,8 +191,8 @@ _unix_free_lod(u3_umon* mon_u);
 static void
 _unix_lod_del(struct _u3_unix* unx_u, u3_ufil* fil_u);
 
-static void
-_unix_lod_put(u3_umon* mon_u, const c3_c* pax_c, c3_w mug_w);
+static c3_i
+_unix_lod_cmp(const void* lef_v, const void* rit_v);
 
 /* u3_unix_cane(): true iff (unix) path is canonical.
 */
@@ -543,9 +544,7 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
     mug_w = 0;
   }
   else {
-    //  mug the full octet-stream as written, so that a subsequent
-    //  scan of the file (which mugs all [siz_w] bytes, including
-    //  trailing zeros) compares equal
+    //  mug all [siz_w] bytes, matching a later scan of the file
     //
     mug_w = u3r_mug_bytes(dat_y, siz_w);
   }
@@ -627,9 +626,7 @@ _unix_write_file_soft(u3_ufil* fil_u, u3_noun mim)
   c3_free(old_y);
 
   if ( old_w == _unix_mim_mug(mim) ) {
-    //  the disk file already has clay's contents: nothing to write.
-    //  this is the common case when the file just came in via %into
-    //  and clay is echoing it back out
+    //  the disk file already has clay's contents
     //
     fil_u->gum_w = old_w;
     u3z(mim);
@@ -782,7 +779,7 @@ static u3_noun _unix_free_node(u3_unix* unx_u, u3_unod* nod_u, c3_t del_t);
 static void
 _unix_watch_close_cb(uv_handle_t* han_u)
 {
-  //  the handle is the first member of u3_uwat
+  //  frees the containing u3_uwat; the handle is its first member
   //
   c3_free(han_u);
 }
@@ -1145,9 +1142,7 @@ _unix_event_cb(uv_fs_event_t* eve_u,
   u3_udir* dir_u = wat_u->dir_u;
   u3_unix* unx_u = wat_u->unx_u;
 
-  //  watcher is pending close
-  //
-  if ( !dir_u ) {
+  if ( !dir_u ) {  //  watcher is pending close
     return;
   }
 
@@ -1182,7 +1177,7 @@ _unix_event_cb(uv_fs_event_t* eve_u,
       }
     }
     else {
-      //  we don't know what changed: re-examine the whole subtree
+      //  no filename from the platform: re-examine the whole subtree
       //
       _unix_mark_wet(dir_u);
     }
@@ -1206,10 +1201,8 @@ _unix_event_cb(uv_fs_event_t* eve_u,
     }
   }
 
-  //  debounce until quiescence: each change extends the window, so
-  //  multi-step editor saves (write-rename, delete-write) coalesce
-  //  into one scan; but never delay more than SYNC_CAP_MS past the
-  //  first change, so a busy writer can't starve sync
+  //  debounce until quiescence, capped so a busy writer can't
+  //  starve sync (see SYNC_QUIET_MS/SYNC_CAP_MS)
   //
   {
     c3_d now_d = uv_now(u3L);
@@ -1341,6 +1334,7 @@ _unix_sync_free(u3_usyc* syc_u)
   for ( i_w = 0; i_w < syc_u->len_w; i_w++ ) {
     c3_free(syc_u->ent_u[i_w].pax_c);
   }
+  c3_free(syc_u->nam_c);
   c3_free(syc_u->ent_u);
   c3_free(syc_u);
 }
@@ -1355,20 +1349,26 @@ _unix_sync_done(u3_usyc* syc_u)
   u3_umon* mon_u;
   c3_w     i_w;
 
+  //  the mount may have been deleted while the event was in flight
+  //
+  for ( mon_u = unx_u->mon_u;
+        mon_u && (0 != strcmp(mon_u->nam_c, syc_u->nam_c));
+        mon_u = mon_u->nex_u )
+  { }
+
+  if ( !mon_u ) {
+    return;
+  }
+
   for ( i_w = 0; i_w < syc_u->len_w; i_w++ ) {
-    for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
-      u3_unod* nod_u = _unix_find_node(&mon_u->dir_u,
-                                       syc_u->ent_u[i_w].pax_c);
-      if ( nod_u && (c3n == nod_u->dir) ) {
-        ((u3_ufil*)nod_u)->gum_w = syc_u->ent_u[i_w].mug_w;
-        break;
-      }
+    u3_unod* nod_u = _unix_find_node(&mon_u->dir_u,
+                                     syc_u->ent_u[i_w].pax_c);
+    if ( nod_u && (c3n == nod_u->dir) ) {
+      ((u3_ufil*)nod_u)->gum_w = syc_u->ent_u[i_w].mug_w;
     }
   }
 
-  for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
-    _unix_save_mugs(unx_u, mon_u);
-  }
+  _unix_save_mugs(unx_u, mon_u);
 }
 
 /* _unix_sync_news(): notification of %into event status.
@@ -1426,33 +1426,83 @@ _unix_mug_pax(u3_unix* unx_u, u3_umon* mon_u, const c3_c* suf_c)
 
 #define SYNC_MUG_HEAD "vere-sync-mug-v1"
 
-/* _unix_fold_mugs_dir(): merge a directory tree's mugs into the cache.
+/* _unix_grab_mugs_dir(): collect a directory tree's mugs, unsorted.
 */
 static void
-_unix_fold_mugs_dir(u3_umon* mon_u, u3_udir* dir_u)
+_unix_grab_mugs_dir(u3_udir* dir_u, u3_umug** ent_u, c3_w* len_w, c3_w* siz_w)
 {
   u3_unod* nod_u;
 
   for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
     if ( c3y == nod_u->dir ) {
-      _unix_fold_mugs_dir(mon_u, (u3_udir*)nod_u);
+      _unix_grab_mugs_dir((u3_udir*)nod_u, ent_u, len_w, siz_w);
     }
     else {
       u3_ufil* fic_u = (u3_ufil*)nod_u;
 
       if ( fic_u->gum_w ) {
-        _unix_lod_put(mon_u, fic_u->pax_c, fic_u->gum_w);
+        if ( *len_w == *siz_w ) {
+          *siz_w = *siz_w ? (2 * *siz_w) : 256;
+          *ent_u = c3_realloc(*ent_u, *siz_w * sizeof(**ent_u));
+        }
+        (*ent_u)[*len_w].pax_c = strdup(fic_u->pax_c);
+        (*ent_u)[*len_w].mug_w = fic_u->gum_w;
+        (*len_w)++;
       }
     }
   }
 }
 
+/* _unix_fold_mugs(): merge the node tree's mugs into the cache.
+**
+**  the tree is built lazily, so it may cover only part of the mount;
+**  tree state takes precedence over cache entries for the same path.
+*/
+static void
+_unix_fold_mugs(u3_umon* mon_u)
+{
+  u3_umug* tre_u = NULL;
+  c3_w     tre_w = 0, sat_w = 0;
+
+  _unix_grab_mugs_dir(&mon_u->dir_u, &tre_u, &tre_w, &sat_w);
+
+  if ( !tre_w ) {
+    return;
+  }
+
+  qsort(tre_u, tre_w, sizeof(u3_umug), _unix_lod_cmp);
+
+  {
+    u3_umug* new_u = c3_malloc((tre_w + mon_u->lod_w) * sizeof(u3_umug));
+    c3_w     new_w = 0, t_w = 0, l_w = 0;
+
+    while ( (t_w < tre_w) || (l_w < mon_u->lod_w) ) {
+      c3_i cmp_i = (t_w == tre_w)        ?  1
+                 : (l_w == mon_u->lod_w) ? -1
+                 : strcmp(tre_u[t_w].pax_c, mon_u->lod_u[l_w].pax_c);
+
+      if ( cmp_i < 0 ) {
+        new_u[new_w++] = tre_u[t_w++];
+      }
+      else if ( cmp_i > 0 ) {
+        new_u[new_w++] = mon_u->lod_u[l_w++];
+      }
+      else {
+        new_u[new_w++] = tre_u[t_w++];
+        c3_free(mon_u->lod_u[l_w].pax_c);
+        l_w++;
+      }
+    }
+
+    c3_free(tre_u);
+    c3_free(mon_u->lod_u);
+    mon_u->lod_u = new_u;
+    mon_u->lod_w = new_w;
+  }
+}
+
 /* _unix_save_mugs(): persist a mount point's synced mugs, so that
 **                    a post-restart scan only sends real changes.
-**
-**  the node tree is built lazily, so it may cover only part of the
-**  mount; tree state is merged into the cache loaded at startup
-**  (updated as files are deleted) rather than replacing it.
 */
 static void
 _unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u)
@@ -1470,7 +1520,7 @@ _unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u)
     return;
   }
 
-  _unix_fold_mugs_dir(mon_u, &mon_u->dir_u);
+  _unix_fold_mugs(mon_u);
 
   fprintf(fil_u, "%s\n", SYNC_MUG_HEAD);
 
@@ -1632,42 +1682,6 @@ _unix_seed_mug(u3_unix* unx_u, u3_ufil* fil_u)
   }
 }
 
-/* _unix_lod_put(): update or insert a mug cache entry.
-*/
-static void
-_unix_lod_put(u3_umon* mon_u, const c3_c* pax_c, c3_w mug_w)
-{
-  u3_umug key_u;
-  c3_w    i_w;
-
-  key_u.pax_c = (c3_c*)pax_c;
-
-  if ( mon_u->lod_w ) {
-    u3_umug* fon_u = bsearch(&key_u, mon_u->lod_u, mon_u->lod_w,
-                             sizeof(u3_umug), _unix_lod_cmp);
-    if ( fon_u ) {
-      fon_u->mug_w = mug_w;
-      return;
-    }
-  }
-
-  //  insert, keeping the array sorted
-  //
-  mon_u->lod_u = c3_realloc(mon_u->lod_u,
-                            (1 + mon_u->lod_w) * sizeof(u3_umug));
-
-  for ( i_w = mon_u->lod_w;
-        i_w && (0 < strcmp(mon_u->lod_u[i_w - 1].pax_c, pax_c));
-        i_w-- )
-  {
-    mon_u->lod_u[i_w] = mon_u->lod_u[i_w - 1];
-  }
-
-  mon_u->lod_u[i_w].pax_c = strdup(pax_c);
-  mon_u->lod_u[i_w].mug_w = mug_w;
-  mon_u->lod_w++;
-}
-
 /* _unix_lod_del(): remove a deleted file from its mount's mug cache.
 */
 static void
@@ -1697,6 +1711,25 @@ _unix_lod_del(u3_unix* unx_u, u3_ufil* fil_u)
 
 static u3_noun _unix_update_node(u3_unix* unx_u, u3_unod* nod_u);
 
+/* _unix_doom_hold(): a file is missing; hold its deletion until it
+**                     has stayed missing through the grace period.
+**
+**  editors often delete a file moments before rewriting it, so a
+**  deletion only syncs once it survives a recheck.
+*/
+static c3_t
+_unix_doom_hold(u3_ufil* fil_u)
+{
+  c3_d now_d = uv_now(u3L);
+
+  if ( !fil_u->dum_d ) {
+    fil_u->dum_d = now_d;
+    return 1;
+  }
+
+  return (now_d - fil_u->dum_d) < SYNC_GRACE_MS;
+}
+
 /* _unix_update_file(): update file, producing list of changes
 **
 **  when scanning through files, if dry, do nothing. otherwise,
@@ -1724,18 +1757,8 @@ _unix_update_file(u3_unix* unx_u, u3_ufil* fil_u)
 
   if ( fid_i < 0 || fstat(fid_i, &buf_u) < 0 ) {
     if ( ENOENT == errno ) {
-      c3_d now_d = uv_now(u3L);
-
-      //  deletion grace: editors often delete a file moments before
-      //  rewriting it. only emit the deletion once the file has
-      //  stayed missing through a recheck.
-      //
-      if ( !fil_u->dum_d || ((now_d - fil_u->dum_d) < SYNC_GRACE_MS) ) {
+      if ( _unix_doom_hold(fil_u) ) {
         u3_udir* par_u;
-
-        if ( !fil_u->dum_d ) {
-          fil_u->dum_d = now_d;
-        }
 
         //  stay wet, and keep ancestors wet, so the recheck
         //  scan descends back to this node
@@ -1759,8 +1782,6 @@ _unix_update_file(u3_unix* unx_u, u3_ufil* fil_u)
     }
   }
 
-  //  the file exists: clear any pending doom
-  //
   fil_u->dum_d = 0;
 
   len_ws = buf_u.st_size;
@@ -1849,18 +1870,12 @@ _unix_update_dir(u3_unix* unx_u, u3_udir* dir_u)
           c3_i  fid_i = c3_open(nod_u->pax_c, O_RDONLY, 0644);
 
           if ( (fid_i < 0) || (fstat(fid_i, &buf_u) < 0) ) {
-            u3_ufil* fil_u = (u3_ufil*)nod_u;
-
             if ( ENOENT != errno ) {
               u3l_log("_unix_update_dir: error opening file %s: %s",
                       nod_u->pax_c, strerror(errno));
             }
-            else if ( !fil_u->dum_d
-                   || ((uv_now(u3L) - fil_u->dum_d) < SYNC_GRACE_MS) )
-            {
-              //  deletion grace: leave the node in place; the file
-              //  pass will doom it and schedule a recheck
-              //
+            else if ( _unix_doom_hold((u3_ufil*)nod_u) ) {
+              unx_u->dum_o = c3y;
               nod_u = nod_u->nex_u;
               continue;
             }
@@ -2011,6 +2026,7 @@ _unix_update_mount(u3_unix* unx_u, u3_umon* mon_u, u3_noun all)
     u3_assert( !unx_u->pen_u );
     syc_u = c3_calloc(sizeof(*syc_u));
     syc_u->unx_u = unx_u;
+    syc_u->nam_c = strdup(mon_u->nam_c);
     unx_u->pen_u = syc_u;
 
     for ( nod_u = mon_u->dir_u.kid_u; nod_u; nod_u = nod_u->nex_u ) {
@@ -2409,8 +2425,6 @@ u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, u3_noun all)
     }
     c3_free(nam_c);
     if ( mon_u ) {
-      //  a commit re-examines the whole mount
-      //
       _unix_mark_wet(&mon_u->dir_u);
       _unix_update_mount(unx_u, mon_u, all);
       _unix_doom_recheck(unx_u);

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -59,11 +59,16 @@ struct _u3_unix;
 **                    propagates a transient deletion
 **   SYNC_RECHECK_MS: how soon to recheck files awaiting the grace
 **                    period (must exceed SYNC_GRACE_MS)
+**   SYNC_SWEEP_MS:   backstop: rescan auto-synced mounts at least
+**                    this often, in case an fs event was dropped
+**                    (inotify queue overflow, unwatchable edge
+**                    cases, etc)
 */
 #define SYNC_QUIET_MS    100
 #define SYNC_CAP_MS     1000
 #define SYNC_GRACE_MS    300
 #define SYNC_RECHECK_MS  350
+#define SYNC_SWEEP_MS  30000
 
 /* u3_unod: file or directory.
 */
@@ -150,6 +155,7 @@ struct _u3_unix;
     c3_o        dyr;                    //  ready to update
     u3_noun     sat;                    //  (sane %ta) handle
     uv_timer_t* syt_u;                  //  auto-sync debounce timer
+    uv_timer_t* swt_u;                  //  auto-sync backstop sweep timer
     c3_d        fir_d;                  //  debounce window start (ms)
     c3_o        dum_o;                  //  doomed files await recheck
     u3_usyc*    pen_u;                  //  scan accumulator, if scanning
@@ -1128,6 +1134,37 @@ _unix_time_cb(uv_timer_t* tim_u)
   }
 
   _unix_doom_recheck(unx_u);
+}
+
+/* _unix_sweep_cb(): periodic backstop sweep.
+**
+**  fs events can be dropped (inotify queue overflow, exhausted
+**  watch descriptors, platform edge cases), so periodically treat
+**  every auto-synced mount as if an event had fired for its whole
+**  tree.  the scan re-reads wet files but only syncs those whose
+**  contents changed, so a quiescent tree produces no event.
+*/
+static void
+_unix_sweep_cb(uv_timer_t* tim_u)
+{
+  u3_unix* unx_u = tim_u->data;
+  u3_umon* mon_u;
+  c3_o     wet_o = c3n;
+
+  for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
+    if ( c3y == mon_u->syn_o ) {
+      _unix_mark_wet(&mon_u->dir_u);
+      wet_o = c3y;
+    }
+  }
+
+  //  schedule the scan through the debounce path, so a sweep
+  //  landing mid-save coalesces with the save's own events
+  //
+  if ( (c3y == wet_o) && !uv_is_active((uv_handle_t*)unx_u->syt_u) ) {
+    unx_u->fir_d = uv_now(u3L);
+    uv_timer_start(unx_u->syt_u, _unix_time_cb, SYNC_QUIET_MS, 0);
+  }
 }
 
 /* _unix_event_cb(): fs event on a watched directory.
@@ -2549,6 +2586,7 @@ _unix_io_exit(u3_auto* car_u)
   }
 
   uv_close((uv_handle_t*)unx_u->syt_u, _unix_timer_close_cb);
+  uv_close((uv_handle_t*)unx_u->swt_u, _unix_timer_close_cb);
 
   u3z(unx_u->sat);
   c3_free(unx_u->pax_c);
@@ -2573,6 +2611,11 @@ u3_unix_io_init(u3_pier* pir_u)
   unx_u->syt_u = c3_malloc(sizeof(*unx_u->syt_u));
   uv_timer_init(u3L, unx_u->syt_u);
   unx_u->syt_u->data = unx_u;
+
+  unx_u->swt_u = c3_malloc(sizeof(*unx_u->swt_u));
+  uv_timer_init(u3L, unx_u->swt_u);
+  unx_u->swt_u->data = unx_u;
+  uv_timer_start(unx_u->swt_u, _unix_sweep_cb, SYNC_SWEEP_MS, SYNC_SWEEP_MS);
 
   u3_auto* car_u = &unx_u->car_u;
   car_u->nam_m = c3__unix;

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -43,6 +43,7 @@
 struct _u3_umon;
 struct _u3_udir;
 struct _u3_ufil;
+struct _u3_unix;
 
 /* u3_unod: file or directory.
 */
@@ -74,13 +75,36 @@ struct _u3_ufil;
     struct _u3_udir*  par_u;            //  parent
     struct _u3_unod*  nex_u;            //  internal list
     u3_unod*          kid_u;            //  subnodes
+    struct _u3_uwat*  wat_u;            //  fs-event watcher, if any
   } u3_udir;
+
+/* u3_uwat: fs-event watcher on a directory.
+*/
+  typedef struct _u3_uwat {
+    uv_fs_event_t     eve_u;            //  libuv handle, must be first
+    struct _u3_unix*  unx_u;            //  driver backpointer
+    struct _u3_udir*  dir_u;            //  watched directory, 0 once freed
+  } u3_uwat;
+
+/* u3_usyc: files included in an injected %into event, used to
+**          update mug state once the event commits.
+*/
+  typedef struct _u3_usyc {
+    struct _u3_unix*  unx_u;            //  driver backpointer
+    c3_w              len_w;            //  entries used
+    c3_w              siz_w;            //  entries allocated
+    struct _u3_usye {
+      c3_c*           pax_c;            //  absolute unix path
+      c3_w            mug_w;            //  mug of content sent
+    }* ent_u;                           //  entry array
+  } u3_usyc;
 
 /* u3_ufil: synchronized mount point.
 */
   typedef struct _u3_umon {
     u3_udir          dir_u;             //  root directory, must be first
     c3_c*            nam_c;             //  mount point name
+    c3_o             syn_o;             //  auto-sync (fs-event watch) on
     struct _u3_umon* nex_u;             //  internal list
   } u3_umon;
 
@@ -94,6 +118,8 @@ struct _u3_ufil;
     c3_o        alm;                    //  timer set
     c3_o        dyr;                    //  ready to update
     u3_noun     sat;                    //  (sane %ta) handle
+    uv_timer_t* syt_u;                  //  auto-sync debounce timer
+    u3_usyc*    pen_u;                  //  scan accumulator, if scanning
 #ifdef SYNCLOG
     c3_w         lot_w;                 //  sync-slot
     struct _u3_sylo {
@@ -107,6 +133,18 @@ struct _u3_ufil;
 
 void
 u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, u3_noun all);
+
+static void
+_unix_update_mount(u3_unix* unx_u, u3_umon* mon_u, u3_noun all);
+
+static void
+_unix_mark_wet(u3_udir* dir_u);
+
+static void
+_unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u);
+
+static void
+_unix_drop_mugs(u3_unix* unx_u, u3_umon* mon_u);
 
 /* u3_unix_cane(): true iff (unix) path is canonical.
 */
@@ -447,7 +485,7 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
   len_w = u3r_met(3, dat);
   dat_y = c3_calloc(siz_w);
 
-  u3r_bytes(0, len_w, dat_y, dat);
+  u3r_bytes(0, c3_min(len_w, siz_w), dat_y, dat);
   u3z(mim);
 
   rit_w = write(fid_i, dat_y, siz_w);
@@ -458,10 +496,34 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
     mug_w = 0;
   }
   else {
-    mug_w = u3r_mug_bytes(dat_y, len_w);
+    //  mug the full octet-stream as written, so that a subsequent
+    //  scan of the file (which mugs all [siz_w] bytes, including
+    //  trailing zeros) compares equal
+    //
+    mug_w = u3r_mug_bytes(dat_y, siz_w);
   }
 
   close(fid_i);
+  c3_free(dat_y);
+
+  return mug_w;
+}
+
+/* _unix_mim_mug(): mug of a mime cell's octet-stream, as bytes at its
+**                  declared length (a noun mug would drop trailing zeros).
+**                  retains [mim].
+*/
+static c3_w
+_unix_mim_mug(u3_noun mim)
+{
+  u3_noun dat = u3t(u3t(mim));
+  c3_w  siz_w = u3h(u3t(mim));
+  c3_w  len_w = u3r_met(3, dat);
+  c3_y* dat_y = c3_calloc((siz_w ? siz_w : 1));
+  c3_w  mug_w;
+
+  u3r_bytes(0, c3_min(len_w, siz_w), dat_y, dat);
+  mug_w = u3r_mug_bytes(dat_y, siz_w);
   c3_free(dat_y);
 
   return mug_w;
@@ -515,15 +577,27 @@ _unix_write_file_soft(u3_ufil* fil_u, u3_noun mim)
   }
 
   old_w = u3r_mug_bytes(old_y, len_ws);
+  c3_free(old_y);
 
-  if ( old_w != fil_u->gum_w ) {
-    fil_u->gum_w = u3r_mug(u3t(u3t(mim))); // XXX this might fail with
-    c3_free(old_y);                           //     trailing zeros
+  if ( old_w == _unix_mim_mug(mim) ) {
+    //  the disk file already has clay's contents: nothing to write.
+    //  this is the common case when the file just came in via %into
+    //  and clay is echoing it back out
+    //
+    fil_u->gum_w = old_w;
     u3z(mim);
     return;
   }
 
-  c3_free(old_y);
+  if ( old_w != fil_u->gum_w ) {
+    //  the file changed on disk since we last synced it; leave the
+    //  edit alone, but record the mug of clay's contents so the
+    //  disk file is seen as changed and synced back in
+    //
+    fil_u->gum_w = _unix_mim_mug(mim);
+    u3z(mim);
+    return;
+  }
 
 _unix_write_file_soft_go:
   fil_u->gum_w = _unix_write_file_hard(fil_u->pax_c, mim);
@@ -557,12 +631,14 @@ _unix_get_mount_point(u3_unix* unx_u, u3_noun mon)
   if ( !mon_u ) {
     mon_u = c3_malloc(sizeof(u3_umon));
     mon_u->nam_c = nam_c;
+    mon_u->syn_o = c3n;
     mon_u->dir_u.dir = c3y;
     mon_u->dir_u.dry = c3n;
     mon_u->dir_u.pax_c = strdup(unx_u->pax_c);
     mon_u->dir_u.par_u = NULL;
     mon_u->dir_u.nex_u = NULL;
     mon_u->dir_u.kid_u = NULL;
+    mon_u->dir_u.wat_u = NULL;
     mon_u->nex_u = unx_u->mon_u;
     unx_u->mon_u = mon_u;
   }
@@ -652,6 +728,47 @@ _unix_scan_mount_point(u3_unix* unx_u, u3_umon* mon_u)
 
 static u3_noun _unix_free_node(u3_unix* unx_u, u3_unod* nod_u, c3_t del_t);
 
+/* _unix_watch_close_cb(): free watcher handle after libuv lets go.
+*/
+static void
+_unix_watch_close_cb(uv_handle_t* han_u)
+{
+  //  the handle is the first member of u3_uwat
+  //
+  c3_free(han_u);
+}
+
+/* _unix_watch_disarm(): stop watching a directory.
+*/
+static void
+_unix_watch_disarm(u3_udir* dir_u)
+{
+  if ( !dir_u->wat_u ) {
+    return;
+  }
+
+  dir_u->wat_u->dir_u = NULL;
+  uv_fs_event_stop(&dir_u->wat_u->eve_u);
+  uv_close((uv_handle_t*)&dir_u->wat_u->eve_u, _unix_watch_close_cb);
+  dir_u->wat_u = NULL;
+}
+
+/* _unix_watch_disarm_deep(): stop watching a directory tree.
+*/
+static void
+_unix_watch_disarm_deep(u3_udir* dir_u)
+{
+  u3_unod* nod_u;
+
+  _unix_watch_disarm(dir_u);
+
+  for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
+    if ( c3y == nod_u->dir ) {
+      _unix_watch_disarm_deep((u3_udir*)nod_u);
+    }
+  }
+}
+
 /* _unix_free_file(): free file, unlinking it
 */
 static void
@@ -673,6 +790,8 @@ _unix_free_file(u3_ufil *fil_u, c3_t del_t)
 static void
 _unix_free_dir(u3_udir *dir_u, c3_t del_t)
 {
+  _unix_watch_disarm(dir_u);
+
   if (del_t) _unix_rm_r(dir_u->pax_c);
 
   if ( dir_u->kid_u ) {
@@ -750,6 +869,8 @@ _unix_free_mount_point(u3_unix* unx_u, u3_umon* mon_u, c3_t del_t)
     nod_u = nex_u;
   }
 
+  _unix_watch_disarm(&mon_u->dir_u);
+
   c3_free(mon_u->dir_u.pax_c);
   c3_free(mon_u->nam_c);
   c3_free(mon_u);
@@ -777,6 +898,7 @@ _unix_delete_mount_point(u3_unix* unx_u, u3_noun mon, c3_t del_t)
   }
   if ( 0 == strcmp(nam_c, mon_u->nam_c) ) {
     unx_u->mon_u = mon_u->nex_u;
+    _unix_drop_mugs(unx_u, mon_u);
     _unix_free_mount_point(unx_u, mon_u, del_t);
     goto _delete_mount_point_out;
   }
@@ -794,6 +916,7 @@ _unix_delete_mount_point(u3_unix* unx_u, u3_noun mon, c3_t del_t)
 
   tem_u = mon_u->nex_u;
   mon_u->nex_u = mon_u->nex_u->nex_u;
+  _unix_drop_mugs(unx_u, tem_u);
   _unix_free_mount_point(unx_u, tem_u, del_t);
 
 _delete_mount_point_out:
@@ -846,6 +969,7 @@ _unix_watch_dir(u3_udir* dir_u, u3_udir* par_u, c3_c* pax_c)
   dir_u->par_u = par_u;
   dir_u->nex_u = NULL;
   dir_u->kid_u = NULL;
+  dir_u->wat_u = NULL;
 
   if ( par_u ) {
     dir_u->nex_u = par_u->kid_u;
@@ -873,7 +997,470 @@ _unix_create_dir(u3_udir* dir_u, u3_udir* par_u, u3_noun nam)
 
   _unix_mkdir(pax_c);
   _unix_watch_dir(dir_u, par_u, pax_c);
-  
+
+  c3_free(pax_c);
+}
+
+/* _unix_mark_wet(): mark a directory tree as modified, so that a
+**                   scan re-examines all of it.
+*/
+static void
+_unix_mark_wet(u3_udir* dir_u)
+{
+  u3_unod* nod_u;
+
+  dir_u->dry = c3n;
+
+  for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
+    if ( c3y == nod_u->dir ) {
+      _unix_mark_wet((u3_udir*)nod_u);
+    }
+    else {
+      nod_u->dry = c3n;
+    }
+  }
+}
+
+/* _unix_node_mount(): find the mount point owning a node.
+*/
+static u3_umon*
+_unix_node_mount(u3_unix* unx_u, u3_unod* nod_u)
+{
+  u3_umon* mon_u;
+
+  while ( nod_u->par_u ) {
+    nod_u = (u3_unod*)nod_u->par_u;
+  }
+
+  for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
+    if ( (u3_unod*)&mon_u->dir_u == nod_u ) {
+      return mon_u;
+    }
+  }
+
+  return NULL;
+}
+
+/* _unix_time_cb(): auto-sync debounce timer fired; scan watched mounts.
+*/
+static void
+_unix_time_cb(uv_timer_t* tim_u)
+{
+  u3_unix* unx_u = tim_u->data;
+  u3_umon* mon_u;
+
+  for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
+    if ( c3y == mon_u->syn_o ) {
+      _unix_update_mount(unx_u, mon_u, c3n);
+    }
+  }
+}
+
+/* _unix_event_cb(): fs event on a watched directory.
+*/
+static void
+_unix_event_cb(uv_fs_event_t* eve_u,
+               const c3_c*    fil_c,
+               c3_i           sev_i,
+               c3_i           sas_i)
+{
+  u3_uwat* wat_u = (u3_uwat*)eve_u;
+  u3_udir* dir_u = wat_u->dir_u;
+  u3_unix* unx_u = wat_u->unx_u;
+
+  //  watcher is pending close
+  //
+  if ( !dir_u ) {
+    return;
+  }
+
+  //  ignore hidden and backup files
+  //
+  if ( fil_c ) {
+    c3_w len_w = strlen(fil_c);
+
+    if ( !len_w || ('.' == fil_c[0]) || ('~' == fil_c[len_w - 1]) ) {
+      return;
+    }
+  }
+
+  {
+    c3_t fon_t = 0;
+
+    if ( fil_c ) {
+      c3_w     dir_w = strlen(dir_u->pax_c);
+      u3_unod* nod_u;
+
+      for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
+        if ( 0 == strcmp(nod_u->pax_c + dir_w + 1, fil_c) ) {
+          if ( c3y == nod_u->dir ) {
+            _unix_mark_wet((u3_udir*)nod_u);
+          }
+          else {
+            nod_u->dry = c3n;
+          }
+          fon_t = 1;
+          break;
+        }
+      }
+    }
+    else {
+      //  we don't know what changed: re-examine the whole subtree
+      //
+      _unix_mark_wet(dir_u);
+    }
+
+    //  the mount root is the pier directory; ignore entries there
+    //  that we aren't already tracking
+    //
+    if ( !fon_t && !dir_u->par_u && fil_c ) {
+      return;
+    }
+  }
+
+  //  wet the directory and its ancestors so a scan descends to it
+  //
+  {
+    u3_udir* par_u = dir_u;
+
+    while ( par_u ) {
+      par_u->dry = c3n;
+      par_u = par_u->par_u;
+    }
+  }
+
+  //  debounce: scan shortly after the first change, batching any
+  //  changes that arrive in the window
+  //
+  if ( !uv_is_active((uv_handle_t*)unx_u->syt_u) ) {
+    uv_timer_start(unx_u->syt_u, _unix_time_cb, 100, 0);
+  }
+}
+
+/* _unix_watch_arm(): watch a directory for fs events.
+*/
+static void
+_unix_watch_arm(u3_unix* unx_u, u3_udir* dir_u)
+{
+  u3_uwat* wat_u;
+
+  if ( dir_u->wat_u ) {
+    return;
+  }
+
+  wat_u = c3_malloc(sizeof(u3_uwat));
+  wat_u->unx_u = unx_u;
+  wat_u->dir_u = dir_u;
+
+  if ( 0 != uv_fs_event_init(u3L, &wat_u->eve_u) ) {
+    u3l_log("unix: can't init watcher for %s", dir_u->pax_c);
+    c3_free(wat_u);
+    return;
+  }
+
+  if ( 0 != uv_fs_event_start(&wat_u->eve_u, _unix_event_cb,
+                              dir_u->pax_c, 0) )
+  {
+    u3l_log("unix: can't watch %s", dir_u->pax_c);
+    wat_u->dir_u = NULL;
+    uv_close((uv_handle_t*)&wat_u->eve_u, _unix_watch_close_cb);
+    return;
+  }
+
+  dir_u->wat_u = wat_u;
+}
+
+/* _unix_watch_arm_deep(): watch a directory tree for fs events.
+*/
+static void
+_unix_watch_arm_deep(u3_unix* unx_u, u3_udir* dir_u)
+{
+  u3_unod* nod_u;
+
+  _unix_watch_arm(unx_u, dir_u);
+
+  for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
+    if ( c3y == nod_u->dir ) {
+      _unix_watch_arm_deep(unx_u, (u3_udir*)nod_u);
+    }
+  }
+}
+
+/* _unix_maybe_watch(): watch a new directory if its mount is auto-synced.
+*/
+static void
+_unix_maybe_watch(u3_unix* unx_u, u3_udir* dir_u)
+{
+  u3_umon* mon_u = _unix_node_mount(unx_u, (u3_unod*)dir_u);
+
+  if ( mon_u && (c3y == mon_u->syn_o) ) {
+    _unix_watch_arm(unx_u, dir_u);
+  }
+}
+
+/* _unix_find_node(): find a node by absolute path, under a directory.
+*/
+static u3_unod*
+_unix_find_node(u3_udir* dir_u, const c3_c* pax_c)
+{
+  u3_unod* nod_u;
+
+  for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
+    c3_w len_w = strlen(nod_u->pax_c);
+
+    if ( 0 == strncmp(nod_u->pax_c, pax_c, len_w) ) {
+      if ( '\0' == pax_c[len_w] ) {
+        return nod_u;
+      }
+      if ( ('/' == pax_c[len_w]) && (c3y == nod_u->dir) ) {
+        return _unix_find_node((u3_udir*)nod_u, pax_c);
+      }
+    }
+  }
+
+  return NULL;
+}
+
+/* _unix_pend(): record a file included in a pending %into event.
+*/
+static void
+_unix_pend(u3_unix* unx_u, const c3_c* pax_c, c3_w mug_w)
+{
+  u3_usyc* syc_u = unx_u->pen_u;
+
+  if ( !syc_u ) {
+    return;
+  }
+
+  if ( syc_u->len_w == syc_u->siz_w ) {
+    syc_u->siz_w = syc_u->siz_w ? (2 * syc_u->siz_w) : 64;
+    syc_u->ent_u = c3_realloc(syc_u->ent_u,
+                              syc_u->siz_w * sizeof(*syc_u->ent_u));
+  }
+
+  syc_u->ent_u[syc_u->len_w].pax_c = strdup(pax_c);
+  syc_u->ent_u[syc_u->len_w].mug_w = mug_w;
+  syc_u->len_w++;
+}
+
+/* _unix_sync_free(): free a pending sync record.
+*/
+static void
+_unix_sync_free(u3_usyc* syc_u)
+{
+  c3_w i_w;
+
+  for ( i_w = 0; i_w < syc_u->len_w; i_w++ ) {
+    c3_free(syc_u->ent_u[i_w].pax_c);
+  }
+  c3_free(syc_u->ent_u);
+  c3_free(syc_u);
+}
+
+/* _unix_sync_done(): a %into event committed; record synced mugs
+**                    so the files aren't re-sent, and persist them.
+*/
+static void
+_unix_sync_done(u3_usyc* syc_u)
+{
+  u3_unix* unx_u = syc_u->unx_u;
+  u3_umon* mon_u;
+  c3_w     i_w;
+
+  for ( i_w = 0; i_w < syc_u->len_w; i_w++ ) {
+    for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
+      u3_unod* nod_u = _unix_find_node(&mon_u->dir_u,
+                                       syc_u->ent_u[i_w].pax_c);
+      if ( nod_u && (c3n == nod_u->dir) ) {
+        ((u3_ufil*)nod_u)->gum_w = syc_u->ent_u[i_w].mug_w;
+        break;
+      }
+    }
+  }
+
+  for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
+    _unix_save_mugs(unx_u, mon_u);
+  }
+}
+
+/* _unix_sync_news(): notification of %into event status.
+*/
+static void
+_unix_sync_news(u3_ovum* egg_u, u3_ovum_news new_e)
+{
+  if ( u3_ovum_done == new_e ) {
+    if ( egg_u->ptr_v ) {
+      _unix_sync_done(egg_u->ptr_v);
+      _unix_sync_free(egg_u->ptr_v);
+      egg_u->ptr_v = NULL;
+    }
+  }
+  else if ( u3_ovum_drop == new_e ) {
+    if ( egg_u->ptr_v ) {
+      _unix_sync_free(egg_u->ptr_v);
+      egg_u->ptr_v = NULL;
+    }
+  }
+}
+
+/* _unix_sync_bail(): a %into event failed; changes will be retried
+**                    by a later scan, since mugs were not updated.
+*/
+static void
+_unix_sync_bail(u3_ovum* egg_u, u3_noun lud)
+{
+  if ( egg_u->ptr_v ) {
+    _unix_sync_free(egg_u->ptr_v);
+    egg_u->ptr_v = NULL;
+  }
+
+  u3_auto_bail_slog(egg_u, lud);
+  u3_ovum_free(egg_u);
+}
+
+/* _unix_mug_pax(): path of the persisted mug cache for a mount point.
+**                  caller frees.
+*/
+static c3_c*
+_unix_mug_pax(u3_unix* unx_u, u3_umon* mon_u, const c3_c* suf_c)
+{
+  c3_w  len_w = strlen(unx_u->pax_c) + strlen(mon_u->nam_c)
+              + strlen(suf_c) + 32;
+  c3_c* pax_c = c3_malloc(len_w);
+
+  snprintf(pax_c, len_w, "%s/.urb/syn", unx_u->pax_c);
+  c3_mkdir(pax_c, 0700);
+  snprintf(pax_c, len_w, "%s/.urb/syn/%s.mug%s",
+           unx_u->pax_c, mon_u->nam_c, suf_c);
+
+  return pax_c;
+}
+
+#define SYNC_MUG_HEAD "vere-sync-mug-v1"
+
+/* _unix_save_mugs_dir(): write mug cache lines for a directory tree.
+*/
+static void
+_unix_save_mugs_dir(FILE* fil_u, u3_udir* dir_u, c3_w bas_w)
+{
+  u3_unod* nod_u;
+
+  for ( nod_u = dir_u->kid_u; nod_u; nod_u = nod_u->nex_u ) {
+    if ( c3y == nod_u->dir ) {
+      _unix_save_mugs_dir(fil_u, (u3_udir*)nod_u, bas_w);
+    }
+    else {
+      u3_ufil* fic_u = (u3_ufil*)nod_u;
+
+      if ( fic_u->gum_w ) {
+        fprintf(fil_u, "%08x %s\n", fic_u->gum_w, fic_u->pax_c + bas_w + 1);
+      }
+    }
+  }
+}
+
+/* _unix_save_mugs(): persist a mount point's synced mugs, so that
+**                    a post-restart scan only sends real changes.
+*/
+static void
+_unix_save_mugs(u3_unix* unx_u, u3_umon* mon_u)
+{
+  c3_c* pax_c = _unix_mug_pax(unx_u, mon_u, "");
+  c3_c* tmp_c = _unix_mug_pax(unx_u, mon_u, ".tmp");
+  FILE* fil_u = fopen(tmp_c, "w");
+
+  if ( !fil_u ) {
+    u3l_log("unix: can't write mug cache %s: %s", tmp_c, strerror(errno));
+    c3_free(pax_c);
+    c3_free(tmp_c);
+    return;
+  }
+
+  fprintf(fil_u, "%s\n", SYNC_MUG_HEAD);
+  _unix_save_mugs_dir(fil_u, &mon_u->dir_u, strlen(unx_u->pax_c));
+
+  if ( fclose(fil_u) || (0 != rename(tmp_c, pax_c)) ) {
+    u3l_log("unix: can't save mug cache %s: %s", pax_c, strerror(errno));
+    c3_unlink(tmp_c);
+  }
+
+  c3_free(pax_c);
+  c3_free(tmp_c);
+}
+
+/* _unix_drop_mugs(): delete a mount point's persisted mug cache.
+*/
+static void
+_unix_drop_mugs(u3_unix* unx_u, u3_umon* mon_u)
+{
+  c3_c* pax_c = _unix_mug_pax(unx_u, mon_u, "");
+
+  c3_unlink(pax_c);
+  c3_free(pax_c);
+}
+
+/* _unix_load_mugs(): seed gum_w from the persisted mug cache.
+*/
+static void
+_unix_load_mugs(u3_unix* unx_u, u3_umon* mon_u)
+{
+  c3_c* pax_c = _unix_mug_pax(unx_u, mon_u, "");
+  FILE* fil_u = fopen(pax_c, "r");
+  c3_c  lin_c[8192];
+  c3_w  bas_w = strlen(unx_u->pax_c);
+
+  if ( !fil_u ) {
+    c3_free(pax_c);
+    return;
+  }
+
+  if (  !fgets(lin_c, sizeof(lin_c), fil_u)
+     || 0 != strncmp(lin_c, SYNC_MUG_HEAD, strlen(SYNC_MUG_HEAD)) )
+  {
+    u3l_log("unix: discarding unrecognized mug cache %s", pax_c);
+    fclose(fil_u);
+    c3_free(pax_c);
+    return;
+  }
+
+  while ( fgets(lin_c, sizeof(lin_c), fil_u) ) {
+    c3_w  len_w = strlen(lin_c);
+    c3_w  mug_w;
+    c3_c* rel_c;
+
+    if ( len_w && ('\n' == lin_c[len_w - 1]) ) {
+      lin_c[--len_w] = '\0';
+    }
+
+    //  "%08x <path>": malformed lines abort the load; mugs already
+    //  applied are only hints, so this is safe
+    //
+    if ( (len_w < 10) || (' ' != lin_c[8])
+       || (1 != sscanf(lin_c, "%8x", &mug_w)) )
+    {
+      u3l_log("unix: discarding malformed mug cache %s", pax_c);
+      break;
+    }
+
+    rel_c = lin_c + 9;
+
+    {
+      c3_w  abs_w = bas_w + 1 + strlen(rel_c) + 1;
+      c3_c* abs_c = c3_malloc(abs_w);
+      u3_unod* nod_u;
+
+      snprintf(abs_c, abs_w, "%s/%s", unx_u->pax_c, rel_c);
+      nod_u = _unix_find_node(&mon_u->dir_u, abs_c);
+
+      if ( nod_u && (c3n == nod_u->dir) ) {
+        ((u3_ufil*)nod_u)->gum_w = mug_w;
+      }
+
+      c3_free(abs_c);
+    }
+  }
+
+  fclose(fil_u);
   c3_free(pax_c);
 }
 
@@ -897,7 +1484,7 @@ _unix_update_file(u3_unix* unx_u, u3_ufil* fil_u)
     return u3_nul;
   }
 
-  fil_u->dry = c3n;
+  fil_u->dry = c3y;
 
   struct stat buf_u;
   c3_i  fid_i = c3_open(fil_u->pax_c, O_RDONLY, 0644);
@@ -948,6 +1535,8 @@ _unix_update_file(u3_unix* unx_u, u3_ufil* fil_u)
       u3_noun mim = u3nt(c3__text, u3i_string("plain"), u3_nul);
       u3_noun dat = u3nt(mim, len_ws, u3i_bytes(len_ws, dat_y));
 
+      _unix_pend(unx_u, fil_u->pax_c, mug_w);
+
       c3_free(dat_y);
       return u3nc(u3nt(pax, u3_nul, dat), u3_nul);
     }
@@ -970,7 +1559,7 @@ _unix_update_dir(u3_unix* unx_u, u3_udir* dir_u)
     return u3_nul;
   }
 
-  dir_u->dry = c3n;
+  dir_u->dry = c3y;
 
   // Check that old nodes are still there
 
@@ -1093,6 +1682,7 @@ _unix_update_dir(u3_unix* unx_u, u3_udir* dir_u)
           else {
             u3_udir* dis_u = c3_malloc(sizeof(u3_udir));
             _unix_watch_dir(dis_u, dir_u, pax_c);
+            _unix_maybe_watch(unx_u, dis_u);
             can = u3kb_weld(_unix_update_dir(unx_u, dis_u), can); // XXX unnecessary?
           }
         }
@@ -1141,8 +1731,28 @@ _unix_update_mount(u3_unix* unx_u, u3_umon* mon_u, u3_noun all)
   if ( c3n == mon_u->dir_u.dry ) {
     u3_noun  can = u3_nul;
     u3_unod* nod_u;
+    u3_usyc* syc_u;
+
+    //  accumulate (path, mug) for files included in the event,
+    //  to be recorded if and when the event commits
+    //
+    u3_assert( !unx_u->pen_u );
+    syc_u = c3_calloc(sizeof(*syc_u));
+    syc_u->unx_u = unx_u;
+    unx_u->pen_u = syc_u;
+
     for ( nod_u = mon_u->dir_u.kid_u; nod_u; nod_u = nod_u->nex_u ) {
       can = u3kb_weld(_unix_update_node(unx_u, nod_u), can);
+    }
+
+    unx_u->pen_u = NULL;
+
+    //  if nothing changed, don't inject an empty event
+    //
+    if ( (u3_nul == can) && (c3n == all) ) {
+      _unix_sync_free(syc_u);
+      u3z(all);
+      return;
     }
 
     {
@@ -1154,7 +1764,9 @@ _unix_update_mount(u3_unix* unx_u, u3_umon* mon_u, u3_noun all)
       u3_noun cad = u3nq(c3__into, _unix_string_to_knot(mon_u->nam_c), all,
                          can);
 
-      u3_auto_plan(&unx_u->car_u, u3_ovum_init(0, c3__c, wir, cad));
+      u3_auto_peer(
+        u3_auto_plan(&unx_u->car_u, u3_ovum_init(0, c3__c, wir, cad)),
+        syc_u, _unix_sync_news, _unix_sync_bail);
     }
   }
 }
@@ -1395,6 +2007,7 @@ _unix_sync_change(u3_unix* unx_u, u3_udir* dir_u, u3_noun pax, u3_noun mim)
       if ( !nod_u ) {
         nod_u = c3_malloc(sizeof(u3_udir));
         _unix_create_dir((u3_udir*) nod_u, dir_u, u3k(i_pax));
+        _unix_maybe_watch(unx_u, (u3_udir*) nod_u);
       }
 
       if ( c3n == nod_u->dir ) {
@@ -1424,6 +2037,10 @@ _unix_sync_ergo(u3_unix* unx_u, u3_umon* mon_u, u3_noun can)
                       u3k(u3t(u3h(nac))));
     nac = u3t(nac);
   }
+
+  //  %ergo confirms a commit: persist the synced mugs
+  //
+  _unix_save_mugs(unx_u, mon_u);
 
   u3z(nam);
   u3z(can);
@@ -1455,6 +2072,37 @@ u3_unix_ef_ogre(u3_unix* unx_u, u3_noun mon)
   _unix_delete_mount_point(unx_u, mon, true);
 }
 
+/* u3_unix_ef_wath(): start auto-syncing a mount point.
+*/
+void
+u3_unix_ef_wath(u3_unix* unx_u, u3_noun mon)
+{
+  u3_umon* mon_u = _unix_get_mount_point(unx_u, mon);
+
+  if ( c3n == mon_u->syn_o ) {
+    mon_u->syn_o = c3y;
+    _unix_watch_arm_deep(unx_u, &mon_u->dir_u);
+  }
+
+  //  reconciliation scan: sync any changes made while not watching
+  //
+  _unix_mark_wet(&mon_u->dir_u);
+  _unix_update_mount(unx_u, mon_u, c3n);
+}
+
+/* u3_unix_ef_wend(): stop auto-syncing a mount point.
+*/
+void
+u3_unix_ef_wend(u3_unix* unx_u, u3_noun mon)
+{
+  u3_umon* mon_u = _unix_get_mount_point(unx_u, mon);
+
+  if ( c3y == mon_u->syn_o ) {
+    mon_u->syn_o = c3n;
+    _unix_watch_disarm_deep(&mon_u->dir_u);
+  }
+}
+
 /* u3_unix_ef_hill(): enumerate mount points
 */
 void
@@ -1465,6 +2113,7 @@ u3_unix_ef_hill(u3_unix* unx_u, u3_noun hil)
   for ( mon = hil; c3y == u3du(mon); mon = u3t(mon) ) {
     u3_umon* mon_u = _unix_get_mount_point(unx_u, u3k(u3h(mon)));
     _unix_scan_mount_point(unx_u, mon_u);
+    _unix_load_mugs(unx_u, mon_u);
   }
 
   unx_u->car_u.liv_o = c3y;
@@ -1487,6 +2136,9 @@ u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, u3_noun all)
     }
     c3_free(nam_c);
     if ( mon_u ) {
+      //  a commit re-examines the whole mount
+      //
+      _unix_mark_wet(&mon_u->dir_u);
       _unix_update_mount(unx_u, mon_u, all);
     }
   }
@@ -1552,6 +2204,16 @@ _unix_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
         u3_unix_ef_hill(unx_u, u3k(dat));
         ret_o = c3y;
       } break;
+
+      case c3__wath: {
+        u3_unix_ef_wath(unx_u, u3k(dat));
+        ret_o = c3y;
+      } break;
+
+      case c3__wend: {
+        u3_unix_ef_wend(unx_u, u3k(dat));
+        ret_o = c3y;
+      } break;
     }
   }
 
@@ -1579,6 +2241,12 @@ _unix_io_mark(u3_auto* car_u, c3_w *out_w)
 /* _unix_io_exit(): terminate unix I/O.
 */
 static void
+_unix_timer_close_cb(uv_handle_t* han_u)
+{
+  c3_free(han_u);
+}
+
+static void
 _unix_io_exit(u3_auto* car_u)
 {
   u3_unix* unx_u = (u3_unix*)car_u;
@@ -1587,9 +2255,12 @@ _unix_io_exit(u3_auto* car_u)
   u3_umon* nex_u;
   while ( mon_u ) {
     nex_u = mon_u->nex_u;
+    _unix_save_mugs(unx_u, mon_u);
     _unix_free_mount_point(unx_u, mon_u, false);
     mon_u = nex_u;
   }
+
+  uv_close((uv_handle_t*)unx_u->syt_u, _unix_timer_close_cb);
 
   u3z(unx_u->sat);
   c3_free(unx_u->pax_c);
@@ -1607,6 +2278,11 @@ u3_unix_io_init(u3_pier* pir_u)
   unx_u->alm = c3n;
   unx_u->dyr = c3n;
   unx_u->sat = u3do("sane", c3__ta);
+  unx_u->pen_u = NULL;
+
+  unx_u->syt_u = c3_malloc(sizeof(*unx_u->syt_u));
+  uv_timer_init(u3L, unx_u->syt_u);
+  unx_u->syt_u->data = unx_u;
 
   u3_auto* car_u = &unx_u->car_u;
   car_u->nam_m = c3__unix;

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -45,6 +45,26 @@ struct _u3_udir;
 struct _u3_ufil;
 struct _u3_unix;
 
+/* auto-sync heuristics, tuned for editor save patterns (write-temp-
+** then-rename, delete-then-write, truncate-then-write):
+**
+**   SYNC_QUIET_MS:   scan only after the filesystem has been quiet
+**                    this long, so multi-step saves coalesce
+**   SYNC_CAP_MS:     but never delay a scan longer than this past
+**                    the first change, so a busy writer can't
+**                    starve sync entirely
+**   SYNC_GRACE_MS:   a missing file must stay missing this long
+**                    before its deletion is synced, so a file
+**                    deleted moments before being rewritten never
+**                    propagates a transient deletion
+**   SYNC_RECHECK_MS: how soon to recheck files awaiting the grace
+**                    period (must exceed SYNC_GRACE_MS)
+*/
+#define SYNC_QUIET_MS    100
+#define SYNC_CAP_MS     1000
+#define SYNC_GRACE_MS    300
+#define SYNC_RECHECK_MS  350
+
 /* u3_unod: file or directory.
 */
   typedef struct _u3_unod {
@@ -64,6 +84,7 @@ struct _u3_unix;
     struct _u3_udir*  par_u;            //  parent
     struct _u3_unod*  nex_u;            //  internal list
     c3_w              gum_w;            //  mug of last %ergo
+    c3_d              dum_d;            //  first seen missing (ms), or 0
   } u3_ufil;
 
 /* u3_ufil: synchronized directory.
@@ -128,6 +149,8 @@ struct _u3_unix;
     c3_o        dyr;                    //  ready to update
     u3_noun     sat;                    //  (sane %ta) handle
     uv_timer_t* syt_u;                  //  auto-sync debounce timer
+    c3_d        fir_d;                  //  debounce window start (ms)
+    c3_o        dum_o;                  //  doomed files await recheck
     u3_usyc*    pen_u;                  //  scan accumulator, if scanning
 #ifdef SYNCLOG
     c3_w         lot_w;                 //  sync-slot
@@ -976,6 +999,7 @@ _unix_watch_file(u3_unix* unx_u, u3_ufil* fil_u, u3_udir* par_u, c3_c* pax_c)
   fil_u->par_u = par_u;
   fil_u->nex_u = NULL;
   fil_u->gum_w = 0;
+  fil_u->dum_d = 0;
 
   if ( par_u ) {
     fil_u->nex_u = par_u->kid_u;
@@ -1070,7 +1094,31 @@ _unix_node_mount(u3_unix* unx_u, u3_unod* nod_u)
   return NULL;
 }
 
-/* _unix_time_cb(): auto-sync debounce timer fired; scan watched mounts.
+static void
+_unix_time_cb(uv_timer_t* tim_u);
+
+/* _unix_doom_recheck(): if a scan deferred any deletions, schedule
+**                       a follow-up scan to confirm them.
+*/
+static void
+_unix_doom_recheck(u3_unix* unx_u)
+{
+  if ( c3y == unx_u->dum_o ) {
+    unx_u->dum_o = c3n;
+
+    if ( !uv_is_active((uv_handle_t*)unx_u->syt_u) ) {
+      unx_u->fir_d = uv_now(u3L);
+      uv_timer_start(unx_u->syt_u, _unix_time_cb, SYNC_RECHECK_MS, 0);
+    }
+  }
+}
+
+/* _unix_time_cb(): auto-sync debounce timer fired.
+**
+**  scans every mount: on watched mounts, wet subtrees are pending
+**  fs events; on unwatched mounts nothing is ever wet between
+**  commits except files awaiting a deletion-grace recheck, so the
+**  scan is surgical either way.
 */
 static void
 _unix_time_cb(uv_timer_t* tim_u)
@@ -1079,10 +1127,10 @@ _unix_time_cb(uv_timer_t* tim_u)
   u3_umon* mon_u;
 
   for ( mon_u = unx_u->mon_u; mon_u; mon_u = mon_u->nex_u ) {
-    if ( c3y == mon_u->syn_o ) {
-      _unix_update_mount(unx_u, mon_u, c3n);
-    }
+    _unix_update_mount(unx_u, mon_u, c3n);
   }
+
+  _unix_doom_recheck(unx_u);
 }
 
 /* _unix_event_cb(): fs event on a watched directory.
@@ -1158,11 +1206,22 @@ _unix_event_cb(uv_fs_event_t* eve_u,
     }
   }
 
-  //  debounce: scan shortly after the first change, batching any
-  //  changes that arrive in the window
+  //  debounce until quiescence: each change extends the window, so
+  //  multi-step editor saves (write-rename, delete-write) coalesce
+  //  into one scan; but never delay more than SYNC_CAP_MS past the
+  //  first change, so a busy writer can't starve sync
   //
-  if ( !uv_is_active((uv_handle_t*)unx_u->syt_u) ) {
-    uv_timer_start(unx_u->syt_u, _unix_time_cb, 100, 0);
+  {
+    c3_d now_d = uv_now(u3L);
+
+    if ( !uv_is_active((uv_handle_t*)unx_u->syt_u) ) {
+      unx_u->fir_d = now_d;
+      uv_timer_start(unx_u->syt_u, _unix_time_cb, SYNC_QUIET_MS, 0);
+    }
+    else if ( (now_d - unx_u->fir_d) < SYNC_CAP_MS ) {
+      uv_timer_start(unx_u->syt_u, _unix_time_cb, SYNC_QUIET_MS, 0);
+    }
+    //  else: cap reached, let the pending scan fire
   }
 }
 
@@ -1656,6 +1715,32 @@ _unix_update_file(u3_unix* unx_u, u3_ufil* fil_u)
 
   if ( fid_i < 0 || fstat(fid_i, &buf_u) < 0 ) {
     if ( ENOENT == errno ) {
+      c3_d now_d = uv_now(u3L);
+
+      //  deletion grace: editors often delete a file moments before
+      //  rewriting it. only emit the deletion once the file has
+      //  stayed missing through a recheck.
+      //
+      if ( !fil_u->dum_d || ((now_d - fil_u->dum_d) < SYNC_GRACE_MS) ) {
+        u3_udir* par_u;
+
+        if ( !fil_u->dum_d ) {
+          fil_u->dum_d = now_d;
+        }
+
+        //  stay wet, and keep ancestors wet, so the recheck
+        //  scan descends back to this node
+        //
+        fil_u->dry = c3n;
+        for ( par_u = fil_u->par_u; par_u; par_u = par_u->par_u ) {
+          par_u->dry = c3n;
+        }
+
+        unx_u->dum_o = c3y;
+        return u3_nul;
+      }
+
+      fil_u->dum_d = 0;
       return u3nc(u3nc(_unix_string_to_path(unx_u, fil_u->pax_c), u3_nul), u3_nul);
     }
     else {
@@ -1664,6 +1749,10 @@ _unix_update_file(u3_unix* unx_u, u3_ufil* fil_u)
       return u3_nul;
     }
   }
+
+  //  the file exists: clear any pending doom
+  //
+  fil_u->dum_d = 0;
 
   len_ws = buf_u.st_size;
   dat_y = c3_malloc(len_ws);
@@ -1751,9 +1840,20 @@ _unix_update_dir(u3_unix* unx_u, u3_udir* dir_u)
           c3_i  fid_i = c3_open(nod_u->pax_c, O_RDONLY, 0644);
 
           if ( (fid_i < 0) || (fstat(fid_i, &buf_u) < 0) ) {
+            u3_ufil* fil_u = (u3_ufil*)nod_u;
+
             if ( ENOENT != errno ) {
               u3l_log("_unix_update_dir: error opening file %s: %s",
                       nod_u->pax_c, strerror(errno));
+            }
+            else if ( !fil_u->dum_d
+                   || ((uv_now(u3L) - fil_u->dum_d) < SYNC_GRACE_MS) )
+            {
+              //  deletion grace: leave the node in place; the file
+              //  pass will doom it and schedule a recheck
+              //
+              nod_u = nod_u->nex_u;
+              continue;
             }
 
             u3_unod* nex_u = nod_u->nex_u;
@@ -2251,6 +2351,7 @@ u3_unix_ef_wath(u3_unix* unx_u, u3_noun mon)
   //
   _unix_mark_wet(&mon_u->dir_u);
   _unix_update_mount(unx_u, mon_u, c3n);
+  _unix_doom_recheck(unx_u);
 }
 
 /* u3_unix_ef_wend(): stop auto-syncing a mount point.
@@ -2303,6 +2404,7 @@ u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, u3_noun all)
       //
       _unix_mark_wet(&mon_u->dir_u);
       _unix_update_mount(unx_u, mon_u, all);
+      _unix_doom_recheck(unx_u);
     }
   }
   u3z(mon);
@@ -2442,6 +2544,8 @@ u3_unix_io_init(u3_pier* pir_u)
   unx_u->dyr = c3n;
   unx_u->sat = u3do("sane", c3__ta);
   unx_u->pen_u = NULL;
+  unx_u->fir_d = 0;
+  unx_u->dum_o = c3n;
 
   unx_u->syt_u = c3_malloc(sizeof(*unx_u->syt_u));
   uv_timer_init(u3L, unx_u->syt_u);

--- a/pkg/vere/unix_tests.c
+++ b/pkg/vere/unix_tests.c
@@ -1,50 +1,409 @@
 /// @file
 
+#include <stdbool.h>
+
 #include "noun.h"
 #include "vere.h"
+
+//  include the unix driver source to reach its internals.  its
+//  exported symbols are renamed to avoid colliding with the copies
+//  linked in from the vere library.
+//
+#define u3_readdir_r              _ut_readdir_r
+#define u3_unix_cane              _ut_unix_cane
+#define u3_unix_save              _ut_unix_save
+#define u3_unix_initial_into_card _ut_unix_initial_into_card
+#define u3_unix_ef_dirk           _ut_unix_ef_dirk
+#define u3_unix_ef_ergo           _ut_unix_ef_ergo
+#define u3_unix_ef_ogre           _ut_unix_ef_ogre
+#define u3_unix_ef_wath           _ut_unix_ef_wath
+#define u3_unix_ef_wend           _ut_unix_ef_wend
+#define u3_unix_ef_hill           _ut_unix_ef_hill
+#define u3_unix_ef_look           _ut_unix_ef_look
+#define u3_unix_io_init           _ut_unix_io_init
+#include "io/unix.c"
 
 /* _setup(): prepare for tests.
 */
 static void
 _setup(void)
 {
+  u3m_boot_lite(1 << 26);
 }
 
-/* _test_safe():
+/* _ut_mon_init(): initialize a mount point for tests.
+*/
+static void
+_ut_mon_init(u3_umon* mon_u, c3_c* nam_c, c3_c* pax_c)
+{
+  memset(mon_u, 0, sizeof(*mon_u));
+  mon_u->nam_c       = nam_c;
+  mon_u->syn_o       = c3n;
+  mon_u->dir_u.dir   = c3y;
+  mon_u->dir_u.dry   = c3n;
+  mon_u->dir_u.pax_c = pax_c;
+}
+
+/* _test_safe(): path validation.
 */
 static c3_i
 _test_safe()
 {
   c3_i ret_i = 1;
 
-  if ( !u3_unix_cane("/") ||
-       !u3_unix_cane("~.") ||
-       !u3_unix_cane("a") ||
-       !u3_unix_cane("a/b") ||
-       !u3_unix_cane("a/b/c/defg/h/ijklmnop") )
+  if ( !_ut_unix_cane("/") ||
+       !_ut_unix_cane("~.") ||
+       !_ut_unix_cane("a") ||
+       !_ut_unix_cane("a/b") ||
+       !_ut_unix_cane("a/b/c/defg/h/ijklmnop") )
   {
     fprintf(stderr, "_safe fail 1\n");
     ret_i = 0;
   }
 
-  if ( u3_unix_cane("") ||
-       u3_unix_cane(".") ||
-       u3_unix_cane("..") ||
-       u3_unix_cane("/.") ||
-       u3_unix_cane("a/b/c//") ||
-       u3_unix_cane("a/b/.") ||
-       u3_unix_cane("/././../.") ||
-       u3_unix_cane("/../etc") )
+  if ( _ut_unix_cane("") ||
+       _ut_unix_cane(".") ||
+       _ut_unix_cane("..") ||
+       _ut_unix_cane("/.") ||
+       _ut_unix_cane("a/b/c//") ||
+       _ut_unix_cane("a/b/.") ||
+       _ut_unix_cane("/././../.") ||
+       _ut_unix_cane("/../etc") )
   {
     fprintf(stderr, "_safe fail 2\r\n");
     ret_i = 0;
   }
 
-  if ( !u3_unix_cane(".a") ||
-       !u3_unix_cane("/.a.b.c/..c") )
+  if ( !_ut_unix_cane(".a") ||
+       !_ut_unix_cane("/.a.b.c/..c") )
   {
     fprintf(stderr, "_safe fail 3\r\n");
     ret_i = 0;
+  }
+
+  return ret_i;
+}
+
+/* _test_lod(): mug-cache insert, update, delete; sorted order.
+*/
+static c3_i
+_test_lod()
+{
+  c3_i     ret_i = 1;
+  u3_unix  unx_u;
+  u3_umon  mon_u;
+
+  memset(&unx_u, 0, sizeof(unx_u));
+  _ut_mon_init(&mon_u, "base", "/p");
+  unx_u.pax_c = "/p";
+  unx_u.mon_u = &mon_u;
+
+  //  out-of-order inserts land sorted
+  //
+  _unix_lod_put(&mon_u, "/p/base/b.txt", 2);
+  _unix_lod_put(&mon_u, "/p/base/a.txt", 1);
+  _unix_lod_put(&mon_u, "/p/base/c.txt", 3);
+
+  if (  (3 != mon_u.lod_w)
+     || (0 != strcmp(mon_u.lod_u[0].pax_c, "/p/base/a.txt"))
+     || (0 != strcmp(mon_u.lod_u[1].pax_c, "/p/base/b.txt"))
+     || (0 != strcmp(mon_u.lod_u[2].pax_c, "/p/base/c.txt"))
+     || (1 != mon_u.lod_u[0].mug_w)
+     || (2 != mon_u.lod_u[1].mug_w)
+     || (3 != mon_u.lod_u[2].mug_w) )
+  {
+    fprintf(stderr, "_lod fail: insert order\r\n");
+    ret_i = 0;
+  }
+
+  //  put on an existing path updates in place
+  //
+  _unix_lod_put(&mon_u, "/p/base/b.txt", 9);
+
+  if ( (3 != mon_u.lod_w) || (9 != mon_u.lod_u[1].mug_w) ) {
+    fprintf(stderr, "_lod fail: update\r\n");
+    ret_i = 0;
+  }
+
+  //  deleting a file removes its entry, keeping order
+  //
+  {
+    u3_ufil fil_u;
+    memset(&fil_u, 0, sizeof(fil_u));
+    fil_u.dir   = c3n;
+    fil_u.pax_c = "/p/base/b.txt";
+    fil_u.par_u = &mon_u.dir_u;
+
+    _unix_lod_del(&unx_u, &fil_u);
+
+    if (  (2 != mon_u.lod_w)
+       || (0 != strcmp(mon_u.lod_u[0].pax_c, "/p/base/a.txt"))
+       || (0 != strcmp(mon_u.lod_u[1].pax_c, "/p/base/c.txt")) )
+    {
+      fprintf(stderr, "_lod fail: delete\r\n");
+      ret_i = 0;
+    }
+
+    //  deleting a missing path is a no-op
+    //
+    fil_u.pax_c = "/p/base/nope.txt";
+    _unix_lod_del(&unx_u, &fil_u);
+
+    if ( 2 != mon_u.lod_w ) {
+      fprintf(stderr, "_lod fail: missing delete\r\n");
+      ret_i = 0;
+    }
+  }
+
+  _unix_free_lod(&mon_u);
+  return ret_i;
+}
+
+/* _test_seed(): new file nodes pick up their mug from the cache.
+*/
+static c3_i
+_test_seed()
+{
+  c3_i     ret_i = 1;
+  u3_unix  unx_u;
+  u3_umon  mon_u;
+
+  memset(&unx_u, 0, sizeof(unx_u));
+  _ut_mon_init(&mon_u, "base", "/p");
+  unx_u.pax_c = "/p";
+  unx_u.mon_u = &mon_u;
+
+  _unix_lod_put(&mon_u, "/p/base/a.txt", 0xabcd);
+
+  {
+    u3_ufil* fil_u = c3_malloc(sizeof(u3_ufil));
+    _unix_watch_file(&unx_u, fil_u, &mon_u.dir_u, "/p/base/a.txt");
+
+    if ( 0xabcd != fil_u->gum_w ) {
+      fprintf(stderr, "_seed fail: cached mug\r\n");
+      ret_i = 0;
+    }
+  }
+
+  {
+    u3_ufil* fil_u = c3_malloc(sizeof(u3_ufil));
+    _unix_watch_file(&unx_u, fil_u, &mon_u.dir_u, "/p/base/new.txt");
+
+    if ( 0 != fil_u->gum_w ) {
+      fprintf(stderr, "_seed fail: uncached mug\r\n");
+      ret_i = 0;
+    }
+  }
+
+  _unix_free_lod(&mon_u);
+  return ret_i;
+}
+
+/* _test_find_node(): path lookup in the node tree.
+*/
+static c3_i
+_test_find_node()
+{
+  c3_i     ret_i = 1;
+  u3_unix  unx_u;
+  u3_umon  mon_u;
+  u3_udir* dir_u = c3_malloc(sizeof(u3_udir));
+  u3_ufil* fil_u = c3_malloc(sizeof(u3_ufil));
+
+  memset(&unx_u, 0, sizeof(unx_u));
+  _ut_mon_init(&mon_u, "base", "/p");
+  unx_u.pax_c = "/p";
+  unx_u.mon_u = &mon_u;
+
+  _unix_watch_dir(dir_u, &mon_u.dir_u, "/p/base");
+  _unix_watch_file(&unx_u, fil_u, dir_u, "/p/base/foo.txt");
+
+  if ( (u3_unod*)fil_u != _unix_find_node(&mon_u.dir_u, "/p/base/foo.txt") ) {
+    fprintf(stderr, "_find fail: file\r\n");
+    ret_i = 0;
+  }
+
+  if ( (u3_unod*)dir_u != _unix_find_node(&mon_u.dir_u, "/p/base") ) {
+    fprintf(stderr, "_find fail: dir\r\n");
+    ret_i = 0;
+  }
+
+  if (  _unix_find_node(&mon_u.dir_u, "/p/base/nope.txt")
+     || _unix_find_node(&mon_u.dir_u, "/p/nope")
+     || _unix_find_node(&mon_u.dir_u, "/p/base/foo.txt.bak") )
+  {
+    fprintf(stderr, "_find fail: miss\r\n");
+    ret_i = 0;
+  }
+
+  return ret_i;
+}
+
+/* _test_mug_cache(): sidecar save/load round-trip; corruption safety.
+*/
+static c3_i
+_test_mug_cache()
+{
+  c3_i ret_i = 1;
+  c3_c pir_c[64];
+
+  strcpy(pir_c, "/tmp/ut-unix-XXXXXX");
+  if ( !mkdtemp(pir_c) ) {
+    fprintf(stderr, "_mug_cache fail: mkdtemp\r\n");
+    return 0;
+  }
+
+  {
+    c3_c urb_c[80];
+    snprintf(urb_c, sizeof(urb_c), "%s/.urb", pir_c);
+    c3_mkdir(urb_c, 0700);
+  }
+
+  u3_unix unx_u;
+  memset(&unx_u, 0, sizeof(unx_u));
+  unx_u.pax_c = pir_c;
+
+  //  save a cache, load it back, compare
+  //
+  {
+    u3_umon mon_u, won_u;
+    c3_c    pax_c[128];
+
+    _ut_mon_init(&mon_u, "base", pir_c);
+    _ut_mon_init(&won_u, "base", pir_c);
+    unx_u.mon_u = &mon_u;
+
+    snprintf(pax_c, sizeof(pax_c), "%s/base/a.txt", pir_c);
+    _unix_lod_put(&mon_u, pax_c, 0x1111);
+    snprintf(pax_c, sizeof(pax_c), "%s/base/sub/b.hoon", pir_c);
+    _unix_lod_put(&mon_u, pax_c, 0x2222);
+
+    _unix_save_mugs(&unx_u, &mon_u);
+    _unix_load_mugs(&unx_u, &won_u);
+
+    if (  (2 != won_u.lod_w)
+       || (0x1111 != won_u.lod_u[0].mug_w)
+       || (0x2222 != won_u.lod_u[1].mug_w)
+       || (0 != strcmp(won_u.lod_u[0].pax_c, mon_u.lod_u[0].pax_c))
+       || (0 != strcmp(won_u.lod_u[1].pax_c, mon_u.lod_u[1].pax_c)) )
+    {
+      fprintf(stderr, "_mug_cache fail: round trip\r\n");
+      ret_i = 0;
+    }
+
+    //  a second save must atomically replace the first
+    //
+    _unix_save_mugs(&unx_u, &mon_u);
+    _unix_free_lod(&won_u);
+    _unix_load_mugs(&unx_u, &won_u);
+
+    if ( 2 != won_u.lod_w ) {
+      fprintf(stderr, "_mug_cache fail: re-save\r\n");
+      ret_i = 0;
+    }
+
+    _unix_free_lod(&mon_u);
+    _unix_free_lod(&won_u);
+  }
+
+  //  an unrecognized header discards the cache
+  //
+  {
+    u3_umon mon_u;
+    c3_c*   pax_c;
+    FILE*   fil_u;
+
+    _ut_mon_init(&mon_u, "base", pir_c);
+    pax_c = _unix_mug_pax(&unx_u, &mon_u, "");
+    fil_u = fopen(pax_c, "w");
+    fprintf(fil_u, "not-a-mug-cache\n00000001 base/a.txt\n");
+    fclose(fil_u);
+
+    _unix_load_mugs(&unx_u, &mon_u);
+
+    if ( 0 != mon_u.lod_w ) {
+      fprintf(stderr, "_mug_cache fail: bad header\r\n");
+      ret_i = 0;
+    }
+    c3_free(pax_c);
+  }
+
+  //  a malformed line discards the cache wholesale
+  //
+  {
+    u3_umon mon_u;
+    c3_c*   pax_c;
+    FILE*   fil_u;
+
+    _ut_mon_init(&mon_u, "base", pir_c);
+    pax_c = _unix_mug_pax(&unx_u, &mon_u, "");
+    fil_u = fopen(pax_c, "w");
+    fprintf(fil_u, "%s\n00000001 base/a.txt\ngarbage\n", SYNC_MUG_HEAD);
+    fclose(fil_u);
+
+    _unix_load_mugs(&unx_u, &mon_u);
+
+    if ( 0 != mon_u.lod_w ) {
+      fprintf(stderr, "_mug_cache fail: malformed line\r\n");
+      ret_i = 0;
+    }
+    c3_free(pax_c);
+  }
+
+  //  a missing cache loads as empty
+  //
+  {
+    u3_umon mon_u;
+    _ut_mon_init(&mon_u, "missing", pir_c);
+    _unix_load_mugs(&unx_u, &mon_u);
+
+    if ( 0 != mon_u.lod_w ) {
+      fprintf(stderr, "_mug_cache fail: missing file\r\n");
+      ret_i = 0;
+    }
+  }
+
+  return ret_i;
+}
+
+/* _test_mim_mug(): mugs are computed over the octet-stream at its
+**                  declared length, including trailing zero bytes.
+*/
+static c3_i
+_test_mim_mug()
+{
+  c3_i ret_i = 1;
+
+  //  'ab' followed by two zero bytes: the atom drops them, the
+  //  mime length keeps them
+  //
+  {
+    c3_y    dat_y[4] = { 'a', 'b', 0x0, 0x0 };
+    u3_noun mim = u3nt(c3__text, u3i_word(4), u3i_bytes(4, dat_y));
+    c3_w    mug_w = _unix_mim_mug(mim);
+
+    if ( u3r_mug_bytes(dat_y, 4) != mug_w ) {
+      fprintf(stderr, "_mim_mug fail: trailing zeros\r\n");
+      ret_i = 0;
+    }
+    if ( u3r_mug(u3t(u3t(mim))) == mug_w ) {
+      fprintf(stderr, "_mim_mug fail: noun mug should differ\r\n");
+      ret_i = 0;
+    }
+    u3z(mim);
+  }
+
+  //  no trailing zeros: byte mug at declared length still matches
+  //
+  {
+    c3_y    dat_y[3] = { 'a', 'b', 'c' };
+    u3_noun mim = u3nt(c3__text, u3i_word(3), u3i_bytes(3, dat_y));
+
+    if ( u3r_mug_bytes(dat_y, 3) != _unix_mim_mug(mim) ) {
+      fprintf(stderr, "_mim_mug fail: plain\r\n");
+      ret_i = 0;
+    }
+    u3z(mim);
   }
 
   return ret_i;
@@ -59,6 +418,31 @@ main(int argc, char* argv[])
 
   if ( !_test_safe() ) {
     fprintf(stderr, "test unix: failed\r\n");
+    exit(1);
+  }
+
+  if ( !_test_lod() ) {
+    fprintf(stderr, "test unix: lod failed\r\n");
+    exit(1);
+  }
+
+  if ( !_test_seed() ) {
+    fprintf(stderr, "test unix: seed failed\r\n");
+    exit(1);
+  }
+
+  if ( !_test_find_node() ) {
+    fprintf(stderr, "test unix: find-node failed\r\n");
+    exit(1);
+  }
+
+  if ( !_test_mug_cache() ) {
+    fprintf(stderr, "test unix: mug-cache failed\r\n");
+    exit(1);
+  }
+
+  if ( !_test_mim_mug() ) {
+    fprintf(stderr, "test unix: mim-mug failed\r\n");
     exit(1);
   }
 

--- a/pkg/vere/unix_tests.c
+++ b/pkg/vere/unix_tests.c
@@ -84,7 +84,19 @@ _test_safe()
   return ret_i;
 }
 
-/* _test_lod(): mug-cache insert, update, delete; sorted order.
+/* _ut_lod_add(): append a cache entry; calls must be in sorted order.
+*/
+static void
+_ut_lod_add(u3_umon* mon_u, const c3_c* pax_c, c3_w mug_w)
+{
+  mon_u->lod_u = c3_realloc(mon_u->lod_u,
+                            (1 + mon_u->lod_w) * sizeof(u3_umug));
+  mon_u->lod_u[mon_u->lod_w].pax_c = strdup(pax_c);
+  mon_u->lod_u[mon_u->lod_w].mug_w = mug_w;
+  mon_u->lod_w++;
+}
+
+/* _test_lod(): mug-cache fold (tree wins, union otherwise) and delete.
 */
 static c3_i
 _test_lod()
@@ -92,49 +104,48 @@ _test_lod()
   c3_i     ret_i = 1;
   u3_unix  unx_u;
   u3_umon  mon_u;
+  u3_ufil* fil_u = c3_malloc(sizeof(u3_ufil));
+  u3_ufil* fol_u = c3_malloc(sizeof(u3_ufil));
 
   memset(&unx_u, 0, sizeof(unx_u));
   _ut_mon_init(&mon_u, "base", "/p");
   unx_u.pax_c = "/p";
   unx_u.mon_u = &mon_u;
 
-  //  out-of-order inserts land sorted
+  //  cache: a (stale) and c; tree: a (fresh) and b
   //
-  _unix_lod_put(&mon_u, "/p/base/b.txt", 2);
-  _unix_lod_put(&mon_u, "/p/base/a.txt", 1);
-  _unix_lod_put(&mon_u, "/p/base/c.txt", 3);
+  _ut_lod_add(&mon_u, "/p/base/a.txt", 1);
+  _ut_lod_add(&mon_u, "/p/base/c.txt", 3);
+
+  _unix_watch_file(&unx_u, fil_u, &mon_u.dir_u, "/p/base/b.txt");
+  _unix_watch_file(&unx_u, fol_u, &mon_u.dir_u, "/p/base/a.txt");
+  fil_u->gum_w = 2;
+  fol_u->gum_w = 9;
+
+  _unix_fold_mugs(&mon_u);
 
   if (  (3 != mon_u.lod_w)
      || (0 != strcmp(mon_u.lod_u[0].pax_c, "/p/base/a.txt"))
      || (0 != strcmp(mon_u.lod_u[1].pax_c, "/p/base/b.txt"))
      || (0 != strcmp(mon_u.lod_u[2].pax_c, "/p/base/c.txt"))
-     || (1 != mon_u.lod_u[0].mug_w)
+     || (9 != mon_u.lod_u[0].mug_w)
      || (2 != mon_u.lod_u[1].mug_w)
      || (3 != mon_u.lod_u[2].mug_w) )
   {
-    fprintf(stderr, "_lod fail: insert order\r\n");
-    ret_i = 0;
-  }
-
-  //  put on an existing path updates in place
-  //
-  _unix_lod_put(&mon_u, "/p/base/b.txt", 9);
-
-  if ( (3 != mon_u.lod_w) || (9 != mon_u.lod_u[1].mug_w) ) {
-    fprintf(stderr, "_lod fail: update\r\n");
+    fprintf(stderr, "_lod fail: fold\r\n");
     ret_i = 0;
   }
 
   //  deleting a file removes its entry, keeping order
   //
   {
-    u3_ufil fil_u;
-    memset(&fil_u, 0, sizeof(fil_u));
-    fil_u.dir   = c3n;
-    fil_u.pax_c = "/p/base/b.txt";
-    fil_u.par_u = &mon_u.dir_u;
+    u3_ufil del_u;
+    memset(&del_u, 0, sizeof(del_u));
+    del_u.dir   = c3n;
+    del_u.pax_c = "/p/base/b.txt";
+    del_u.par_u = &mon_u.dir_u;
 
-    _unix_lod_del(&unx_u, &fil_u);
+    _unix_lod_del(&unx_u, &del_u);
 
     if (  (2 != mon_u.lod_w)
        || (0 != strcmp(mon_u.lod_u[0].pax_c, "/p/base/a.txt"))
@@ -146,8 +157,8 @@ _test_lod()
 
     //  deleting a missing path is a no-op
     //
-    fil_u.pax_c = "/p/base/nope.txt";
-    _unix_lod_del(&unx_u, &fil_u);
+    del_u.pax_c = "/p/base/nope.txt";
+    _unix_lod_del(&unx_u, &del_u);
 
     if ( 2 != mon_u.lod_w ) {
       fprintf(stderr, "_lod fail: missing delete\r\n");
@@ -173,7 +184,7 @@ _test_seed()
   unx_u.pax_c = "/p";
   unx_u.mon_u = &mon_u;
 
-  _unix_lod_put(&mon_u, "/p/base/a.txt", 0xabcd);
+  _ut_lod_add(&mon_u, "/p/base/a.txt", 0xabcd);
 
   {
     u3_ufil* fil_u = c3_malloc(sizeof(u3_ufil));
@@ -274,9 +285,9 @@ _test_mug_cache()
     unx_u.mon_u = &mon_u;
 
     snprintf(pax_c, sizeof(pax_c), "%s/base/a.txt", pir_c);
-    _unix_lod_put(&mon_u, pax_c, 0x1111);
+    _ut_lod_add(&mon_u, pax_c, 0x1111);
     snprintf(pax_c, sizeof(pax_c), "%s/base/sub/b.hoon", pir_c);
-    _unix_lod_put(&mon_u, pax_c, 0x2222);
+    _ut_lod_add(&mon_u, pax_c, 0x2222);
 
     _unix_save_mugs(&unx_u, &mon_u);
     _unix_load_mugs(&unx_u, &won_u);


### PR DESCRIPTION
Implements the runtime side of per-file desk auto-sync — see the accompanying UIP draft (urbit/UIPs PR to follow) and the Arvo side in urbit/urbit#7362.

A mount point marked for auto-sync is watched with libuv fs-event watchers (one per directory). Changes are debounced until quiescence (100ms quiet, 1s cap), only affected subtrees are rescanned, and a `%into` event is injected containing only the files that actually changed. Deletions are confirmed through a 300ms grace period so editor delete-then-write save patterns don't propagate transient deletions.

Also fixes three event-log amplification bugs that affect plain `|commit`/`|autocommit`:

- empty `%into` events are no longer injected when a scan finds no changes (previously every autocommit tick logged one)
- per-file sync state is persisted per mount (`.urb/syn/<mon>.mug`) and reloaded at startup, so the first commit after a restart no longer writes the entire desk into the event log
- content mugs are computed over the octet-stream at declared length on both sides of every comparison; previously a noun mug was cached on one side, so files with trailing zero bytes were re-sent on every scan

Measured on a fake ship: 60s idle with auto-sync active adds 0 bytes to the event log (vs ~120 events/min under `|autocommit`), and a no-op restart adds ~0 bytes (previously the full desk, ~4.2MB). Unit tests cover the mug cache, lazy seeding, tree lookup, and sidecar round-trip/corruption handling; cross-compiles clean for x86_64-windows-gnu.
