### PR TITLE
retrieve: `u3r_met` returns `c3_d`

### DIFF
--- a/ext/natpmp/build.zig.zon
+++ b/ext/natpmp/build.zig.zon
@@ -4,8 +4,7 @@
     .version = "0.0.1",
     .dependencies = .{
         .natpmp = .{
-            .url = "https://mirrors.wikimedia.org/ubuntu/ubuntu/pool/main/libn/libnatpmp/libnatpmp_20230423.orig.tar.gz",
-            // .url = "https://debian.mirror.root.lu/debian/pool/main/libn/libnatpmp/libnatpmp_20230423.orig.tar.gz",
+            .url = "http://deb.debian.org/debian/pool/main/libn/libnatpmp/libnatpmp_20230423.orig.tar.gz",
             .hash = "N-V-__8AAKudAQA_d3eW8d8dskxBlLzGBg0qe-4u6ohSfCM2",
         },
     },

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -2017,7 +2017,11 @@ u3a_walk_fore(u3_noun    a,
 c3_c*
 u3a_string(u3_atom a)
 {
-  c3_w  met_w = u3r_met(3, a);
+  c3_d  met_d = u3r_met(3, a);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w  met_w = (c3_w)met_d;
   c3_c* str_c = u3a_malloc(met_w + 1);
 
   u3r_bytes(0, met_w, (c3_y*)str_c, a);

--- a/pkg/noun/imprison.c
+++ b/pkg/noun/imprison.c
@@ -669,7 +669,11 @@ u3i_edit(u3_noun big, u3_noun axe, u3_noun som)
     case 1: break;
 
     default: {
-      c3_w        dep_w = u3r_met(0, u3x_atom(axe)) - 2;
+      c3_d        dep_d = u3r_met(0, u3x_atom(axe)) - 2;
+      if ( UINT32_MAX < dep_d ) {
+        u3m_bail(c3__fail);
+      }
+      c3_w        dep_w = (c3_w)dep_d;
       const c3_w* axe_w = ( c3y == u3a_is_cat(axe) )
                         ? &axe
                         : ((u3a_atom*)u3a_to_ptr(axe))->buf_w;

--- a/pkg/noun/jets.c
+++ b/pkg/noun/jets.c
@@ -1800,7 +1800,11 @@ _cj_minx(u3_noun cey, u3_noun cor)
 static void
 _cj_print_tas(u3_noun tas)
 {
-  c3_w  met_w = u3r_met(3, tas);
+  c3_d  met_d = u3r_met(3, tas);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w  met_w = (c3_w)met_d;
   c3_c* str_c = alloca(met_w + 1);
   u3r_bytes(0, met_w, (c3_y*)str_c, tas);
   str_c[met_w] = 0;

--- a/pkg/noun/jets/a/add.c
+++ b/pkg/noun/jets/a/add.c
@@ -78,9 +78,9 @@ u3qa_add(u3_atom a,
     //  we have to do more measuring to avoid growing atom buffers on each
     //  addition as u3a_wtrim noops as of 3e8473d
     //
-    c3_w a_met0_w = u3r_met(0, a),
-         b_met0_w = u3r_met(0, b);
-    u3i_slab_init(&sab_u, 0, c3_max(a_met0_w, b_met0_w) + 1);
+    c3_d a_met0_d = u3r_met(0, a),
+         b_met0_d = u3r_met(0, b);
+    u3i_slab_init(&sab_u, 0, c3_max(a_met0_d, b_met0_d) + 1);
     
     c_buf_w = sab_u.buf_w;
 

--- a/pkg/noun/jets/c/aor.c
+++ b/pkg/noun/jets/c/aor.c
@@ -25,8 +25,17 @@
       else {
         if ( c3n == u3ud(b) ) return c3y;
         {
-          c3_w len_a_w = u3r_met(3, a);
-          c3_w len_b_w = u3r_met(3, b);;
+          c3_d len_a_d = u3r_met(3, a);
+          c3_d len_b_d = u3r_met(3, b);
+          c3_w len_a_w, len_b_w;
+          if ( UINT32_MAX < len_a_d ) {
+            u3m_bail(c3__fail);
+          }
+          if ( UINT32_MAX < len_b_d ) {
+            u3m_bail(c3__fail);
+          }
+          len_a_w = (c3_w)len_a_d;
+          len_b_w = (c3_w)len_b_d;
           c3_y *buf_a_y, *buf_b_y;
           c3_y cut_a_y, cut_b_y;
           if ( c3y == u3a_is_cat(a) ) {

--- a/pkg/noun/jets/c/c0n.c
+++ b/pkg/noun/jets/c/c0n.c
@@ -11,8 +11,18 @@
   u3qc_con(u3_atom a,
            u3_atom b)
   {
-    c3_w lna_w = u3r_met(5, a);
-    c3_w lnb_w = u3r_met(5, b);
+    c3_d lna_d = u3r_met(5, a);
+    c3_d lnb_d = u3r_met(5, b);
+    c3_w lna_w, lnb_w;
+
+    if ( UINT32_MAX < lna_d ) {
+      u3m_bail(c3__fail);
+    }
+    if ( UINT32_MAX < lnb_d ) {
+      u3m_bail(c3__fail);
+    }
+    lna_w = (c3_w)lna_d;
+    lnb_w = (c3_w)lnb_d;
 
     if ( (lna_w == 0) && (lnb_w == 0) ) {
       return 0;

--- a/pkg/noun/jets/c/cap.c
+++ b/pkg/noun/jets/c/cap.c
@@ -8,7 +8,13 @@
 u3_noun
 u3qc_cap(u3_atom a)
 {
-  c3_w met_w = u3r_met(0, a);
+  c3_d met_d = u3r_met(0, a);
+  c3_w met_w;
+
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  met_w = (c3_w)met_d;
 
   if ( 2 > met_w ) {
     return u3m_bail(c3__exit);

--- a/pkg/noun/jets/c/cat.c
+++ b/pkg/noun/jets/c/cat.c
@@ -16,18 +16,18 @@
     }
     else {
       c3_g   a_g = a;
-      c3_w   lew_w = u3r_met(a_g, b);
-      c3_w   ler_w = u3r_met(a_g, c);
-      c3_w   all_w = (lew_w + ler_w);
+      c3_d   lew_d = u3r_met(a_g, b);
+      c3_d   ler_d = u3r_met(a_g, c);
+      c3_d   all_d = (lew_d + ler_d);
 
-      if ( 0 == all_w ) {
+      if ( 0 == all_d ) {
         return 0;
       }
       else {
         u3i_slab sab_u;
-        u3i_slab_from(&sab_u, b, a_g, all_w);
+        u3i_slab_from(&sab_u, b, a_g, all_d);
 
-        u3r_chop(a_g, 0, ler_w, lew_w, sab_u.buf_w, c);
+        u3r_chop(a_g, 0, ler_d, lew_d, sab_u.buf_w, c);
 
         return u3i_slab_mint(&sab_u);
       }

--- a/pkg/noun/jets/c/clz.c
+++ b/pkg/noun/jets/c/clz.c
@@ -24,7 +24,13 @@ u3qc_clz(u3_atom boq, u3_atom sep, u3_atom a)
     return u3m_bail(c3__fail);
   }
 
-  c3_w met_w = u3r_met(0, a);
+  c3_d met_d = u3r_met(0, a);
+  c3_w met_w;
+
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  met_w = (c3_w)met_d;
 
   if ( met_w <= tot_w ) {
     tot_w -= met_w;

--- a/pkg/noun/jets/c/cut.c
+++ b/pkg/noun/jets/c/cut.c
@@ -25,7 +25,13 @@
 
     {
       c3_g a_g   = a;
-      c3_w len_w = u3r_met(a_g, d);
+      c3_d len_d = u3r_met(a_g, d);
+      c3_w len_w;
+
+      if ( UINT32_MAX < len_d ) {
+        u3m_bail(c3__fail);
+      }
+      len_w = (c3_w)len_d;
 
       if ( (0 == c_w) || (b_w >= len_w) ) {
         return 0;

--- a/pkg/noun/jets/c/dis.c
+++ b/pkg/noun/jets/c/dis.c
@@ -10,8 +10,18 @@
   u3qc_dis(u3_atom a,
            u3_atom b)
   {
-    c3_w lna_w = u3r_met(5, a);
-    c3_w lnb_w = u3r_met(5, b);
+    c3_d lna_d = u3r_met(5, a);
+    c3_d lnb_d = u3r_met(5, b);
+    c3_w lna_w, lnb_w;
+
+    if ( UINT32_MAX < lna_d ) {
+      u3m_bail(c3__fail);
+    }
+    if ( UINT32_MAX < lnb_d ) {
+      u3m_bail(c3__fail);
+    }
+    lna_w = (c3_w)lna_d;
+    lnb_w = (c3_w)lnb_d;
 
     if ( (lna_w == 0) && (lnb_w == 0) ) {
       return 0;

--- a/pkg/noun/jets/c/end.c
+++ b/pkg/noun/jets/c/end.c
@@ -19,12 +19,12 @@ u3qc_end(u3_atom a,
   else {
     c3_g a_g   = a;
     c3_w b_w   = b;
-    c3_w len_w = u3r_met(a_g, c);
+    c3_d len_d = u3r_met(a_g, c);
 
     if ( 0 == b_w ) {
       return 0;
     }
-    else if ( b_w >= len_w ) {
+    else if ( b_w >= len_d ) {
       return u3k(c);
     }
     else {

--- a/pkg/noun/jets/c/ham.c
+++ b/pkg/noun/jets/c/ham.c
@@ -8,9 +8,15 @@
 u3_atom
 u3qc_ham(u3_atom a)
 {
-  c3_w len_w = u3r_met(5, a);
+  c3_d len_d = u3r_met(5, a);
   c3_d pop_d = 0;
+  c3_w len_w;
   c3_w wor_w;
+
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  len_w = (c3_w)len_d;
 
   for ( c3_w i_w = 0; i_w < len_w; i_w++ ) {
     wor_w  = u3r_word(i_w, a);

--- a/pkg/noun/jets/c/lsh.c
+++ b/pkg/noun/jets/c/lsh.c
@@ -20,7 +20,13 @@ u3qc_lsh(u3_atom a,
   else {
     c3_g a_g   = a;
     c3_w b_w   = b;
-    c3_w len_w = u3r_met(a_g, c);
+    c3_d len_d = u3r_met(a_g, c);
+    c3_w len_w;
+
+    if ( UINT32_MAX < len_d ) {
+      u3m_bail(c3__fail);
+    }
+    len_w = (c3_w)len_d;
 
     if ( 0 == len_w ) {
       return 0;

--- a/pkg/noun/jets/c/mas.c
+++ b/pkg/noun/jets/c/mas.c
@@ -21,7 +21,12 @@ u3qc_mas(u3_atom a)
     }
   }
   else {
-    b_w = u3r_met(0, a);
+    c3_d b_d = u3r_met(0, a);
+
+    if ( UINT32_MAX < b_d ) {
+      u3m_bail(c3__fail);
+    }
+    b_w = (c3_w)b_d;
 
     if ( 64 > b_w ) {
       c3_d a_d = u3r_chub(0, a);

--- a/pkg/noun/jets/c/met.c
+++ b/pkg/noun/jets/c/met.c
@@ -17,12 +17,12 @@
       return u3m_bail(c3__fail);;
     }
     else {
-      c3_w met_w = u3r_met(a, b);
+      c3_d met_d = u3r_met(a, b);
 
-      if ( !_(u3a_is_cat(met_w)) ) {
-        return u3i_words(1, &met_w);
+      if ( !_(u3a_is_cat(met_d)) ) {
+        return u3i_chub(met_d);
       }
-      else return met_w;
+      else return met_d;
     }
   }
   u3_noun

--- a/pkg/noun/jets/c/mix.c
+++ b/pkg/noun/jets/c/mix.c
@@ -11,8 +11,18 @@
   u3qc_mix(u3_atom a,
            u3_atom b)
   {
-    c3_w lna_w = u3r_met(5, a);
-    c3_w lnb_w = u3r_met(5, b);
+    c3_d lna_d = u3r_met(5, a);
+    c3_d lnb_d = u3r_met(5, b);
+    c3_w lna_w, lnb_w;
+
+    if ( UINT32_MAX < lna_d ) {
+      u3m_bail(c3__fail);
+    }
+    if ( UINT32_MAX < lnb_d ) {
+      u3m_bail(c3__fail);
+    }
+    lna_w = (c3_w)lna_d;
+    lnb_w = (c3_w)lnb_d;
 
     if ( (lna_w == 0) && (lnb_w == 0) ) {
       return 0;

--- a/pkg/noun/jets/c/muk.c
+++ b/pkg/noun/jets/c/muk.c
@@ -16,11 +16,11 @@ u3qc_muk(u3_atom sed,
   }
   else {
     c3_w len_w = (c3_w)len;
-    c3_w key_w = u3r_met(3, key);
+    c3_d key_d = u3r_met(3, key);
 
     //  NB: this condition is implicit in the pad subtraction
     //
-    if ( key_w > len_w ) {
+    if ( key_d > len_w ) {
       return u3m_bail(c3__exit);
     }
     else {
@@ -32,7 +32,7 @@ u3qc_muk(u3_atom sed,
       //  if we're hashing more bytes than we have, allocate and copy
       //  to ensure trailing null bytes
       //
-      if ( len_w > key_w ) {
+      if ( len_w > key_d ) {
         loc_o = c3y;
         key_y = u3a_calloc(sizeof(c3_y), len_w);
         u3r_bytes(0, len_w, key_y, key);

--- a/pkg/noun/jets/c/peg.c
+++ b/pkg/noun/jets/c/peg.c
@@ -22,18 +22,22 @@ u3qc_peg(u3_atom a, u3_atom b)
     b_d = b;
   }
   else {
-    c3_w d_w = u3r_met(0, a);
+    c3_d d_d = u3r_met(0, a);
+    c3_d c_d = u3r_met(0, b) - 1;
     c3_d e_d;
 
-    c_w = u3r_met(0, b) - 1;
-    e_d = (c3_d)c_w + d_w;
+    if ( UINT32_MAX < c_d ) {
+      u3m_bail(c3__fail);
+    }
+    c_w = (c3_w)c_d;
+    e_d = (c3_d)c_w + d_d;
 
     if ( 64 <= e_d ) {
       u3i_slab sab_u;
       u3i_slab_init(&sab_u, 0, e_d);
 
       u3r_chop(0, 0, c_w,   0, sab_u.buf_w, b);
-      u3r_chop(0, 0, d_w, c_w, sab_u.buf_w, a);
+      u3r_chop(0, 0, d_d, c_w, sab_u.buf_w, a);
 
       return u3i_slab_moot(&sab_u);
     }

--- a/pkg/noun/jets/c/rap.c
+++ b/pkg/noun/jets/c/rap.c
@@ -26,6 +26,7 @@
         while ( 1 ) {
           u3_noun h_cab;
           c3_w    len_w;
+          c3_d    met_d;
 
           if ( 0 == cab ) {
             break;
@@ -36,8 +37,13 @@
           else if ( c3n == u3ud(h_cab = u3h(cab)) ) {
             return u3m_bail(c3__exit);
           }
-          else if ( (tot_w + (len_w = u3r_met(a_g, h_cab))) < tot_w ) {
-            return u3m_bail(c3__fail);
+          else {
+            if ( UINT32_MAX < (met_d = u3r_met(a_g, h_cab)) ) {
+              u3m_bail(c3__fail);
+            }
+            if ( (tot_w + (len_w = (c3_w)met_d)) < tot_w ) {
+              return u3m_bail(c3__fail);
+            }
           }
           tot_w += len_w;
           cab = u3t(cab);
@@ -58,8 +64,13 @@
 
         while ( 0 != cab ) {
           u3_noun h_cab = u3h(cab);
-          c3_w    len_w = u3r_met(a_g, h_cab);
+          c3_d    met_d = u3r_met(a_g, h_cab);
+          c3_w    len_w;
 
+          if ( UINT32_MAX < met_d ) {
+            u3m_bail(c3__fail);
+          }
+          len_w = (c3_w)met_d;
           u3r_chop(a_g, 0, len_w, pos_w, sab_u.buf_w, h_cab);
           pos_w += len_w;
           cab = u3t(cab);

--- a/pkg/noun/jets/c/rep.c
+++ b/pkg/noun/jets/c/rep.c
@@ -116,6 +116,7 @@ _block_rep(u3_atom a,
       while ( 1 ) {
         u3_noun h_cab;
         c3_w    len_w;
+        c3_d    met_d;
 
         if ( 0 == cab ) {
           break;
@@ -126,8 +127,13 @@ _block_rep(u3_atom a,
         else if ( c3n == u3ud(h_cab = u3h(cab)) ) {
           return u3m_bail(c3__exit);
         }
-        else if ( (tot_w + (len_w = u3r_met(a_g, h_cab))) < tot_w ) {
-          return u3m_bail(c3__fail);
+        else {
+          if ( UINT32_MAX < (met_d = u3r_met(a_g, h_cab)) ) {
+            u3m_bail(c3__fail);
+          }
+          if ( (tot_w + (len_w = (c3_w)met_d)) < tot_w ) {
+            return u3m_bail(c3__fail);
+          }
         }
         tot_w++;
         cab = u3t(cab);

--- a/pkg/noun/jets/c/rev.c
+++ b/pkg/noun/jets/c/rev.c
@@ -18,7 +18,13 @@
     }
 
     dat = u3qc_end(boz, len, dat);
-    c3_w met = u3r_met(boz, dat);
+    c3_d met_d = u3r_met(boz, dat);
+    c3_w met;
+
+    if ( UINT32_MAX < met_d ) {
+      u3m_bail(c3__fail);
+    }
+    met = (c3_w)met_d;
     return u3kc_lsh(boz, (len - met), u3kc_swp(boz, dat));
   }
 

--- a/pkg/noun/jets/c/rip.c
+++ b/pkg/noun/jets/c/rip.c
@@ -58,7 +58,11 @@ _bit_rip(u3_atom bits, u3_atom atom)
     return u3m_bail(c3__fail);
   }
 
-  c3_w bit_width  = u3r_met(0, atom);
+  c3_d bit_width_d = u3r_met(0, atom);
+  if ( UINT32_MAX < bit_width_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w bit_width  = (c3_w)bit_width_d;
   c3_w num_blocks = DIVCEIL(bit_width, bits);
 
   u3_noun res = u3_nul;
@@ -104,7 +108,11 @@ _block_rip(u3_atom bloq, u3_atom b)
   if ( bloq_g < 5 ) {                                   //  produce direct atoms
     u3_noun acc     = u3_nul;
 
-    c3_w met_w   = u3r_met(bloq_g, b);                  //  num blocks in atom
+    c3_d met_d   = u3r_met(bloq_g, b);                  //  num blocks in atom
+    if ( UINT32_MAX < met_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w met_w   = (c3_w)met_d;
     c3_w nbits_w = 1 << bloq_g;                         //  block size in bits
     c3_w bmask_w = (1 << nbits_w) - 1;                  //  result mask
 
@@ -124,8 +132,16 @@ _block_rip(u3_atom bloq, u3_atom b)
   }
 
   u3_noun acc   = u3_nul;
-  c3_w    met_w = u3r_met(bloq_g, b);
-  c3_w    len_w = u3r_met(5, b);
+  c3_d    met_d = u3r_met(bloq_g, b);
+  c3_d    len_d = u3r_met(5, b);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w    met_w = (c3_w)met_d;
+  c3_w    len_w = (c3_w)len_d;
   c3_g    san_g = (bloq_g - 5);
   c3_w    san_w = 1 << san_g;
   c3_w    dif_w = (met_w << san_g) - len_w;

--- a/pkg/noun/jets/c/rsh.c
+++ b/pkg/noun/jets/c/rsh.c
@@ -20,16 +20,16 @@ u3qc_rsh(u3_atom a,
   else {
     c3_g a_g   = a;
     c3_w b_w   = b;
-    c3_w len_w = u3r_met(a_g, c);
+    c3_d len_d = u3r_met(a_g, c);
 
-    if ( b_w >= len_w ) {
+    if ( b_w >= len_d ) {
       return 0;
     }
     else {
       u3i_slab sab_u;
-      u3i_slab_init(&sab_u, a_g, (len_w - b_w));
+      u3i_slab_init(&sab_u, a_g, (len_d - b_w));
 
-      u3r_chop(a_g, b_w, (len_w - b_w), 0, sab_u.buf_w, c);
+      u3r_chop(a_g, b_w, (len_d - b_w), 0, sab_u.buf_w, c);
 
       return u3i_slab_mint(&sab_u);
     }

--- a/pkg/noun/jets/c/sew.c
+++ b/pkg/noun/jets/c/sew.c
@@ -24,7 +24,7 @@ u3qc_sew(u3_atom a,
   }
 
   c3_g a_g = a;
-  c3_w len_e_w = u3r_met(a_g, e);
+  c3_d len_e_d = u3r_met(a_g, e);
   u3i_slab sab_u;
   c3_w* src_w;
   c3_w len_src_w;
@@ -37,13 +37,13 @@ u3qc_sew(u3_atom a,
     len_src_w = src_u->len_w;
     src_w = src_u->buf_w;
   }
-  u3i_slab_init(&sab_u, a_g, c3_max(len_e_w, b_w + c_w));
+  u3i_slab_init(&sab_u, a_g, c3_max(len_e_d, b_w + c_w));
   u3r_chop_words(a_g, 0, b_w, 0, sab_u.buf_w, len_src_w, src_w);
   u3r_chop(a_g, 0, c_w, b_w, sab_u.buf_w, d);
-  if (len_e_w > b_w + c_w) {
+  if (len_e_d > b_w + c_w) {
     u3r_chop_words(a_g,
              b_w + c_w,
-             len_e_w - (b_w + c_w),
+             len_e_d - (b_w + c_w),
              b_w + c_w,
              sab_u.buf_w,
              len_src_w,

--- a/pkg/noun/jets/c/swp.c
+++ b/pkg/noun/jets/c/swp.c
@@ -14,7 +14,13 @@ u3qc_swp(u3_atom a,
     return u3m_bail(c3__fail);
   }
   c3_g a_g = a;
-  c3_w len_w = u3r_met(a_g, b);
+  c3_d len_d = u3r_met(a_g, b);
+  c3_w len_w;
+
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  len_w = (c3_w)len_d;
   u3i_slab sab_u;
   u3i_slab_init(&sab_u, a_g, len_w);
 

--- a/pkg/noun/jets/c/xeb.c
+++ b/pkg/noun/jets/c/xeb.c
@@ -9,12 +9,12 @@
   u3_noun
   u3qc_xeb(u3_atom a)
   {
-    c3_w met_w = u3r_met(0, a);
+    c3_d met_d = u3r_met(0, a);
 
-    if ( !_(u3a_is_cat(met_w)) ) {
-      return u3i_words(1, &met_w);
+    if ( !_(u3a_is_cat(met_d)) ) {
+      return u3i_chub(met_d);
     }
-    else return met_w;
+    else return met_d;
   }
   u3_noun
   u3wc_xeb(u3_noun cor)

--- a/pkg/noun/jets/e/adler.c
+++ b/pkg/noun/jets/e/adler.c
@@ -28,7 +28,11 @@ static c3_o _x_octs_buffer(u3_atom* p_octs, u3_atom *q_octs,
     return c3n;
   }
 
-  *len_w = u3r_met(3, *q_octs);
+  c3_d met_d = u3r_met(3, *q_octs);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  *len_w = (c3_w)met_d;
 
   if (c3y == u3a_is_cat(*q_octs)) {
     *buf_y = (c3_y*)q_octs;

--- a/pkg/noun/jets/e/aes_siv.c
+++ b/pkg/noun/jets/e/aes_siv.c
@@ -27,8 +27,12 @@ _cqea_measure_ads(u3_noun ads, c3_w* soc_w, c3_w *mat_w, c3_w *dat_w)
       return;
     }
     else {
+      c3_d met_d = u3r_met(3, i);
+      if ( UINT32_MAX < met_d ) {
+        u3m_bail(c3__fail);
+      }
       tmp_w = b_w;
-      b_w += u3r_met(3, i);
+      b_w += (c3_w)met_d;
       if ( b_w < tmp_w ) {
         u3m_bail(c3__fail);
         return;
@@ -62,8 +66,13 @@ _cqea_encode_ads(u3_noun ads,
   c3_y *dat_y = ((c3_y*) dat_u) + mat_w;
 
   for ( cur_u = dat_u, t = ads; u3_nul != t; t = u3t(t), ++cur_u ) {
+    c3_d met_d;
     i = u3h(t);
-    met_w = u3r_met(3, i);
+    met_d = u3r_met(3, i);
+    if ( UINT32_MAX < met_d ) {
+      u3m_bail(c3__fail);
+    }
+    met_w = (c3_w)met_d;
     u3r_bytes(0, met_w, dat_y, i);
     cur_u->length = met_w;
     cur_u->bytes = dat_y;

--- a/pkg/noun/jets/e/base.c
+++ b/pkg/noun/jets/e/base.c
@@ -110,7 +110,11 @@ _of_hex_even(u3_atom inp, c3_w len_w, c3_y* buf_y)
 u3_noun
 u3qe_de_base16(u3_atom inp)
 {
-  c3_w     len_w = u3r_met(4, inp);
+  c3_d     len_d = u3r_met(4, inp);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w     len_w = (c3_w)len_d;
   u3i_slab sab_u;
 
   u3i_slab_bare(&sab_u, 3, len_w);
@@ -120,7 +124,11 @@ u3qe_de_base16(u3_atom inp)
   //  but odd byte-length input cannot, and is expressed more simply in bytes.
   //
   {
-    c3_w byt_w = u3r_met(3, inp);
+    c3_d byt_d = u3r_met(3, inp);
+    if ( UINT32_MAX < byt_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w byt_w = (c3_w)byt_d;
     c3_o ret_o = ( byt_w & 1 )
                ? _of_hex_odd(inp, len_w, byt_w, sab_u.buf_y)
                : _of_hex_even(inp, len_w, sab_u.buf_y);

--- a/pkg/noun/jets/e/bytestream.c
+++ b/pkg/noun/jets/e/bytestream.c
@@ -32,7 +32,11 @@ _x_octs_buffer(u3_atom* p_octs, u3_atom *q_octs,
     return c3n;
   }
 
-  *len_w = u3r_met(3, *q_octs);
+  c3_d met_d = u3r_met(3, *q_octs);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  *len_w = (c3_w)met_d;
 
   if (c3y == u3a_is_cat(*q_octs)) {
     *buf_y = (c3_y*)q_octs;
@@ -232,7 +236,11 @@ _qe_bytestream_can_octs(u3_noun octs_list) {
   //  octs is non-zero: but at the return u3i_slab_mint
   //  takes care of trimming.
   //
-  c3_w last_lead_w = (u3r_word(0, u3h(octs)) - u3r_met(3, u3t(octs)));
+  c3_d last_met_d = u3r_met(3, u3t(octs));
+  if ( UINT32_MAX < last_met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w last_lead_w = (u3r_word(0, u3h(octs)) - (c3_w)last_met_d);
   c3_d buf_len_w = tot_d - last_lead_w;
 
   if (buf_len_w == 0) {

--- a/pkg/noun/jets/e/crc.c
+++ b/pkg/noun/jets/e/crc.c
@@ -13,7 +13,11 @@ u3qe_crc32(u3_noun input_octs)
 {
   u3_atom head = u3h(input_octs);
   u3_atom tail = u3t(input_octs);
-  c3_w  tel_w = u3r_met(3, tail);
+  c3_d  tel_d = u3r_met(3, tail);
+  if ( UINT32_MAX < tel_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w  tel_w = (c3_w)tel_d;
   c3_w hed_w;
   if ( c3n == u3r_safe_word(head, &hed_w) ) {
     return u3m_bail(c3__fail);

--- a/pkg/noun/jets/e/ed_add_double_scalarmult.c
+++ b/pkg/noun/jets/e/ed_add_double_scalarmult.c
@@ -15,11 +15,11 @@
     c3_y a_y[32], a_point_y[32],
          b_y[32], b_point_y[32],
          out_y[32];
-    c3_w met_w;
+    c3_d met_d;
 
-    met_w = u3r_met(3, a);
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    met_d = u3r_met(3, a);
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, a)) )
         ) {
       u3_noun a_recs = u3qee_recs(a);
@@ -29,9 +29,9 @@
       u3r_bytes(0, 32, a_y, a);
     }
 
-    met_w = u3r_met(3, b);
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    met_d = u3r_met(3, b);
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, b)) )
         ) {
       u3_noun b_recs = u3qee_recs(b);

--- a/pkg/noun/jets/e/ed_add_scalarmult_scalarmult_base.c
+++ b/pkg/noun/jets/e/ed_add_scalarmult_scalarmult_base.c
@@ -12,11 +12,11 @@
                                       u3_atom b)
   {
     c3_y a_y[32], a_point_y[32], b_y[32], out_y[32];
-    c3_w met_w;
+    c3_d met_d;
 
-    met_w = u3r_met(3, a);
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    met_d = u3r_met(3, a);
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, a)) )
         ) {
       u3_noun a_recs = u3qee_recs(a);
@@ -26,9 +26,9 @@
       u3r_bytes(0, 32, a_y, a);
     }
 
-    met_w = u3r_met(3, b);
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    met_d = u3r_met(3, b);
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, b)) )
         ) {
       u3_noun b_recs = u3qee_recs(b);

--- a/pkg/noun/jets/e/ed_recs.c
+++ b/pkg/noun/jets/e/ed_recs.c
@@ -17,9 +17,9 @@
   u3_atom
   u3qee_recs(u3_atom a)
   {
-    c3_w met_w = u3r_met(3, a);
+    c3_d met_d = u3r_met(3, a);
 
-    if ( 64 < met_w ) {
+    if ( 64 < met_d ) {
       u3_atom l_prime = u3i_bytes(32, _cqee_l_prime);
       u3_atom pro = u3qa_mod(a, l_prime);
       u3z(l_prime);

--- a/pkg/noun/jets/e/ed_scalarmult.c
+++ b/pkg/noun/jets/e/ed_scalarmult.c
@@ -15,10 +15,10 @@
       return u3m_bail(c3__exit);
     }
 
-    c3_w met_w = u3r_met(3, a);
+    c3_d met_d = u3r_met(3, a);
     // scalarmult expects a_y[31] <= 127
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, a)) )
         ) {
       u3_noun a_recs = u3qee_recs(a);

--- a/pkg/noun/jets/e/ed_scalarmult_base.c
+++ b/pkg/noun/jets/e/ed_scalarmult_base.c
@@ -10,10 +10,10 @@
   _cqee_scalarmult_base(u3_atom a)
   {
     c3_y a_y[32], out_y[32];
-    c3_w met_w = u3r_met(3, a);
+    c3_d met_d = u3r_met(3, a);
     // scalarmult_base expects a_y[31] <= 127
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, a)) )
         ) {
       u3_noun a_recs = u3qee_recs(a);

--- a/pkg/noun/jets/e/ed_smac.c
+++ b/pkg/noun/jets/e/ed_smac.c
@@ -12,11 +12,11 @@
              u3_atom c)
   {
     c3_y a_y[32], b_y[32], c_y[32], out_y[32];
-    c3_w met_w;
+    c3_d met_d;
 
-    met_w = u3r_met(3, a);
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    met_d = u3r_met(3, a);
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, a)) )
         ) {
       u3_noun a_recs = u3qee_recs(a);
@@ -26,9 +26,9 @@
       u3r_bytes(0, 32, a_y, a);
     }
 
-    met_w = u3r_met(3, b);
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    met_d = u3r_met(3, b);
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, b)) )
         ) {
       u3_noun b_recs = u3qee_recs(b);
@@ -38,9 +38,9 @@
       u3r_bytes(0, 32, b_y, b);
     }
 
-    met_w = u3r_met(3, c);
-    if ( (32 < met_w) ||
-         ( (32 == met_w) &&
+    met_d = u3r_met(3, c);
+    if ( (32 < met_d) ||
+         ( (32 == met_d) &&
            (127 < u3r_byte(31, c)) )
         ) {
       u3_noun c_recs = u3qee_recs(c);

--- a/pkg/noun/jets/e/fein_ob.c
+++ b/pkg/noun/jets/e/fein_ob.c
@@ -60,13 +60,13 @@ _feis_ob(c3_w m_w)
 u3_atom
 u3qe_fein_ob(u3_atom pyn)
 {
-  c3_w sor_w = u3r_met(4, pyn);
+  c3_d sor_d = u3r_met(4, pyn);
 
-  if ( (sor_w < 2) || (sor_w > 4) ) {
+  if ( (sor_d < 2) || (sor_d > 4) ) {
     return u3k(pyn);
   }
 
-  if ( 2 == sor_w ) {
+  if ( 2 == sor_d ) {
     return u3i_word(_feis_ob(u3r_word(0, pyn)));
   }
   else {

--- a/pkg/noun/jets/e/fynd_ob.c
+++ b/pkg/noun/jets/e/fynd_ob.c
@@ -64,13 +64,13 @@ _tail_ob(c3_w m_w)
 u3_atom
 u3qe_fynd_ob(u3_atom pyn)
 {
-  c3_w sor_w = u3r_met(4, pyn);
+  c3_d sor_d = u3r_met(4, pyn);
 
-  if ( (sor_w < 2) || (sor_w > 4) ) {
+  if ( (sor_d < 2) || (sor_d > 4) ) {
     return u3k(pyn);
   }
 
-  if ( 2 == sor_w ) {
+  if ( 2 == sor_d ) {
     return u3i_word(_tail_ob(u3r_word(0, pyn)));
   }
   else {

--- a/pkg/noun/jets/e/json_de.c
+++ b/pkg/noun/jets/e/json_de.c
@@ -94,7 +94,11 @@ _parse(u3_atom txt)
 
   const c3_y *byt_y;
   c3_z        cnt_z;
-  c3_w        len_w = u3r_met(3, txt);
+  c3_d        len_d = u3r_met(3, txt);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w        len_w = (c3_w)len_d;
 
   //
   // initialization

--- a/pkg/noun/jets/e/json_en.c
+++ b/pkg/noun/jets/e/json_en.c
@@ -115,7 +115,11 @@ _measure_number(u3_noun a)
     u3m_bail(c3__exit);
   }
 
-  return u3r_met(3, a);
+  c3_d met_d = u3r_met(3, a);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  return (c3_w)met_d;
 }
 
 static void
@@ -133,7 +137,11 @@ _serialize_number(json_buffer *buf_u, u3_noun a)
     byt_y = (c3_y*)vat_u->buf_w;
   }
 
-  _append_text(buf_u, byt_y, u3r_met(3, a));
+  c3_d met_d = u3r_met(3, a);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  _append_text(buf_u, byt_y, (c3_w)met_d);
 }
 
 static c3_w
@@ -143,7 +151,11 @@ _measure_string(u3_noun a)
     u3m_bail(c3__exit);
   }
 
-  c3_w len_w = u3r_met(3, a);
+  c3_d len_d = u3r_met(3, a);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w len_w = (c3_w)len_d;
   c3_w siz_w = 0;
 
   for (c3_w i = 0; i < len_w; ++i) {
@@ -184,7 +196,11 @@ _measure_string(u3_noun a)
 static void
 _serialize_string(json_buffer *buf_u, u3_noun a)
 {
-  c3_w len_w = u3r_met(3, a);
+  c3_d len_d = u3r_met(3, a);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w len_w = (c3_w)len_d;
 
   _append_char(buf_u, '"');
   for (c3_w i = 0; i < len_w; ++i) {

--- a/pkg/noun/jets/e/leer.c
+++ b/pkg/noun/jets/e/leer.c
@@ -29,7 +29,11 @@ _leer_cut(c3_w pos_w, c3_w len_w, u3_atom src)
 u3_noun
 u3qe_lore(u3_atom lub)
 {
-  c3_w    len_w = u3r_met(3, lub);
+  c3_d    len_d = u3r_met(3, lub);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w    len_w = (c3_w)len_d;
   c3_w    pos_w = 0;
   u3_noun tez = u3_nul;
 
@@ -90,7 +94,11 @@ u3qe_leer(u3_atom txt)
   u3_noun* lit = &pro;
 
   {
-    c3_w pos_w, i_w = 0, len_w = u3r_met(3, txt);
+    c3_d len_d = u3r_met(3, txt);
+    if ( UINT32_MAX < len_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w pos_w, i_w = 0, len_w = (c3_w)len_d;
     u3_noun* hed;
     u3_noun* tel;
 

--- a/pkg/noun/jets/e/lune.c
+++ b/pkg/noun/jets/e/lune.c
@@ -14,7 +14,11 @@
     }
 
     {
-      c3_w end_w  = u3r_met(3, lub) - 1;
+      c3_d met_d  = u3r_met(3, lub);
+      if ( UINT32_MAX < met_d ) {
+        u3m_bail(c3__fail);
+      }
+      c3_w end_w  = (c3_w)met_d - 1;
       c3_w pos_w  = end_w;
       u3_noun lin = u3_nul;
 

--- a/pkg/noun/jets/e/rub.c
+++ b/pkg/noun/jets/e/rub.c
@@ -16,7 +16,11 @@
 
     u3_atom m;
     {
-      c3_w  bit_w = u3r_met(0, b);
+      c3_d  bit_d = u3r_met(0, b);
+      if ( UINT32_MAX < bit_d ) {
+        u3m_bail(c3__fail);
+      }
+      c3_w  bit_w = (c3_w)bit_d;
       u3_noun bit = u3i_words(1, &bit_w);
       m = u3qa_add(a, bit);
       u3z(bit);

--- a/pkg/noun/jets/e/scr.c
+++ b/pkg/noun/jets/e/scr.c
@@ -115,8 +115,16 @@
             u3_atom z,
             u3_atom d)
   {
-     return _cqes_hs(p, u3r_met(3, p),
-                     s, u3r_met(3, s),
+     c3_d pwd_d = u3r_met(3, p);
+     c3_d sal_d = u3r_met(3, s);
+     if ( UINT32_MAX < pwd_d ) {
+       u3m_bail(c3__fail);
+     }
+     if ( UINT32_MAX < sal_d ) {
+       u3m_bail(c3__fail);
+     }
+     return _cqes_hs(p, (c3_w)pwd_d,
+                     s, (c3_w)sal_d,
                      n, r, z, d);
   }
 
@@ -205,8 +213,16 @@
   static u3_atom
   _cqes_pbk(u3_atom p, u3_atom s, u3_atom c, u3_atom d)
   {
-    return _cqes_pb(p, u3r_met(3, p),
-                    s, u3r_met(3, s),
+    c3_d pwd_d = u3r_met(3, p);
+    c3_d sal_d = u3r_met(3, s);
+    if ( UINT32_MAX < pwd_d ) {
+      u3m_bail(c3__fail);
+    }
+    if ( UINT32_MAX < sal_d ) {
+      u3m_bail(c3__fail);
+    }
+    return _cqes_pb(p, (c3_w)pwd_d,
+                    s, (c3_w)sal_d,
                     c, d);
   }
 

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -732,7 +732,11 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
     u3_atom name = u3x_atom(u3at(arr_sam_2, monad));
     u3_noun args = u3at(arr_sam_3, monad);
 
-    c3_w met_w = u3r_met(3, name);
+    c3_d met_d = u3r_met(3, name);
+    if ( UINT32_MAX < met_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w met_w = (c3_w)met_d;
     c3_c* name_c = u3a_malloc(met_w + 1);
     u3r_bytes(0, met_w, (c3_y*)name_c, name);
     name_c[met_w] = 0;
@@ -1146,7 +1150,11 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
     u3_atom name = u3x_atom(u3at(arr_sam_2, monad));
     u3_atom value = u3x_atom(u3at(arr_sam_3, monad));
 
-    c3_w met_w = u3r_met(3, name);
+    c3_d met_d = u3r_met(3, name);
+    if ( UINT32_MAX < met_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w met_w = (c3_w)met_d;
     c3_c* name_c = u3a_malloc(met_w + 1);
     u3r_bytes(0, met_w, (c3_y*)name_c, name);
     name_c[met_w] = 0;
@@ -1218,7 +1226,11 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
     //  global-get
     u3_atom name = u3x_atom(u3at(arr_sam, monad));
 
-    c3_w met_w = u3r_met(3, name);
+    c3_d met_d = u3r_met(3, name);
+    if ( UINT32_MAX < met_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w met_w = (c3_w)met_d;
     c3_c* name_c = u3a_malloc(met_w + 1);
     u3r_bytes(0, met_w, (c3_y*)name_c, name);
     name_c[met_w] = 0;
@@ -1468,7 +1480,11 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
         u3m_bail(c3__fail);
       }
       u3_noun name = u3t(frame);
-      c3_w met_w = u3r_met(3, name);
+      c3_d met_d = u3r_met(3, name);
+      if ( UINT32_MAX < met_d ) {
+        u3m_bail(c3__fail);
+      }
+      c3_w met_w = (c3_w)met_d;
       c3_c* name_c = u3a_malloc(met_w + 1);
       u3r_bytes(0, met_w, (c3_y*)name_c, name);
       u3z(frame);

--- a/pkg/noun/jets/e/zlib.c
+++ b/pkg/noun/jets/e/zlib.c
@@ -38,7 +38,11 @@ _decompress(u3_atom pos, u3_noun octs, int window_bits)
     return u3_none;
   }
 
-  c3_w len_w = u3r_met(3, q_octs);
+  c3_d len_d = u3r_met(3, q_octs);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w len_w = (c3_w)len_d;
 
   int leading_zeros = 0;
 

--- a/pkg/noun/jets/f/fitz.c
+++ b/pkg/noun/jets/f/fitz.c
@@ -9,9 +9,18 @@ static u3_noun
 _fitz_fiz(u3_noun yaz,
           u3_noun wix)
 {
-  c3_w yaz_w = u3r_met(3, yaz);
-  c3_w wix_w = u3r_met(3, wix);
+  c3_d yaz_d = u3r_met(3, yaz);
+  c3_d wix_d = u3r_met(3, wix);
   c3_y yaz_y, wix_y;
+
+  if ( UINT32_MAX < yaz_d ) {
+    u3m_bail(c3__fail);
+  }
+  if ( UINT32_MAX < wix_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w yaz_w = (c3_w)yaz_d;
+  c3_w wix_w = (c3_w)wix_d;
 
   yaz_y = (0 == yaz_w) ? 0 : u3r_byte((yaz_w - 1), yaz);
   if ( (yaz_y < 'A') || (yaz_y > 'Z') ) yaz_y = 0;
@@ -32,8 +41,17 @@ u3_noun
 u3qf_fitz(u3_noun yaz,
           u3_noun wix)
 {
-  c3_w yet_w = u3r_met(3, yaz);
-  c3_w wet_w = u3r_met(3, wix);
+  c3_d yet_d = u3r_met(3, yaz);
+  c3_d wet_d = u3r_met(3, wix);
+
+  if ( UINT32_MAX < yet_d ) {
+    u3m_bail(c3__fail);
+  }
+  if ( UINT32_MAX < wet_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w yet_w = (c3_w)yet_d;
+  c3_w wet_w = (c3_w)wet_d;
 
   c3_w i_w, met_w = c3_min(yet_w, wet_w);
 

--- a/pkg/noun/jets/g/plot.c
+++ b/pkg/noun/jets/g/plot.c
@@ -108,7 +108,13 @@ _met_list(c3_g    a_g,
 
       //  ?@  i.b.p
       if ( c3y == u3a_is_atom(i) ) {
-        met_w  = u3r_met(a_g, i);
+        {
+          c3_d met_d = u3r_met(a_g, i);
+          if ( UINT32_MAX < met_d ) {
+            u3m_bail(c3__fail);
+          }
+          met_w = (c3_w)met_d;
+        }
         sep_w += met_w;  // XX overflow
       }
       else {
@@ -232,7 +238,13 @@ _fax_list(u3i_slab* sab_u,
 
       //  ?@  i.b.p
       if ( c3y == u3a_is_atom(i) ) {
-        met_w  = u3r_met(a_g, i);
+        {
+          c3_d met_d = u3r_met(a_g, i);
+          if ( UINT32_MAX < met_d ) {
+            u3m_bail(c3__fail);
+          }
+          met_w = (c3_w)met_d;
+        }
 
         u3r_chop(a_g, 0, met_w, sep_w, sab_u->buf_w, i);
 

--- a/pkg/noun/jets/i/lagoon.c
+++ b/pkg/noun/jets/i/lagoon.c
@@ -119,7 +119,11 @@
     u3_atom sin = _get_length(shp);     // calculated length of ray
 
     //  Calculate actual size.
-    u3_atom len = u3r_met(blq, u3t(ray));   // length of ray
+    c3_d len_d = u3r_met(blq, u3t(ray));    // length of ray
+    if ( UINT32_MAX < len_d ) {
+      u3m_bail(c3__fail);
+    }
+    u3_atom len = (u3_atom)len_d;
     u3_atom dex = u3qa_dec(len);            // decrement length b/c of pinned 1
 
     return __(sin == dex);

--- a/pkg/noun/jets_tests.c
+++ b/pkg/noun/jets_tests.c
@@ -481,7 +481,7 @@ _test_en_base16(void)
 
   {
     u3_atom dat = 0xaa;
-    u3_atom pro = u3qe_en_base16(u3r_met(3, dat), dat);
+    u3_atom pro = u3qe_en_base16((c3_w)u3r_met(3, dat), dat);
 
     if ( c3n == u3r_sing_c("aa", pro) ) {
       fprintf(stderr, "en_base16: fail (a)\r\n");
@@ -493,7 +493,7 @@ _test_en_base16(void)
 
   {
     u3_atom dat = 0x1234;
-    u3_atom pro = u3qe_en_base16(u3r_met(3, dat), dat);
+    u3_atom pro = u3qe_en_base16((c3_w)u3r_met(3, dat), dat);
 
     if ( c3n == u3r_sing_c("1234", pro) ) {
       fprintf(stderr, "en_base16: fail (b)\r\n");
@@ -505,7 +505,7 @@ _test_en_base16(void)
 
   {
     u3_atom dat = 0xf012;
-    u3_atom pro = u3qe_en_base16(u3r_met(3, dat), dat);
+    u3_atom pro = u3qe_en_base16((c3_w)u3r_met(3, dat), dat);
 
     if ( c3n == u3r_sing_c("f012", pro) ) {
       fprintf(stderr, "en_base16: fail (c)\r\n");
@@ -517,7 +517,7 @@ _test_en_base16(void)
 
   {
     u3_atom dat = 0x10b;
-    u3_atom pro = u3qe_en_base16(u3r_met(3, dat), dat);
+    u3_atom pro = u3qe_en_base16((c3_w)u3r_met(3, dat), dat);
 
     if ( c3n == u3r_sing_c("010b", pro) ) {
       fprintf(stderr, "en_base16: fail (d)\r\n");

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -2064,7 +2064,11 @@ _cm_in_pretty(u3_noun som, c3_o sel_o, c3_c* str_c)
       return len_w;
     }
     else {
-      c3_w len_w = u3r_met(3, som);
+      c3_d len_d = u3r_met(3, som);
+      if ( UINT32_MAX < len_d ) {
+        u3m_bail(c3__fail);
+      }
+      c3_w len_w = (c3_w)len_d;
 
       if ( _(_cm_is_tas(som, len_w)) ) {
         if ( str_c ) {
@@ -2167,7 +2171,11 @@ _cm_in_pretty_path(u3_noun som, c3_c* str_c)
     return sel_w + one_w + two_w;
   }
   else {
-    c3_w len_w = u3r_met(3, som);
+    c3_d len_d = u3r_met(3, som);
+    if ( UINT32_MAX < len_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w len_w = (c3_w)len_d;
     if ( str_c && len_w ) {
       u3r_bytes(0, len_w, (c3_y *)str_c, som);
       str_c += len_w;

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -963,57 +963,11 @@ u3r_pqrs(u3_noun  a,
 **   (1 << a_y).
 **
 **   For example, (a_y == 3) returns the size in bytes.
-**   NB: (a_y) must be < 37.
+**   NB: (a_y) must be < 69.
 */
-c3_w
+c3_d
 u3r_met(c3_y  a_y,
         u3_atom b)
-{
-  c3_dessert(u3_none != b);
-  c3_dessert(_(u3a_is_atom(b)));
-
-  if ( b == 0 ) {
-    return 0;
-  }
-  /* gal_w: number of words besides (daz_w) in (b).
-  ** daz_w: top word in (b).
-  */
-  c3_w gal_w;
-  c3_w daz_w;
-
-  if ( _(u3a_is_cat(b)) ) {
-    gal_w = 0;
-    daz_w = b;
-  }
-  else {
-    u3a_atom* b_u = u3a_to_ptr(b);
-
-    gal_w = (b_u->len_w) - 1;
-    daz_w = b_u->buf_w[gal_w];
-  }
-
-  /* 5 because 1<<2 bytes in c3_w, 1<<3 bits in byte.
-     aka log2(CHAR_BIT * sizeof gal_w)
-     a_y < 5 informs whether we shift return left or right
-     */
-  if (a_y < 5) {
-    c3_y max_y = (1 << a_y) - 1;
-    c3_y gow_y = 5 - a_y;
-
-    if (gal_w > ((UINT32_MAX - (32 + max_y)) >> gow_y))
-      return u3m_bail(c3__fail);
-
-    return (gal_w << gow_y)
-      + ((c3_bits_word(daz_w) + max_y)
-         >> a_y);
-  }
-  c3_y gow_y = (a_y - 5);
-  return ((gal_w + 1) + ((1 << gow_y) - 1)) >> gow_y;
-}
-
-c3_d
-u3r_met_d(c3_y  a_y,
-          u3_atom b)
 {
   c3_dessert(u3_none != b);
   c3_dessert(_(u3a_is_atom(b)));
@@ -1169,13 +1123,13 @@ u3r_bytes(c3_w    a_w,
 c3_w
 u3r_bytes_fit(c3_w len_w, c3_y *buf_y, u3_atom a)
 {
-  c3_w met_w = u3r_met(3, a);
-  if ( met_w <= len_w ) {
+  c3_d met_d = u3r_met(3, a);
+  if ( met_d <= len_w ) {
     u3r_bytes(0, len_w, buf_y, a);
     return 0;
   }
   else {
-    return len_w - met_w;
+    return (c3_w)(len_w - met_d);
   }
 }
 
@@ -1201,7 +1155,11 @@ u3r_bytes_alloc(c3_w    a_w,
 c3_y*
 u3r_bytes_all(c3_w* len_w, u3_atom a)
 {
-  c3_w met_w = *len_w = u3r_met(3, a);
+  c3_d met_d = u3r_met(3, a);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w met_w = *len_w = (c3_w)met_d;
   return u3r_bytes_alloc(0, met_w, a);
 }
 
@@ -1626,7 +1584,11 @@ u3r_chop(c3_g  met_g,
 c3_c*
 u3r_string(u3_atom a)
 {
-  c3_w  met_w = u3r_met(3, a);
+  c3_d  met_d = u3r_met(3, a);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w  met_w = (c3_w)met_d;
   c3_c* str_c = c3_malloc(met_w + 1);
 
   u3r_bytes(0, met_w, (c3_y*)str_c, a);

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -342,23 +342,11 @@
       **   (1 << a_y).
       **
       **   For example, (a_y == 3) returns the size in bytes.
-      **   NB: (a_y) must be < 37.
-      */
-        c3_w
-        u3r_met(c3_y    a_y,
-                u3_atom b);
-
-      /* u3r_met_d():
-      **
-      **   Return the size of (b) in bits, rounded up to
-      **   (1 << a_y).
-      **
-      **   For example, (a_y == 3) returns the size in bytes.
       **   NB: (a_y) must be < 69.
       */
         c3_d
-        u3r_met_d(c3_y    a_y,
-                  u3_atom b);
+        u3r_met(c3_y    a_y,
+                u3_atom b);
 
       /* u3r_bit():
       **

--- a/pkg/noun/retrieve_tests.c
+++ b/pkg/noun/retrieve_tests.c
@@ -120,8 +120,8 @@ _test_mug(void)
                            u3kc_mix(u3qc_bex(212),
                            u3i_string("abcdefjhijklmnopqrstuvwxyz")));
 
-    c3_w  byt_w = u3r_met(3, str);
-    c3_w  wor_w = u3r_met(5, str);
+    c3_w  byt_w = (c3_w)u3r_met(3, str);
+    c3_w  wor_w = (c3_w)u3r_met(5, str);
     c3_y* str_y = c3_malloc(byt_w);
     c3_w* str_w = c3_malloc(4 * wor_w);
     c3_d  str_d = 0;

--- a/pkg/noun/serial.c
+++ b/pkg/noun/serial.c
@@ -87,7 +87,7 @@ _cs_jam_fib_mat(struct _cs_jam_fib* fib_u, u3_noun a)
     _cs_jam_fib_chop(fib_u, 1, 1);
   }
   else {
-    c3_d   a_d = u3r_met_d(0, a);
+    c3_d   a_d = u3r_met(0, a);
     c3_w   b_w = c3_bits_dabl(a_d);
     c3_d bit_d = fib_u->bit_d;
 
@@ -152,8 +152,8 @@ _cs_jam_fib_atom_cb(u3_atom a, void* ptr_v)
     _cs_jam_fib_mat(fib_u, a);
   }
   else {
-    c3_d a_d = u3r_met_d(0, a);
-    c3_d b_d = u3r_met_d(0, b);
+    c3_d a_d = u3r_met(0, a);
+    c3_d b_d = u3r_met(0, b);
 
     //  if [a] is smaller than the backref, encode atom
     //
@@ -276,14 +276,14 @@ _cs_jam_xeno_atom(u3_atom a, void* ptr_v)
   _jam_xeno_t* jam_u = ptr_v;
   ur_bsw_t*    rit_u = &(jam_u->rit_u);
   u3_weak        bak = u3h_git(jam_u->har_p, a);
-  c3_d         met_d = u3r_met_d(0, a);
+  c3_d         met_d = u3r_met(0, a);
 
   if ( u3_none == bak ) {
     u3h_put(jam_u->har_p, a, _cs_coin_chub(rit_u->bits));
     _cs_jam_bsw_atom(rit_u, met_d, a);
   }
   else {
-    c3_d bak_d = u3r_met_d(0, bak);
+    c3_d bak_d = u3r_met(0, bak);
 
     if ( met_d <= bak_d ) {
       _cs_jam_bsw_atom(rit_u, met_d, a);
@@ -309,7 +309,7 @@ _cs_jam_xeno_cell(u3_noun a, void* ptr_v)
     return c3y;
   }
   else {
-    _cs_jam_bsw_back(rit_u, u3r_met_d(0, bak), bak);
+    _cs_jam_bsw_back(rit_u, u3r_met(0, bak), bak);
     return c3n;
   }
 }
@@ -879,7 +879,7 @@ u3s_cue_bytes(c3_d len_d, const c3_y* byt_y)
 u3_noun
 u3s_cue_atom(u3_atom a)
 {
-  c3_w  len_w = u3r_met(3, a);
+  c3_d  len_d = u3r_met(3, a);
   c3_y* byt_y;
 
   // XX assumes little-endian
@@ -892,7 +892,7 @@ u3s_cue_atom(u3_atom a)
     byt_y = (c3_y*)vat_u->buf_w;
   }
 
-  return u3s_cue_bytes((c3_d)len_w, byt_y);
+  return u3s_cue_bytes(len_d, byt_y);
 }
 
 /* _cs_etch_ud_size(): output length in @ud for given mpz_t.
@@ -1103,8 +1103,12 @@ u3s_etch_ux(u3_atom a)
     return c3_s3('0', 'x', '0');
   }
 
-  c3_w     sep_w = u3r_met(4, a) - 1;                //  number of separators
-  c3_w     las_w = u3r_met(2, u3r_short(sep_w, a));  //  digits before separator
+  c3_d     mes_d = u3r_met(4, a);
+  if ( UINT32_MAX < mes_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w     sep_w = (c3_w)mes_d - 1;                  //  number of separators
+  c3_w     las_w = (c3_w)u3r_met(2, u3r_short(sep_w, a));  //  digits before separator
   c3_w     len_w = 2 + las_w + (sep_w * 5);          //  output bytes
   u3i_slab sab_u;
   u3i_slab_bare(&sab_u, 3, len_w);
@@ -1126,8 +1130,12 @@ u3s_etch_ux_c(u3_atom a, c3_c** out_c)
   }
 
   c3_y*  buf_y;
-  c3_w   sep_w = u3r_met(4, a) - 1;
-  c3_w   las_w = u3r_met(2, u3r_short(sep_w, a));
+  c3_d   mes_d = u3r_met(4, a);
+  if ( UINT32_MAX < mes_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w   sep_w = (c3_w)mes_d - 1;
+  c3_w   las_w = (c3_w)u3r_met(2, u3r_short(sep_w, a));
   size_t len_i = 2 + las_w + (sep_w * 5);
 
   buf_y = c3_malloc(1 + len_i);
@@ -1147,7 +1155,11 @@ u3s_etch_ux_c(u3_atom a, c3_c** out_c)
 static inline size_t
 _cs_etch_uv_size(u3_atom a, c3_w* out_w)
 {
-  c3_w met_w = u3r_met(0, a);
+  c3_d met_d = u3r_met(0, a);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w met_w = (c3_w)met_d;
   c3_w sep_w = _divc_nz(met_w, 25) - 1;  //  number of separators
   c3_w max_w = sep_w * 25;
   c3_w end_w = 0;
@@ -1241,7 +1253,11 @@ u3s_etch_uv_c(u3_atom a, c3_c** out_c)
 static inline size_t
 _cs_etch_uw_size(u3_atom a, c3_w* out_w)
 {
-  c3_w met_w = u3r_met(0, a);
+  c3_d met_d = u3r_met(0, a);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w met_w = (c3_w)met_d;
   c3_w sep_w = _divc_nz(met_w, 30) - 1;  //  number of separators
   c3_w max_w = sep_w * 30;
   c3_w end_w = 0;
@@ -1440,7 +1456,11 @@ u3s_sift_ud_bytes(c3_w len_w, c3_y* byt_y)
 u3_weak
 u3s_sift_ud(u3_atom a)
 {
-  c3_w  len_w = u3r_met(3, a);
+  c3_d  len_d = u3r_met(3, a);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w  len_w = (c3_w)len_d;
   c3_y* byt_y;
 
   // XX assumes little-endian

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -87,7 +87,11 @@ u3t_heck(u3_atom cog)
 #if 0
   u3R->pro.cel_d++;
 #else
-  c3_w len_w = u3r_met(3, cog);
+  c3_d len_d = u3r_met(3, cog);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w len_w = (c3_w)len_d;
   c3_c* str_c = alloca(1 + len_w);
 
   u3r_bytes(0, len_w, (c3_y *)str_c, cog);
@@ -1240,8 +1244,12 @@ u3t_sstack_push(u3_noun nam)
     nam = c3__cell;
   }
 
-  c3_w  met_w = u3r_met(3, nam);
-  
+  c3_d  met_d = u3r_met(3, nam);
+  if ( UINT32_MAX < met_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w  met_w = (c3_w)met_d;
+
   // Exit if full
   if ( 0 < u3t_Spin->fow_w || 
        sizeof(u3t_Spin->dat_y) < u3t_Spin->off_w + met_w + sizeof(c3_w) ) {

--- a/pkg/vere/auto.c
+++ b/pkg/vere/auto.c
@@ -382,8 +382,13 @@ u3_auto_slog(u3_auto* car_u)
   while ( car_u ) {
     nex_u = car_u->nex_u;
 
+    c3_d nam_d = u3r_met(3, car_u->nam_m);
+    if ( UINT32_MAX < nam_d ) {
+      u3m_bail(c3__fail);
+    }
+
     u3l_log("    %.*s: live=%s, queue=%u",
-            u3r_met(3, car_u->nam_m),
+            (c3_w)nam_d,
             (c3_c*)&car_u->nam_m,
             ( c3y == car_u->liv_o ) ? "&" : "|",
             car_u->dep_w);

--- a/pkg/vere/benchmarks.c
+++ b/pkg/vere/benchmarks.c
@@ -183,7 +183,7 @@ _cue_bench(void)
     gettimeofday(&b4, 0);
 
     {
-      c3_w  len_w = u3r_met(3, vat);
+      c3_w  len_w = (c3_w)u3r_met(3, vat);
       // XX assumes little-endian
       //
       c3_y* byt_y = ( c3y == u3a_is_cat(vat) )
@@ -207,7 +207,7 @@ _cue_bench(void)
     {
       u3_cue_xeno* sil_u = u3s_cue_xeno_init();
 
-      c3_w  len_w = u3r_met(3, vat);
+      c3_w  len_w = (c3_w)u3r_met(3, vat);
       // XX assumes little-endian
       //
       c3_y* byt_y = ( c3y == u3a_is_cat(vat) )
@@ -231,7 +231,7 @@ _cue_bench(void)
     gettimeofday(&b4, 0);
 
     {
-      c3_w  len_w = u3r_met(3, vat);
+      c3_w  len_w = (c3_w)u3r_met(3, vat);
       // XX assumes little-endian
       //
       c3_y* byt_y = ( c3y == u3a_is_cat(vat) )
@@ -255,7 +255,7 @@ _cue_bench(void)
     {
       ur_cue_test_t *t = ur_cue_test_init();
 
-      c3_w  len_w = u3r_met(3, vat);
+      c3_w  len_w = (c3_w)u3r_met(3, vat);
       // XX assumes little-endian
       //
       c3_y* byt_y = ( c3y == u3a_is_cat(vat) )
@@ -281,7 +281,7 @@ _cue_bench(void)
     {
       ur_root_t* rot_u = ur_root_init();
       ur_nref      ref;
-      c3_w  len_w = u3r_met(3, vat);
+      c3_w  len_w = (c3_w)u3r_met(3, vat);
       // XX assumes little-endian
       //
       c3_y* byt_y = ( c3y == u3a_is_cat(vat) )
@@ -307,7 +307,7 @@ _cue_bench(void)
     {
       ur_root_t* rot_u;
       ur_nref      ref;
-      c3_w  len_w = u3r_met(3, vat);
+      c3_w  len_w = (c3_w)u3r_met(3, vat);
       // XX assumes little-endian
       //
       c3_y* byt_y = ( c3y == u3a_is_cat(vat) )

--- a/pkg/vere/disk.c
+++ b/pkg/vere/disk.c
@@ -132,7 +132,11 @@ u3_disk_etch(u3_disk* log_u,
   //
   {
     u3_atom mat = u3qe_jam(eve);
-    c3_w  len_w = u3r_met(3, mat);
+    c3_d  len_d = u3r_met(3, mat);
+    if ( UINT32_MAX < len_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w  len_w = (c3_w)len_d;
 
     len_i = 4 + len_w;
     dat_y = c3_malloc(len_i);

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -511,7 +511,11 @@ static c3_o
 _fine_sift_meow(u3_meow* mew_u, u3_noun mew)
 {
   c3_o ret_o;
-  c3_w len_w = u3r_met(3, mew);
+  c3_d len_d = u3r_met(3, mew);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w len_w = (c3_w)len_d;
   c3_w sig_w = sizeof(mew_u->sig_y);
   c3_w num_w = sizeof(mew_u->num_w);
   c3_w min_w = sig_w + 1;
@@ -1345,7 +1349,11 @@ _ames_ef_send(u3_ames* sam_u, u3_noun lan, u3_noun pac)
     u3_pact* pac_u = c3_calloc(sizeof(*pac_u));
     pac_u->sam_u = sam_u;
     pac_u->lan_u = lan_u;
-    pac_u->len_w = u3r_met(3, pac);
+    c3_d len_d = u3r_met(3, pac);
+    if ( UINT32_MAX < len_d ) {
+      u3m_bail(c3__fail);
+    }
+    pac_u->len_w = (c3_w)len_d;
     pac_u->hun_y = c3_malloc(pac_u->len_w);
 
     u3r_bytes(0, pac_u->len_w, pac_u->hun_y, pac);

--- a/pkg/vere/io/cttp.c
+++ b/pkg/vere/io/cttp.c
@@ -238,8 +238,16 @@ _cttp_heds_free(u3_hhed* hed_u)
 static u3_hhed*
 _cttp_hed_new(u3_atom nam, u3_atom val)
 {
-  c3_w     nam_w = u3r_met(3, nam);
-  c3_w     val_w = u3r_met(3, val);
+  c3_d     nam_d = u3r_met(3, nam);
+  c3_d     val_d = u3r_met(3, val);
+  if ( UINT32_MAX < nam_d ) {
+    u3m_bail(c3__fail);
+  }
+  if ( UINT32_MAX < val_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w     nam_w = (c3_w)nam_d;
+  c3_w     val_w = (c3_w)val_d;
   u3_hhed* hed_u = c3_malloc(sizeof(*hed_u));
 
   hed_u->nam_c = c3_malloc(1 + nam_w);

--- a/pkg/vere/io/fore.c
+++ b/pkg/vere/io/fore.c
@@ -80,7 +80,11 @@ _fore_import(u3_auto* car_u, c3_c* pax_c)
 {
   u3_noun arc = u3ke_cue(u3m_file(pax_c));
   u3_noun imp = u3dt("cat", 3, u3i_string("#import_"), arc);
-  u3_noun siz = u3r_met(3, imp);
+  c3_d    siz_d = u3r_met(3, imp);
+  if ( UINT32_MAX < siz_d ) {
+    u3m_bail(c3__fail);
+  }
+  u3_noun siz = (c3_w)siz_d;
   u3_noun dat = u3nt(u3_nul, siz, imp);
 
   u3_noun req = u3nt(c3n,

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -290,8 +290,16 @@ _http_heds_free(u3_hhed* hed_u)
 static u3_hhed*
 _http_hed_new(u3_atom nam, u3_atom val)
 {
-  c3_w     nam_w = u3r_met(3, nam);
-  c3_w     val_w = u3r_met(3, val);
+  c3_d     nam_d = u3r_met(3, nam);
+  c3_d     val_d = u3r_met(3, val);
+  if ( UINT32_MAX < nam_d ) {
+    u3m_bail(c3__fail);
+  }
+  if ( UINT32_MAX < val_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w     nam_w = (c3_w)nam_d;
+  c3_w     val_w = (c3_w)val_d;
   u3_hhed* hed_u = c3_malloc(sizeof(*hed_u));
 
   hed_u->nam_c = c3_malloc(1 + nam_w);
@@ -2844,7 +2852,11 @@ _http_stream_slog(void* vop_p, c3_w pri_w, u3_noun tan)
                              c3_s2('\n', '\n'),
                              u3_none);
       u3_atom txt = u3qc_rap(3, lin);
-      data = u3nt(u3_nul, u3r_met(3, txt), txt);
+      c3_d    txt_d = u3r_met(3, txt);
+      if ( UINT32_MAX < txt_d ) {
+        u3m_bail(c3__fail);
+      }
+      data = u3nt(u3_nul, (c3_w)txt_d, txt);
       u3z(lin);
     }
     else {
@@ -2877,7 +2889,11 @@ _http_stream_slog(void* vop_p, c3_w pri_w, u3_noun tan)
           low = u3t(low);
         }
         u3_atom txt = u3qc_rap(3, paz);
-        data = u3nt(u3_nul, u3r_met(3, txt), txt);
+        c3_d    txt_d = u3r_met(3, txt);
+        if ( UINT32_MAX < txt_d ) {
+          u3m_bail(c3__fail);
+        }
+        data = u3nt(u3_nul, (c3_w)txt_d, txt);
         u3z(paz);
       }
 
@@ -2946,7 +2962,11 @@ _http_spin_timer_cb(uv_timer_t* tim_u)
                              c3_s2('\n', '\n'),
                              u3_none);
       u3_atom txt = u3qc_rap(3, lin);
-      u3_noun dat = u3nt(u3_nul, u3r_met(3, txt), txt);
+      c3_d    txt_d = u3r_met(3, txt);
+      if ( UINT32_MAX < txt_d ) {
+        u3m_bail(c3__fail);
+      }
+      u3_noun dat = u3nt(u3_nul, (c3_w)txt_d, txt);
 
       while ( 0 != siq_u ) {
         _http_continue_respond(siq_u, u3k(dat), c3n);
@@ -3113,7 +3133,11 @@ _http_io_exit(u3_auto* car_u)
 
   {
     u3_atom lin = u3i_string("data:urbit shutting down\n\n");
-    u3_noun dat = u3nt(u3_nul, u3r_met(3, lin), lin);
+    c3_d    lin_d = u3r_met(3, lin);
+    if ( UINT32_MAX < lin_d ) {
+      u3m_bail(c3__fail);
+    }
+    u3_noun dat = u3nt(u3_nul, (c3_w)lin_d, lin);
     u3_hreq* seq_u = htd_u->fig_u.seq_u;
     while ( 0 != seq_u ) {
       _http_continue_respond(seq_u, u3k(dat), c3y);

--- a/pkg/vere/io/lick.c
+++ b/pkg/vere/io/lick.c
@@ -95,7 +95,11 @@ _lick_it_path(u3_noun pax)
     u3_noun wiz = pax;
 
     while ( u3_nul != wiz ) {
-      len_w += (1 + u3r_met(3, u3h(wiz)));
+      c3_d met_d = u3r_met(3, u3h(wiz));
+      if ( UINT32_MAX < met_d ) {
+        u3m_bail(c3__fail);
+      }
+      len_w += (1 + (c3_w)met_d);
       wiz = u3t(wiz);
     }
   }
@@ -109,7 +113,11 @@ _lick_it_path(u3_noun pax)
     c3_c*   waq_c = pas_c;
 
     while ( u3_nul != wiz ) {
-      c3_w tis_w = u3r_met(3, u3h(wiz));
+      c3_d tis_d = u3r_met(3, u3h(wiz));
+      if ( UINT32_MAX < tis_d ) {
+        u3m_bail(c3__fail);
+      }
+      c3_w tis_w = (c3_w)tis_d;
 
       if ( (u3_nul == u3t(wiz)) ) {
         *waq_c++ = '/';

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -1383,7 +1383,11 @@ _mesa_hear(u3_mesa* sam_u,
 static void
 _mesa_ef_send(u3_mesa* sam_u, u3_noun las, u3_noun pac)
 {
-  c3_w len_w = u3r_met(3, pac);
+  c3_d len_d = u3r_met(3, pac);
+  if ( UINT32_MAX < len_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w len_w = (c3_w)len_d;
   arena are_u = arena_create(len_w + 16384);
   c3_y* buf_y = new(&are_u, c3_y, len_w);
   u3r_bytes(0, len_w, buf_y, pac);
@@ -1798,7 +1802,11 @@ _mesa_page_scry_jumbo_cb(void* vod_p, u3_noun res)
 
   u3_mesa_line* lin_u;
   {
-    c3_w jumbo_w = u3r_met(3, pac);
+    c3_d jumbo_d = u3r_met(3, pac);
+    if ( UINT32_MAX < jumbo_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w jumbo_w = (c3_w)jumbo_d;
     c3_y* jumbo_y = c3_calloc(jumbo_w);
     u3r_bytes(0, jumbo_w, jumbo_y, pac);
 

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -1923,7 +1923,7 @@ _forward_lanes_cb(void* vod_p, u3_noun nun)
     // both atoms guaranteed to be cats, bc we don't call unless forwarding
     per_u->ful_o = c3y;
     per_u->imp_y = gal;
-    u3_noun sal = u3k(u3t(las));
+    u3_noun sal = u3t(las);
     u3_noun lan;
     while ( sal != u3_nul ) {
       u3x_cell(sal, &lan, &sal);
@@ -1935,7 +1935,6 @@ _forward_lanes_cb(void* vod_p, u3_noun nun)
         per_u->dan_u = lan_u;
       }
     }
-    u3z(sal);
     _mesa_put_peer(per_u->sam_u, per_u->her_u, per_u);
   }
 
@@ -2404,7 +2403,7 @@ _mesa_hear_peek(u3_mesa_pict* pic_u, sockaddr_in lan_u)
   dat_u->sam_u = sam_u;
   _mesa_copy_name(&dat_u->nam_u, &pac_u->pek_u.nam_u, &han_u->are_u);
 
-  u3_pier_peek(sam_u->car_u.pir_u, u3_nul, u3k(u3nq(1, c3__beam, c3__ax, bem)), han_u, _mesa_page_scry_jumbo_cb);
+  u3_pier_peek(sam_u->car_u.pir_u, u3_nul, u3nq(1, c3__beam, c3__ax, bem), han_u, _mesa_page_scry_jumbo_cb);
 }
 
 static void

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -1808,6 +1808,7 @@ _mesa_page_scry_jumbo_cb(void* vod_p, u3_noun res)
       u3l_log("mesa: jumbo frame parse failure: %s", err_c);
       arena_free(&han_u->are_u);
       u3z(res);
+      c3_free(jumbo_y);
       return;
     }
     u3_mesa_data* dat_u = &jum_u.pag_u.dat_u;
@@ -2058,6 +2059,11 @@ _mesa_req_pact_init(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u, u3_p
   c3_w pof_w = lss_proof_size(tof_d);
   c3_w pairs_w = c3_bits_word(pof_w);
   c3_d pek_d = dat_u->tob_d;
+
+  if ( dat_u->len_w != pof_w*sizeof(lss_hash) ) {
+    return; // TODO: handle like other auth failures
+  }
+
   arena are_u = arena_create(5*dat_u->tob_d);
   u3_pend_req* req_u = new(&are_u, u3_pend_req, 1);
   req_u->are_u = are_u;
@@ -2094,9 +2100,6 @@ _mesa_req_pact_init(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u, u3_p
   req_u->ack_d = 0;
 
   lss_hash* pof_u = new(&req_u->are_u, lss_hash, pof_w);
-  if ( dat_u->len_w != pof_w*sizeof(lss_hash) ) {
-    return; // TODO: handle like other auth failures
-  }
   for ( int i = 0; i < pof_w; i++ ) {
     memcpy(pof_u[i], dat_u->fra_y + (i * sizeof(lss_hash)), sizeof(lss_hash));
   }

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -2177,9 +2177,13 @@ _mesa_forward_request(u3_mesa* sam_u, u3_mesa_pict* pic_u, sockaddr_in lan_u)
     per_u->her_u[1] = pac_u->pek_u.nam_u.her_u[1];
 
     _get_peer_lanes(sam_u, per_u); // forward-lanes
+    _mesa_put_peer(sam_u, per_u->her_u, per_u);
+
     return;
   }
-  if ( c3y == sam_u->for_o && sam_u->pir_u->who_d[0] == per_u->imp_y ) {
+  if ( c3y == sam_u->for_o
+       && c3y == per_u->ful_o
+       && sam_u->pir_u->who_d[0] == per_u->imp_y ) {
     sockaddr_in lin_u = _mesa_get_direct_lane(sam_u, pac_u->pek_u.nam_u.her_u);
     if ( _mesa_is_lane_zero(lin_u) == c3y) {
       c3_c* shp_c = u3_ship_to_string(pac_u->pek_u.nam_u.her_u);

--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -534,7 +534,11 @@ _term_it_path(u3_noun pax)
     u3_noun wiz = pax;
 
     while ( u3_nul != wiz ) {
-      len_w += (1 + u3r_met(3, u3h(wiz)));
+      c3_d met_d = u3r_met(3, u3h(wiz));
+      if ( UINT32_MAX < met_d ) {
+        u3m_bail(c3__fail);
+      }
+      len_w += (1 + (c3_w)met_d);
       wiz = u3t(wiz);
     }
   }
@@ -548,7 +552,11 @@ _term_it_path(u3_noun pax)
     c3_c*   waq_c = pas_c;
 
     while ( u3_nul != wiz ) {
-      c3_w tis_w = u3r_met(3, u3h(wiz));
+      c3_d tis_d = u3r_met(3, u3h(wiz));
+      if ( UINT32_MAX < tis_d ) {
+        u3m_bail(c3__fail);
+      }
+      c3_w tis_w = (c3_w)tis_d;
 
       if ( (u3_nul == u3t(wiz)) ) {
         *waq_c++ = '.';

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -207,7 +207,11 @@ _unix_knot_to_string(u3_atom pon)
     ret_c = u3r_string(pon);
   }
   else {
-    c3_w  met_w = u3r_met(3, pon);
+    c3_d  met_d = u3r_met(3, pon);
+    if ( UINT32_MAX < met_d ) {
+      u3m_bail(c3__fail);
+    }
+    c3_w  met_w = (c3_w)met_d;
 
     ret_c = c3_malloc(met_w + 2);
     *ret_c = '!';
@@ -342,7 +346,13 @@ u3_unix_save(c3_c* pax_c, u3_atom pad)
     u3z(pad); u3m_bail(c3__fail);
   }
 
-  fln_w = u3r_met(3, pad);
+  {
+    c3_d fln_d = u3r_met(3, pad);
+    if ( UINT32_MAX < fln_d ) {
+      u3m_bail(c3__fail);
+    }
+    fln_w = (c3_w)fln_d;
+  }
   pad_y = c3_malloc(fln_w);
   u3r_bytes(0, fln_w, pad_y, pad);
   u3z(pad);
@@ -444,7 +454,13 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
   }
 
   siz_w = u3h(u3t(mim));
-  len_w = u3r_met(3, dat);
+  {
+    c3_d len_d = u3r_met(3, dat);
+    if ( UINT32_MAX < len_d ) {
+      u3m_bail(c3__fail);
+    }
+    len_w = (c3_w)len_d;
+  }
   dat_y = c3_calloc(siz_w);
 
   u3r_bytes(0, len_w, dat_y, dat);

--- a/pkg/vere/newt_tests.c
+++ b/pkg/vere/newt_tests.c
@@ -17,7 +17,7 @@ _setup(void)
 static c3_y*
 _newt_encode(u3_atom mat, c3_w* len_w)
 {
-  c3_w  met_w = u3r_met(3, mat);
+  c3_w  met_w = (c3_w)u3r_met(3, mat);
   c3_y* buf_y;
 
   *len_w = 5 + met_w;

--- a/pkg/vere/noun_tests.c
+++ b/pkg/vere/noun_tests.c
@@ -1313,22 +1313,22 @@ _test_met()
    {
     atom = 1;
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (1 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (1 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(4, atom);
+    ret_w = (c3_w)u3r_met(4, atom);
     if (1 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (1 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }
@@ -1338,22 +1338,22 @@ _test_met()
    {
     atom = 2;
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (2 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (1 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (1 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(6, atom);
+    ret_w = (c3_w)u3r_met(6, atom);
     if (1 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }
@@ -1363,22 +1363,22 @@ _test_met()
    {
     atom = 8;
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (4 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (1 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (1 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(6, atom);
+    ret_w = (c3_w)u3r_met(6, atom);
     if (1 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }
@@ -1388,22 +1388,22 @@ _test_met()
    {
     atom = 0xff;
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (8 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (1 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (1 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(6, atom);
+    ret_w = (c3_w)u3r_met(6, atom);
     if (1 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }
@@ -1413,22 +1413,22 @@ _test_met()
    {
     atom = 0x100;
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (9 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (2 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (1 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(6, atom);
+    ret_w = (c3_w)u3r_met(6, atom);
     if (1 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }
@@ -1442,22 +1442,22 @@ _test_met()
   {
     atom = 0xffffffffULL;
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (32 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (4 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (1 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(6, atom);
+    ret_w = (c3_w)u3r_met(6, atom);
     if (1 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }
@@ -1470,22 +1470,22 @@ _test_met()
     c3_w data_w[4] = { 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
     atom = u3i_words(4, data_w);
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (128 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (16 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (4 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(6, atom);
+    ret_w = (c3_w)u3r_met(6, atom);
     if (2 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }
@@ -1497,22 +1497,22 @@ _test_met()
     c3_w data_w[4] = { 0xffffffff, 0xffffffff, 0xffffffff, 1 };
     atom = u3i_words(4, data_w);
 
-    ret_w = u3r_met(0, atom);
+    ret_w = (c3_w)u3r_met(0, atom);
     if (97 != ret_w){
       printf("*** _test_met bit of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(3, atom);
+    ret_w = (c3_w)u3r_met(3, atom);
     if (13 != ret_w){
       printf("*** _test_met byte of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(5, atom);
+    ret_w = (c3_w)u3r_met(5, atom);
     if (4 != ret_w){
       printf("*** _test_met _w of 1 = %d \n", ret_w);
     }
 
-    ret_w = u3r_met(6, atom);
+    ret_w = (c3_w)u3r_met(6, atom);
     if (2 != ret_w){
       printf("*** _test_met _d of 1 = %d \n", ret_w);
     }

--- a/pkg/vere/ward.c
+++ b/pkg/vere/ward.c
@@ -181,7 +181,11 @@ u3_mcut_char(c3_c* buf_c, c3_w len_w, c3_c chr_c)
 c3_w
 u3_mcut_cord(c3_c* buf_c, c3_w len_w, u3_noun san)
 {
-  c3_w ten_w = u3r_met(3, san);
+  c3_d ten_d = u3r_met(3, san);
+  if ( UINT32_MAX < ten_d ) {
+    u3m_bail(c3__fail);
+  }
+  c3_w ten_w = (c3_w)ten_d;
 
   if ( buf_c ) {
     u3r_bytes(0, ten_w, (c3_y *)(buf_c + len_w), san);


### PR DESCRIPTION
promotes `u3r_met` to return `c3_d` so it no longer truncates the bit/byte length of big atoms.

sweeps every callsite: comparisons are left as-is, values feeding 64-bit consumers (`u3i_slab_init`, `u3r_chop_words` widths) are widened to `c3_d`, and values that need 32-bit width get a recoverable `bail:fail` guard before an explicit `(c3_w)` narrow, preserving the behavior u3r_met previously raised on overflow. `rap`/`rep` keep their 32-bit `tot_w` overflow guards. `met`/`xeb` now return via `u3i_chub` so counts past `2^31` produce a correct atom instead of a truncated one.

