### PR TITLE
u3: switch allocator to require explicitly-sized realloc() calls

### DIFF
--- a/ext/pdjson/build.zig
+++ b/ext/pdjson/build.zig
@@ -4,11 +4,6 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const dep_c = b.dependency("pdjson", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
     const lib = b.addLibrary(.{
         .name = "pdjson",
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
@@ -16,10 +11,10 @@ pub fn build(b: *std.Build) void {
 
     lib.linkLibC();
 
-    lib.addIncludePath(dep_c.path("."));
+    lib.addIncludePath(b.path("vendor"));
 
     lib.addCSourceFiles(.{
-        .root = dep_c.path("."),
+        .root = b.path("vendor"),
         .files = &.{"pdjson.c"},
         .flags = &.{
             "-fno-sanitize=all",
@@ -31,7 +26,7 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    lib.installHeader(dep_c.path("pdjson.h"), "pdjson.h");
+    lib.installHeader(b.path("vendor/pdjson.h"), "pdjson.h");
 
     b.installArtifact(lib);
 }

--- a/ext/pdjson/build.zig.zon
+++ b/ext/pdjson/build.zig.zon
@@ -2,12 +2,6 @@
     .name = .pdjson,
     .version = "0.0.1",
     .fingerprint = 0x9c1187b6fa1266aa,
-    .dependencies = .{
-        .pdjson = .{
-            .url = "https://github.com/skeeto/pdjson/archive/67108d883061043e55d0fb13961ac1b6fc8a485c.tar.gz",
-            .hash = "N-V-__8AADC9AACneJx7RTm9Hui7GCYJ2Qdv8Z_CUCbJphyi",
-        },
-    },
     .paths = .{
         "",
     },

--- a/ext/pdjson/vendor/UNLICENSE
+++ b/ext/pdjson/vendor/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/ext/pdjson/vendor/pdjson.c
+++ b/ext/pdjson/vendor/pdjson.c
@@ -1,0 +1,965 @@
+#ifndef _POSIX_C_SOURCE
+#  define _POSIX_C_SOURCE 200112L
+#elif _POSIX_C_SOURCE < 200112L
+#  error incompatible _POSIX_C_SOURCE level
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#ifndef PDJSON_H
+#  include "pdjson.h"
+#endif
+
+#define JSON_FLAG_ERROR      (1u << 0)
+#define JSON_FLAG_STREAMING  (1u << 1)
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+
+#define json_error(json, format, ...)                             \
+    if (!(json->flags & JSON_FLAG_ERROR)) {                       \
+        json->flags |= JSON_FLAG_ERROR;                           \
+        _snprintf_s(json->errmsg, sizeof(json->errmsg),           \
+                 _TRUNCATE,                                       \
+                 format,                                          \
+                 __VA_ARGS__);                                    \
+    }                                                             \
+
+#else
+
+#define json_error(json, format, ...)                             \
+    if (!(json->flags & JSON_FLAG_ERROR)) {                       \
+        json->flags |= JSON_FLAG_ERROR;                           \
+        snprintf(json->errmsg, sizeof(json->errmsg),              \
+                 format,                                          \
+                 __VA_ARGS__);                                    \
+    }                                                             \
+
+#endif /* _MSC_VER */
+
+/* See also PDJSON_STACK_MAX below. */
+#ifndef PDJSON_STACK_INC
+#  define PDJSON_STACK_INC 4
+#endif
+
+struct json_stack {
+    enum json_type type;
+    long count;
+};
+
+static enum json_type
+push(json_stream *json, enum json_type type)
+{
+    json->stack_top++;
+
+#ifdef PDJSON_STACK_MAX
+    if (json->stack_top > PDJSON_STACK_MAX) {
+        json_error(json, "%s", "maximum depth of nesting reached");
+        return JSON_ERROR;
+    }
+#endif
+
+    if (json->stack_top >= json->stack_size) {
+        struct json_stack *stack;
+        size_t size = (json->stack_size + PDJSON_STACK_INC) * sizeof(*json->stack);
+        stack = (struct json_stack *)json->alloc.realloc(json->stack, size);
+        if (stack == NULL) {
+            json_error(json, "%s", "out of memory");
+            return JSON_ERROR;
+        }
+
+        json->stack_size += PDJSON_STACK_INC;
+        json->stack = stack;
+    }
+
+    json->stack[json->stack_top].type = type;
+    json->stack[json->stack_top].count = 0;
+
+    return type;
+}
+
+static enum json_type
+pop(json_stream *json, int c, enum json_type expected)
+{
+    if (json->stack == NULL || json->stack[json->stack_top].type != expected) {
+        json_error(json, "unexpected byte '%c'", c);
+        return JSON_ERROR;
+    }
+    json->stack_top--;
+    return expected == JSON_ARRAY ? JSON_ARRAY_END : JSON_OBJECT_END;
+}
+
+static int buffer_peek(struct json_source *source)
+{
+    if (source->position < source->source.buffer.length)
+        return source->source.buffer.buffer[source->position];
+    else
+        return EOF;
+}
+
+static int buffer_get(struct json_source *source)
+{
+    int c = source->peek(source);
+    source->position++;
+    return c;
+}
+
+static int stream_get(struct json_source *source)
+{
+    source->position++;
+    return fgetc(source->source.stream.stream);
+}
+
+static int stream_peek(struct json_source *source)
+{
+    int c = fgetc(source->source.stream.stream);
+    ungetc(c, source->source.stream.stream);
+    return c;
+}
+
+static void init(json_stream *json)
+{
+    json->lineno = 1;
+    json->flags = JSON_FLAG_STREAMING;
+    json->errmsg[0] = '\0';
+    json->ntokens = 0;
+    json->next = (enum json_type)0;
+
+    json->stack = NULL;
+    json->stack_top = -1;
+    json->stack_size = 0;
+
+    json->data.string = NULL;
+    json->data.string_size = 0;
+    json->data.string_fill = 0;
+    json->source.position = 0;
+
+    json->alloc.malloc = malloc;
+    json->alloc.realloc = realloc;
+    json->alloc.free = free;
+}
+
+static enum json_type
+is_match(json_stream *json, const char *pattern, enum json_type type)
+{
+    int c;
+    for (const char *p = pattern; *p; p++) {
+        if (*p != (c = json->source.get(&json->source))) {
+            json_error(json, "expected '%c' instead of byte '%c'", *p, c);
+            return JSON_ERROR;
+        }
+    }
+    return type;
+}
+
+static int pushchar(json_stream *json, int c)
+{
+    if (json->data.string_fill == json->data.string_size) {
+        size_t size = json->data.string_size * 2;
+        char *buffer = (char *)json->alloc.realloc(json->data.string, size);
+        if (buffer == NULL) {
+            json_error(json, "%s", "out of memory");
+            return -1;
+        } else {
+            json->data.string_size = size;
+            json->data.string = buffer;
+        }
+    }
+    json->data.string[json->data.string_fill++] = c;
+    return 0;
+}
+
+static int init_string(json_stream *json)
+{
+    json->data.string_fill = 0;
+    if (json->data.string == NULL) {
+        json->data.string_size = 1024;
+        json->data.string = (char *)json->alloc.malloc(json->data.string_size);
+        if (json->data.string == NULL) {
+            json_error(json, "%s", "out of memory");
+            return -1;
+        }
+    }
+    json->data.string[0] = '\0';
+    return 0;
+}
+
+static int encode_utf8(json_stream *json, unsigned long c)
+{
+    if (c < 0x80UL) {
+        return pushchar(json, c);
+    } else if (c < 0x0800UL) {
+        return !((pushchar(json, (c >> 6 & 0x1F) | 0xC0) == 0) &&
+                 (pushchar(json, (c >> 0 & 0x3F) | 0x80) == 0));
+    } else if (c < 0x010000UL) {
+        if (c >= 0xd800 && c <= 0xdfff) {
+            json_error(json, "invalid codepoint %06lx", c);
+            return -1;
+        }
+        return !((pushchar(json, (c >> 12 & 0x0F) | 0xE0) == 0) &&
+                 (pushchar(json, (c >>  6 & 0x3F) | 0x80) == 0) &&
+                 (pushchar(json, (c >>  0 & 0x3F) | 0x80) == 0));
+    } else if (c < 0x110000UL) {
+        return !((pushchar(json, (c >> 18 & 0x07) | 0xF0) == 0) &&
+                (pushchar(json, (c >> 12 & 0x3F) | 0x80) == 0) &&
+                (pushchar(json, (c >> 6  & 0x3F) | 0x80) == 0) &&
+                (pushchar(json, (c >> 0  & 0x3F) | 0x80) == 0));
+    } else {
+        json_error(json, "unable to encode %06lx as UTF-8", c);
+        return -1;
+    }
+}
+
+static int hexchar(int c)
+{
+    switch (c) {
+    case '0': return 0;
+    case '1': return 1;
+    case '2': return 2;
+    case '3': return 3;
+    case '4': return 4;
+    case '5': return 5;
+    case '6': return 6;
+    case '7': return 7;
+    case '8': return 8;
+    case '9': return 9;
+    case 'a':
+    case 'A': return 10;
+    case 'b':
+    case 'B': return 11;
+    case 'c':
+    case 'C': return 12;
+    case 'd':
+    case 'D': return 13;
+    case 'e':
+    case 'E': return 14;
+    case 'f':
+    case 'F': return 15;
+    default:
+        return -1;
+    }
+}
+
+static long
+read_unicode_cp(json_stream *json)
+{
+    long cp = 0;
+    int shift = 12;
+
+    for (size_t i = 0; i < 4; i++) {
+        int c = json->source.get(&json->source);
+        int hc;
+
+        if (c == EOF) {
+            json_error(json, "%s", "unterminated string literal in Unicode");
+            return -1;
+        } else if ((hc = hexchar(c)) == -1) {
+            json_error(json, "invalid escape Unicode byte '%c'", c);
+            return -1;
+        }
+
+        cp += hc * (1 << shift);
+        shift -= 4;
+    }
+
+
+    return cp;
+}
+
+static int read_unicode(json_stream *json)
+{
+    long cp, h, l;
+
+    if ((cp = read_unicode_cp(json)) == -1) {
+        return -1;
+    }
+
+    if (cp >= 0xd800 && cp <= 0xdbff) {
+        /* This is the high portion of a surrogate pair; we need to read the
+         * lower portion to get the codepoint
+         */
+        h = cp;
+
+        int c = json->source.get(&json->source);
+        if (c == EOF) {
+            json_error(json, "%s", "unterminated string literal in Unicode");
+            return -1;
+        } else if (c != '\\') {
+            json_error(json, "invalid continuation for surrogate pair '%c', "
+                             "expected '\\'", c);
+            return -1;
+        }
+
+        c = json->source.get(&json->source);
+        if (c == EOF) {
+            json_error(json, "%s", "unterminated string literal in Unicode");
+            return -1;
+        } else if (c != 'u') {
+            json_error(json, "invalid continuation for surrogate pair '%c', "
+                             "expected 'u'", c);
+            return -1;
+        }
+
+        if ((l = read_unicode_cp(json)) == -1) {
+            return -1;
+        }
+
+        if (l < 0xdc00 || l > 0xdfff) {
+            json_error(json, "surrogate pair continuation \\u%04lx out "
+                             "of range (dc00-dfff)", l);
+            return -1;
+        }
+
+        cp = ((h - 0xd800) * 0x400) + ((l - 0xdc00) + 0x10000);
+    } else if (cp >= 0xdc00 && cp <= 0xdfff) {
+            json_error(json, "dangling surrogate \\u%04lx", cp);
+            return -1;
+    }
+
+    return encode_utf8(json, cp);
+}
+
+static int
+read_escaped(json_stream *json)
+{
+    int c = json->source.get(&json->source);
+    if (c == EOF) {
+        json_error(json, "%s", "unterminated string literal in escape");
+        return -1;
+    } else if (c == 'u') {
+        if (read_unicode(json) != 0)
+            return -1;
+    } else {
+        switch (c) {
+        case '\\':
+        case 'b':
+        case 'f':
+        case 'n':
+        case 'r':
+        case 't':
+        case '/':
+        case '"':
+            {
+                const char *codes = "\\bfnrt/\"";
+                const char *p = strchr(codes, c);
+                if (pushchar(json, "\\\b\f\n\r\t/\""[p - codes]) != 0)
+                    return -1;
+            }
+            break;
+        default:
+            json_error(json, "invalid escaped byte '%c'", c);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int
+char_needs_escaping(int c)
+{
+    if ((c >= 0) && (c < 0x20 || c == 0x22 || c == 0x5c)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
+utf8_seq_length(char byte)
+{
+    unsigned char u = (unsigned char) byte;
+    if (u < 0x80) return 1;
+
+    if (0x80 <= u && u <= 0xBF)
+    {
+        // second, third or fourth byte of a multi-byte
+        // sequence, i.e. a "continuation byte"
+        return 0;
+    }
+    else if (u == 0xC0 || u == 0xC1)
+    {
+        // overlong encoding of an ASCII byte
+        return 0;
+    }
+    else if (0xC2 <= u && u <= 0xDF)
+    {
+        // 2-byte sequence
+        return 2;
+    }
+    else if (0xE0 <= u && u <= 0xEF)
+    {
+        // 3-byte sequence
+        return 3;
+    }
+    else if (0xF0 <= u && u <= 0xF4)
+    {
+        // 4-byte sequence
+        return 4;
+    }
+    else
+    {
+        // u >= 0xF5
+        // Restricted (start of 4-, 5- or 6-byte sequence) or invalid UTF-8
+        return 0;
+    }
+}
+
+static int
+is_legal_utf8(const unsigned char *bytes, int length)
+{
+    if (0 == bytes || 0 == length) return 0;
+
+    unsigned char a;
+    const unsigned char* srcptr = bytes + length;
+    switch (length)
+    {
+    default:
+        return 0;
+        // Everything else falls through when true.
+    case 4:
+        if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
+        /* FALLTHRU */
+    case 3:
+        if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
+        /* FALLTHRU */
+    case 2:
+        a = (*--srcptr);
+        switch (*bytes)
+        {
+        case 0xE0:
+            if (a < 0xA0 || a > 0xBF) return 0;
+            break;
+        case 0xED:
+            if (a < 0x80 || a > 0x9F) return 0;
+            break;
+        case 0xF0:
+            if (a < 0x90 || a > 0xBF) return 0;
+            break;
+        case 0xF4:
+            if (a < 0x80 || a > 0x8F) return 0;
+            break;
+        default:
+            if (a < 0x80 || a > 0xBF) return 0;
+            break;
+        }
+        /* FALLTHRU */
+    case 1:
+        if (*bytes >= 0x80 && *bytes < 0xC2) return 0;
+    }
+    return *bytes <= 0xF4;
+}
+
+static int
+read_utf8(json_stream* json, int next_char)
+{
+    int count = utf8_seq_length(next_char);
+    if (!count)
+    {
+        json_error(json, "%s", "invalid UTF-8 character");
+        return -1;
+    }
+
+    char buffer[4];
+    buffer[0] = next_char;
+    int i;
+    for (i = 1; i < count; ++i)
+    {
+        buffer[i] = json->source.get(&json->source);;
+    }
+
+    if (!is_legal_utf8((unsigned char*) buffer, count))
+    {
+        json_error(json, "%s", "invalid UTF-8 text");
+        return -1;
+    }
+
+    for (i = 0; i < count; ++i)
+    {
+        if (pushchar(json, buffer[i]) != 0)
+            return -1;
+    }
+    return 0;
+}
+
+static enum json_type
+read_string(json_stream *json)
+{
+    if (init_string(json) != 0)
+        return JSON_ERROR;
+    while (1) {
+        int c = json->source.get(&json->source);
+        if (c == EOF) {
+            json_error(json, "%s", "unterminated string literal");
+            return JSON_ERROR;
+        } else if (c == '"') {
+            if (pushchar(json, '\0') == 0)
+                return JSON_STRING;
+            else
+                return JSON_ERROR;
+        } else if (c == '\\') {
+            if (read_escaped(json) != 0)
+                return JSON_ERROR;
+        } else if ((unsigned) c >= 0x80) {
+            if (read_utf8(json, c) != 0)
+                return JSON_ERROR;
+        } else {
+            if (char_needs_escaping(c)) {
+                json_error(json, "%s", "unescaped control character in string");
+                return JSON_ERROR;
+            }
+
+            if (pushchar(json, c) != 0)
+                return JSON_ERROR;
+        }
+    }
+    return JSON_ERROR;
+}
+
+static int
+is_digit(int c)
+{
+    return c >= 48 /*0*/ && c <= 57 /*9*/;
+}
+
+static int
+read_digits(json_stream *json)
+{
+    int c;
+    unsigned nread = 0;
+    while (is_digit(c = json->source.peek(&json->source))) {
+        if (pushchar(json, json->source.get(&json->source)) != 0)
+            return -1;
+
+        nread++;
+    }
+
+    if (nread == 0) {
+        json_error(json, "expected digit instead of byte '%c'", c);
+        return -1;
+    }
+
+    return 0;
+}
+
+static enum json_type
+read_number(json_stream *json, int c)
+{
+    if (pushchar(json, c) != 0)
+        return JSON_ERROR;
+    if (c == '-') {
+        c = json->source.get(&json->source);
+        if (is_digit(c)) {
+            return read_number(json, c);
+        } else {
+            json_error(json, "unexpected byte '%c' in number", c);
+            return JSON_ERROR;
+        }
+    } else if (strchr("123456789", c) != NULL) {
+        c = json->source.peek(&json->source);
+        if (is_digit(c)) {
+            if (read_digits(json) != 0)
+                return JSON_ERROR;
+        }
+    }
+    /* Up to decimal or exponent has been read. */
+    c = json->source.peek(&json->source);
+    if (strchr(".eE", c) == NULL) {
+        if (pushchar(json, '\0') != 0)
+            return JSON_ERROR;
+        else
+            return JSON_NUMBER;
+    }
+    if (c == '.') {
+        json->source.get(&json->source); // consume .
+        if (pushchar(json, c) != 0)
+            return JSON_ERROR;
+        if (read_digits(json) != 0)
+            return JSON_ERROR;
+    }
+    /* Check for exponent. */
+    c = json->source.peek(&json->source);
+    if (c == 'e' || c == 'E') {
+        json->source.get(&json->source); // consume e/E
+        if (pushchar(json, c) != 0)
+            return JSON_ERROR;
+        c = json->source.peek(&json->source);
+        if (c == '+' || c == '-') {
+            json->source.get(&json->source); // consume
+            if (pushchar(json, c) != 0)
+                return JSON_ERROR;
+            if (read_digits(json) != 0)
+                return JSON_ERROR;
+        } else if (is_digit(c)) {
+            if (read_digits(json) != 0)
+                return JSON_ERROR;
+        } else {
+            json_error(json, "unexpected byte '%c' in number", c);
+            return JSON_ERROR;
+        }
+    }
+    if (pushchar(json, '\0') != 0)
+        return JSON_ERROR;
+    else
+        return JSON_NUMBER;
+}
+
+bool
+json_isspace(int c)
+{
+    switch (c) {
+    case 0x09:
+    case 0x0a:
+    case 0x0d:
+    case 0x20:
+        return true;
+    }
+
+    return false;
+}
+
+/* Returns the next non-whitespace character in the stream. */
+static int next(json_stream *json)
+{
+   int c;
+   while (json_isspace(c = json->source.get(&json->source)))
+       if (c == '\n')
+           json->lineno++;
+   return c;
+}
+
+static enum json_type
+read_value(json_stream *json, int c)
+{
+    json->ntokens++;
+    switch (c) {
+    case EOF:
+        json_error(json, "%s", "unexpected end of text");
+        return JSON_ERROR;
+    case '{':
+        return push(json, JSON_OBJECT);
+    case '[':
+        return push(json, JSON_ARRAY);
+    case '"':
+        return read_string(json);
+    case 'n':
+        return is_match(json, "ull", JSON_NULL);
+    case 'f':
+        return is_match(json, "alse", JSON_FALSE);
+    case 't':
+        return is_match(json, "rue", JSON_TRUE);
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case '-':
+        if (init_string(json) != 0)
+            return JSON_ERROR;
+        return read_number(json, c);
+    default:
+        json_error(json, "unexpected byte '%c' in value", c);
+        return JSON_ERROR;
+    }
+}
+
+enum json_type json_peek(json_stream *json)
+{
+    enum json_type next;
+    if (json->next)
+        next = json->next;
+    else
+        next = json->next = json_next(json);
+    return next;
+}
+
+enum json_type json_next(json_stream *json)
+{
+    if (json->flags & JSON_FLAG_ERROR)
+        return JSON_ERROR;
+    if (json->next != 0) {
+        enum json_type next = json->next;
+        json->next = (enum json_type)0;
+        return next;
+    }
+    if (json->ntokens > 0 && json->stack_top == (size_t)-1) {
+
+        /* In the streaming mode leave any trailing whitespaces in the stream.
+         * This allows the user to validate any desired separation between
+         * values (such as newlines) using json_source_get/peek() with any
+         * remaining whitespaces ignored as leading when we parse the next
+         * value. */
+        if (!(json->flags & JSON_FLAG_STREAMING)) {
+            int c;
+
+            do {
+                c = json->source.peek(&json->source);
+                if (json_isspace(c)) {
+                    c = json->source.get(&json->source);
+                }
+            } while (json_isspace(c));
+
+            if (c != EOF) {
+                json_error(json, "expected end of text instead of byte '%c'", c);
+                return JSON_ERROR;
+            }
+        }
+
+        return JSON_DONE;
+    }
+    int c = next(json);
+    if (json->stack_top == (size_t)-1) {
+        if (c == EOF && (json->flags & JSON_FLAG_STREAMING))
+            return JSON_DONE;
+
+        return read_value(json, c);
+    }
+    if (json->stack[json->stack_top].type == JSON_ARRAY) {
+        if (json->stack[json->stack_top].count == 0) {
+            if (c == ']') {
+                return pop(json, c, JSON_ARRAY);
+            }
+            json->stack[json->stack_top].count++;
+            return read_value(json, c);
+        } else if (c == ',') {
+            json->stack[json->stack_top].count++;
+            return read_value(json, next(json));
+        } else if (c == ']') {
+            return pop(json, c, JSON_ARRAY);
+        } else {
+            json_error(json, "unexpected byte '%c'", c);
+            return JSON_ERROR;
+        }
+    } else if (json->stack[json->stack_top].type == JSON_OBJECT) {
+        if (json->stack[json->stack_top].count == 0) {
+            if (c == '}') {
+                return pop(json, c, JSON_OBJECT);
+            }
+
+            /* No member name/value pairs yet. */
+            enum json_type value = read_value(json, c);
+            if (value != JSON_STRING) {
+                if (value != JSON_ERROR)
+                    json_error(json, "%s", "expected member name or '}'");
+                return JSON_ERROR;
+            } else {
+                json->stack[json->stack_top].count++;
+                return value;
+            }
+        } else if ((json->stack[json->stack_top].count % 2) == 0) {
+            /* Expecting comma followed by member name. */
+            if (c != ',' && c != '}') {
+                json_error(json, "%s", "expected ',' or '}' after member value");
+                return JSON_ERROR;
+            } else if (c == '}') {
+                return pop(json, c, JSON_OBJECT);
+            } else {
+                enum json_type value = read_value(json, next(json));
+                if (value != JSON_STRING) {
+                    if (value != JSON_ERROR)
+                        json_error(json, "%s", "expected member name");
+                    return JSON_ERROR;
+                } else {
+                    json->stack[json->stack_top].count++;
+                    return value;
+                }
+            }
+        } else if ((json->stack[json->stack_top].count % 2) == 1) {
+            /* Expecting colon followed by value. */
+            if (c != ':') {
+                json_error(json, "%s", "expected ':' after member name");
+                return JSON_ERROR;
+            } else {
+                json->stack[json->stack_top].count++;
+                return read_value(json, next(json));
+            }
+        }
+    }
+    json_error(json, "%s", "invalid parser state");
+    return JSON_ERROR;
+}
+
+void json_reset(json_stream *json)
+{
+    json->stack_top = -1;
+    json->ntokens = 0;
+    json->flags &= ~JSON_FLAG_ERROR;
+    json->errmsg[0] = '\0';
+}
+
+enum json_type json_skip(json_stream *json)
+{
+    enum json_type type = json_next(json);
+    size_t cnt_arr = 0;
+    size_t cnt_obj = 0;
+
+    for (enum json_type skip = type; ; skip = json_next(json)) {
+        if (skip == JSON_ERROR || skip == JSON_DONE)
+            return skip;
+
+        if (skip == JSON_ARRAY) {
+            ++cnt_arr;
+        } else if (skip == JSON_ARRAY_END && cnt_arr > 0) {
+            --cnt_arr;
+        } else if (skip == JSON_OBJECT) {
+            ++cnt_obj;
+        } else if (skip == JSON_OBJECT_END && cnt_obj > 0) {
+            --cnt_obj;
+        }
+
+        if (!cnt_arr && !cnt_obj)
+            break;
+    }
+
+    return type;
+}
+
+enum json_type json_skip_until(json_stream *json, enum json_type type)
+{
+    while (1) {
+        enum json_type skip = json_skip(json);
+
+        if (skip == JSON_ERROR || skip == JSON_DONE)
+            return skip;
+
+        if (skip == type)
+            break;
+    }
+
+    return type;
+}
+
+const char *json_get_string(json_stream *json, size_t *length)
+{
+    if (length != NULL)
+        *length = json->data.string_fill;
+    if (json->data.string == NULL)
+        return "";
+    else
+        return json->data.string;
+}
+
+double json_get_number(json_stream *json)
+{
+    char *p = json->data.string;
+    return p == NULL ? 0 : strtod(p, NULL);
+}
+
+const char *json_get_error(json_stream *json)
+{
+    return json->flags & JSON_FLAG_ERROR ? json->errmsg : NULL;
+}
+
+size_t json_get_lineno(json_stream *json)
+{
+    return json->lineno;
+}
+
+size_t json_get_position(json_stream *json)
+{
+    return json->source.position;
+}
+
+size_t json_get_depth(json_stream *json)
+{
+    return json->stack_top + 1;
+}
+
+/* Return the current parsing context, that is, JSON_OBJECT if we are inside
+   an object, JSON_ARRAY if we are inside an array, and JSON_DONE if we are
+   not yet/anymore in either.
+
+   Additionally, for the first two cases, also return the number of parsing
+   events that have already been observed at this level with json_next/peek().
+   In particular, inside an object, an odd number would indicate that the just
+   observed JSON_STRING event is a member name.
+*/
+enum json_type json_get_context(json_stream *json, size_t *count)
+{
+    if (json->stack_top == (size_t)-1)
+        return JSON_DONE;
+
+    if (count != NULL)
+        *count = json->stack[json->stack_top].count;
+
+    return json->stack[json->stack_top].type;
+}
+
+int json_source_get(json_stream *json)
+{
+    int c = json->source.get(&json->source);
+    if (c == '\n')
+        json->lineno++;
+    return c;
+}
+
+int json_source_peek(json_stream *json)
+{
+    return json->source.peek(&json->source);
+}
+
+void json_open_buffer(json_stream *json, const void *buffer, size_t size)
+{
+    init(json);
+    json->source.get = buffer_get;
+    json->source.peek = buffer_peek;
+    json->source.source.buffer.buffer = (const char *)buffer;
+    json->source.source.buffer.length = size;
+}
+
+void json_open_string(json_stream *json, const char *string)
+{
+    json_open_buffer(json, string, strlen(string));
+}
+
+void json_open_stream(json_stream *json, FILE * stream)
+{
+    init(json);
+    json->source.get = stream_get;
+    json->source.peek = stream_peek;
+    json->source.source.stream.stream = stream;
+}
+
+static int user_get(struct json_source *json)
+{
+    return json->source.user.get(json->source.user.ptr);
+}
+
+static int user_peek(struct json_source *json)
+{
+    return json->source.user.peek(json->source.user.ptr);
+}
+
+void json_open_user(json_stream *json, json_user_io get, json_user_io peek, void *user)
+{
+    init(json);
+    json->source.get = user_get;
+    json->source.peek = user_peek;
+    json->source.source.user.ptr = user;
+    json->source.source.user.get = get;
+    json->source.source.user.peek = peek;
+}
+
+void json_set_allocator(json_stream *json, json_allocator *a)
+{
+    json->alloc = *a;
+}
+
+void json_set_streaming(json_stream *json, bool streaming)
+{
+    if (streaming)
+        json->flags |= JSON_FLAG_STREAMING;
+    else
+        json->flags &= ~JSON_FLAG_STREAMING;
+}
+
+void json_close(json_stream *json)
+{
+    json->alloc.free(json->stack);
+    json->alloc.free(json->data.string);
+}

--- a/ext/pdjson/vendor/pdjson.c
+++ b/ext/pdjson/vendor/pdjson.c
@@ -62,8 +62,9 @@ push(json_stream *json, enum json_type type)
 
     if (json->stack_top >= json->stack_size) {
         struct json_stack *stack;
+        size_t old_size = json->stack_size * sizeof(*json->stack);
         size_t size = (json->stack_size + PDJSON_STACK_INC) * sizeof(*json->stack);
-        stack = (struct json_stack *)json->alloc.realloc(json->stack, size);
+        stack = (struct json_stack *)json->alloc.realloc(json->stack, old_size, size);
         if (stack == NULL) {
             json_error(json, "%s", "out of memory");
             return JSON_ERROR;
@@ -118,6 +119,12 @@ static int stream_peek(struct json_source *source)
     return c;
 }
 
+static void *default_realloc(void *ptr, size_t old_size, size_t size)
+{
+    (void)old_size;
+    return realloc(ptr, size);
+}
+
 static void init(json_stream *json)
 {
     json->lineno = 1;
@@ -136,7 +143,7 @@ static void init(json_stream *json)
     json->source.position = 0;
 
     json->alloc.malloc = malloc;
-    json->alloc.realloc = realloc;
+    json->alloc.realloc = default_realloc;
     json->alloc.free = free;
 }
 
@@ -157,7 +164,8 @@ static int pushchar(json_stream *json, int c)
 {
     if (json->data.string_fill == json->data.string_size) {
         size_t size = json->data.string_size * 2;
-        char *buffer = (char *)json->alloc.realloc(json->data.string, size);
+        char *buffer = (char *)json->alloc.realloc(json->data.string,
+                                                   json->data.string_size, size);
         if (buffer == NULL) {
             json_error(json, "%s", "out of memory");
             return -1;

--- a/ext/pdjson/vendor/pdjson.h
+++ b/ext/pdjson/vendor/pdjson.h
@@ -1,0 +1,117 @@
+#ifndef PDJSON_H
+#define PDJSON_H
+
+#ifndef PDJSON_SYMEXPORT
+#   define PDJSON_SYMEXPORT
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#else
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+    #include <stdbool.h>
+#else
+    #ifndef bool
+        #define bool int
+        #define true 1
+        #define false 0
+    #endif /* bool */
+#endif /* __STDC_VERSION__ */
+#endif /* __cplusplus */
+
+#include <stdio.h>
+
+enum json_type {
+    JSON_ERROR = 1, JSON_DONE,
+    JSON_OBJECT, JSON_OBJECT_END, JSON_ARRAY, JSON_ARRAY_END,
+    JSON_STRING, JSON_NUMBER, JSON_TRUE, JSON_FALSE, JSON_NULL
+};
+
+struct json_allocator {
+    void *(*malloc)(size_t);
+    void *(*realloc)(void *, size_t);
+    void (*free)(void *);
+};
+
+typedef int (*json_user_io)(void *user);
+
+typedef struct json_stream json_stream;
+typedef struct json_allocator json_allocator;
+
+PDJSON_SYMEXPORT void json_open_buffer(json_stream *json, const void *buffer, size_t size);
+PDJSON_SYMEXPORT void json_open_string(json_stream *json, const char *string);
+PDJSON_SYMEXPORT void json_open_stream(json_stream *json, FILE *stream);
+PDJSON_SYMEXPORT void json_open_user(json_stream *json, json_user_io get, json_user_io peek, void *user);
+PDJSON_SYMEXPORT void json_close(json_stream *json);
+
+PDJSON_SYMEXPORT void json_set_allocator(json_stream *json, json_allocator *a);
+PDJSON_SYMEXPORT void json_set_streaming(json_stream *json, bool mode);
+
+PDJSON_SYMEXPORT enum json_type json_next(json_stream *json);
+PDJSON_SYMEXPORT enum json_type json_peek(json_stream *json);
+PDJSON_SYMEXPORT void json_reset(json_stream *json);
+PDJSON_SYMEXPORT const char *json_get_string(json_stream *json, size_t *length);
+PDJSON_SYMEXPORT double json_get_number(json_stream *json);
+
+PDJSON_SYMEXPORT enum json_type json_skip(json_stream *json);
+PDJSON_SYMEXPORT enum json_type json_skip_until(json_stream *json, enum json_type type);
+
+PDJSON_SYMEXPORT size_t json_get_lineno(json_stream *json);
+PDJSON_SYMEXPORT size_t json_get_position(json_stream *json);
+PDJSON_SYMEXPORT size_t json_get_depth(json_stream *json);
+PDJSON_SYMEXPORT enum json_type json_get_context(json_stream *json, size_t *count);
+PDJSON_SYMEXPORT const char *json_get_error(json_stream *json);
+
+PDJSON_SYMEXPORT int json_source_get(json_stream *json);
+PDJSON_SYMEXPORT int json_source_peek(json_stream *json);
+PDJSON_SYMEXPORT bool json_isspace(int c);
+
+/* internal */
+
+struct json_source {
+    int (*get)(struct json_source *);
+    int (*peek)(struct json_source *);
+    size_t position;
+    union {
+        struct {
+            FILE *stream;
+        } stream;
+        struct {
+            const char *buffer;
+            size_t length;
+        } buffer;
+        struct {
+            void *ptr;
+            json_user_io get;
+            json_user_io peek;
+        } user;
+    } source;
+};
+
+struct json_stream {
+    size_t lineno;
+
+    struct json_stack *stack;
+    size_t stack_top;
+    size_t stack_size;
+    enum json_type next;
+    unsigned flags;
+
+    struct {
+        char *string;
+        size_t string_fill;
+        size_t string_size;
+    } data;
+
+    size_t ntokens;
+
+    struct json_source source;
+    struct json_allocator alloc;
+    char errmsg[128];
+};
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif

--- a/ext/pdjson/vendor/pdjson.h
+++ b/ext/pdjson/vendor/pdjson.h
@@ -29,7 +29,7 @@ enum json_type {
 
 struct json_allocator {
     void *(*malloc)(size_t);
-    void *(*realloc)(void *, size_t);
+    void *(*realloc)(void *, size_t, size_t);  /* ptr, old size, new size */
     void (*free)(void *);
 };
 

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -240,8 +240,10 @@ u3a_walloc(c3_w len_w)
 /* u3a_wealloc(): realloc in words.
 */
 void*
-u3a_wealloc(void* lag_v, c3_w len_w)
+u3a_wealloc(void* lag_v, c3_w old_w, c3_w len_w)
 {
+  (void)old_w;
+
   if ( !lag_v ) {
     return u3a_walloc(len_w);
   }
@@ -322,15 +324,21 @@ u3a_malloc(c3_z len_z)
 /* u3a_realloc(): aligned realloc in bytes.
 */
 void*
-u3a_realloc(void* lag_v, c3_z len_z)
+u3a_realloc(void* lag_v, c3_z old_z, c3_z len_z)
 {
   if ( !lag_v ) {
+    (void)old_z;
     return u3a_malloc(len_z);
   }
 
+  c3_z wol_z = (old_z + 3) >> 2;
   c3_z wen_z = (len_z + 3) >> 2;
-  if (wen_z > UINT32_MAX ) return (u3m_bail(c3__fail), (void*)0);
-  return u3a_wealloc(lag_v, (c3_w)wen_z);
+
+  if ( (wol_z > UINT32_MAX) || (wen_z > UINT32_MAX) ) {
+    return (u3m_bail(c3__fail), (void*)0);
+  }
+
+  return u3a_wealloc(lag_v, (c3_w)wol_z, (c3_w)wen_z);
 }
 
 /* u3a_free(): free for aligned malloc.

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -292,14 +292,15 @@ u3a_wtrim(void* tox_v, c3_w old_w, c3_w len_w)
 /* u3a_calloc(): allocate and zero-initialize array
 */
 void*
-u3a_calloc(size_t num_i, size_t len_i)
+u3a_calloc(c3_z num_z, c3_z len_z)
 {
-  size_t byt_i = num_i * len_i;
-  c3_w* out_w;
+  c3_z   byt_z = num_z * len_z;
+  c3_w *out_w;
 
-  u3_assert(byt_i / len_i == num_i);
-  out_w = u3a_malloc(byt_i);
-  memset(out_w, 0, byt_i);
+  if ( num_z != (byt_z / len_z) ) return (u3m_bail(c3__fail), (void*)0);
+
+  out_w = u3a_malloc(byt_z);
+  memset(out_w, 0, byt_z);
 
   return out_w;
 }
@@ -311,9 +312,33 @@ u3a_calloc(size_t num_i, size_t len_i)
 
 */
 void*
-u3a_malloc(size_t len_i)
+u3a_malloc(c3_z len_z)
 {
-  return u3a_walloc((len_i + 3) >> 2);
+  c3_z wor_z = (len_z + 3) >> 2;
+  if ( wor_z > UINT32_MAX ) return (u3m_bail(c3__fail), (void*)0);
+  return u3a_walloc((c3_w)wor_z);
+}
+
+/* u3a_realloc(): aligned realloc in bytes.
+*/
+void*
+u3a_realloc(void* lag_v, c3_z len_z)
+{
+  if ( !lag_v ) {
+    return u3a_malloc(len_z);
+  }
+
+  c3_z wen_z = (len_z + 3) >> 2;
+  if (wen_z > UINT32_MAX ) return (u3m_bail(c3__fail), (void*)0);
+  return u3a_wealloc(lag_v, (c3_w)wen_z);
+}
+
+/* u3a_free(): free for aligned malloc.
+*/
+void
+u3a_free(void* tox_v)
+{
+  u3a_wfree((c3_w*)tox_v);
 }
 
 /* u3a_celloc(): allocate a cell.
@@ -362,26 +387,6 @@ u3a_cfree(c3_w* cel_w)
   }
 
   u3a_wfree(cel_w);
-}
-
-/* u3a_realloc(): aligned realloc in bytes.
-*/
-void*
-u3a_realloc(void* lag_v, size_t len_i)
-{
-  if ( !lag_v ) {
-    return u3a_malloc(len_i);
-  }
-
-  return u3a_wealloc(lag_v, (len_i + 3) >> 2);
-}
-
-/* u3a_free(): free for aligned malloc.
-*/
-void
-u3a_free(void* tox_v)
-{
-  u3a_wfree((c3_w*)tox_v);
 }
 
 /* _me_wash_north(): clean up mug slots after copy.

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -620,17 +620,17 @@ u3a_post_info(u3_post);
         /* u3a_malloc(): aligned storage measured in bytes.
         */
           void*
-          u3a_malloc(size_t len_i);
+          u3a_malloc(c3_z len_z);
 
         /* u3a_calloc(): aligned storage measured in bytes.
         */
           void*
-          u3a_calloc(size_t num_i, size_t len_i);
+          u3a_calloc(c3_z num_z, c3_z len_z);
 
         /* u3a_realloc(): aligned realloc in bytes.
         */
           void*
-          u3a_realloc(void* lag_v, size_t len_i);
+          u3a_realloc(void* lag_v, c3_z len_z);
 
         /* u3a_free(): free for aligned malloc.
         */

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -608,7 +608,7 @@ u3a_post_info(u3_post);
         /* u3a_wealloc(): word realloc.
         */
           void*
-          u3a_wealloc(void* lag_v, c3_w len_w);
+          u3a_wealloc(void* lag_v, c3_w old_w, c3_w len_w);
 
         /* u3a_pile_prep(): initialize stack control.
         */
@@ -630,7 +630,7 @@ u3a_post_info(u3_post);
         /* u3a_realloc(): aligned realloc in bytes.
         */
           void*
-          u3a_realloc(void* lag_v, c3_z len_z);
+          u3a_realloc(void* lag_v, c3_z old_z, c3_z len_z);
 
         /* u3a_free(): free for aligned malloc.
         */

--- a/pkg/noun/imprison.c
+++ b/pkg/noun/imprison.c
@@ -71,9 +71,8 @@ static void
 _ci_slab_grow(u3i_slab* sab_u, c3_w len_w)
 {
   c3_w*     old_w = (void*)sab_u->_._vat_u;
-  //    XX implement a more efficient u3a_wealloc()
-  //
-  c3_w*     nov_w = u3a_wealloc(old_w, len_w + c3_wiseof(u3a_atom));
+  c3_w*     nov_w = u3a_wealloc(old_w, sab_u->len_w + c3_wiseof(u3a_atom),
+                                       len_w + c3_wiseof(u3a_atom));
   u3a_atom* vat_u = (void *)nov_w;
 
   vat_u->len_w = len_w;

--- a/pkg/noun/jets/e/json_de.c
+++ b/pkg/noun/jets/e/json_de.c
@@ -73,6 +73,13 @@ _json_get_string_as_atom(json_stream *sam_u) {
           u3i_bytes(len_i - 1, (const c3_y *)str_c);
 }
 
+static void*
+_json_realloc(void* lag_v, size_t old_i, size_t len_i)
+{
+  (void)old_i;
+  return u3a_realloc(lag_v, len_i);
+}
+
 static u3_noun
 _parse(u3_atom txt)
 {
@@ -82,7 +89,7 @@ _parse(u3_atom txt)
 
   u3qedj_coll *tak_u;
 
-  json_allocator loc_u = {u3a_malloc, u3a_realloc, u3a_free};
+  json_allocator loc_u = {u3a_malloc, _json_realloc, u3a_free};
   json_stream    sem_u;
   json_stream*   sam_u = &sem_u;
 

--- a/pkg/noun/jets/e/json_de.c
+++ b/pkg/noun/jets/e/json_de.c
@@ -73,13 +73,6 @@ _json_get_string_as_atom(json_stream *sam_u) {
           u3i_bytes(len_i - 1, (const c3_y *)str_c);
 }
 
-static void*
-_json_realloc(void* lag_v, size_t old_i, size_t len_i)
-{
-  (void)old_i;
-  return u3a_realloc(lag_v, len_i);
-}
-
 static u3_noun
 _parse(u3_atom txt)
 {
@@ -89,7 +82,7 @@ _parse(u3_atom txt)
 
   u3qedj_coll *tak_u;
 
-  json_allocator loc_u = {u3a_malloc, _json_realloc, u3a_free};
+  json_allocator loc_u = {u3a_malloc, u3a_realloc, u3a_free};
   json_stream    sem_u;
   json_stream*   sam_u = &sem_u;
 

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -61,12 +61,6 @@
 #define KICK1(TRAP)         uw_kick_nock(TRAP, 2)
 #define KICK2(TRAP)         KICK1(KICK1(TRAP))
 
-static void*
-_road_realloc(void* lag_v, size_t old_i, size_t new_i)
-{
-  return u3a_realloc(lag_v, new_i);
-}
-
 // [a b c d e f g h]
 static inline u3_noun
 uw_octo(u3_noun a,
@@ -2040,7 +2034,7 @@ _apply_diff(u3_noun input_tag, u3_noun p_input, lia_state* sat_u)
 {
   m3_SetAllocators(_calloc_bail, _free_bail, _realloc_bail);
   m3_SetTransientAllocators(_calloc_bail, _free_bail, _realloc_bail);
-  m3_SetMemoryAllocators(u3a_calloc, u3a_free, _road_realloc);
+  m3_SetMemoryAllocators(u3a_calloc, u3a_free, u3a_realloc);
 
   if (input_tag == c3y)
   {
@@ -2429,7 +2423,7 @@ u3we_lia_run_v1(u3_noun cor)
 
       m3_SetAllocators(_calloc_box, _free_box, _realloc_box);
       m3_SetTransientAllocators(_calloc_code, _free_code, _realloc_code);
-      m3_SetMemoryAllocators(u3a_calloc, u3a_free, _road_realloc);
+      m3_SetMemoryAllocators(u3a_calloc, u3a_free, u3a_realloc);
       jmp_buf esc;
       CodeArena->esc_u = BoxArena->esc_u = &esc;
       c3_i jmp_i;
@@ -2611,9 +2605,9 @@ u3we_lia_run_v1(u3_noun cor)
                                                  : u3m_bail(c3__fail);
     c3_y* bin_y = u3r_bytes_alloc(0, bin_len_w, u3x_atom(q_octs));
 
-    m3_SetAllocators(u3a_calloc, u3a_free, _road_realloc);
-    m3_SetTransientAllocators(u3a_calloc, u3a_free, _road_realloc);
-    m3_SetMemoryAllocators(u3a_calloc, u3a_free, _road_realloc);
+    m3_SetAllocators(u3a_calloc, u3a_free, u3a_realloc);
+    m3_SetTransientAllocators(u3a_calloc, u3a_free, u3a_realloc);
+    m3_SetMemoryAllocators(u3a_calloc, u3a_free, u3a_realloc);
 
     wasm3_env = m3_NewEnvironment();
     if (!wasm3_env)
@@ -2901,9 +2895,9 @@ u3we_lia_run_once(u3_noun cor)
 
   M3Result result;
 
-  m3_SetAllocators(u3a_calloc, u3a_free, _road_realloc);
-  m3_SetTransientAllocators(u3a_calloc, u3a_free, _road_realloc);
-  m3_SetMemoryAllocators(u3a_calloc, u3a_free, _road_realloc);
+  m3_SetAllocators(u3a_calloc, u3a_free, u3a_realloc);
+  m3_SetTransientAllocators(u3a_calloc, u3a_free, u3a_realloc);
+  m3_SetMemoryAllocators(u3a_calloc, u3a_free, u3a_realloc);
 
   IM3Environment wasm3_env = m3_NewEnvironment();
   if (!wasm3_env)

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -2475,14 +2475,6 @@ _cm_crypto(void)
   u3je_secp_init();
 }
 
-/* _cm_realloc2(): gmp-shaped realloc.
-*/
-static void*
-_cm_realloc2(void* lag_v, size_t old_i, size_t new_i)
-{
-  return u3a_realloc(lag_v, new_i);
-}
-
 /* _cm_free2(): gmp-shaped free.
 */
 static void
@@ -2504,7 +2496,7 @@ u3m_init(size_t len_i)
 
   //  make sure GMP uses our malloc.
   //
-  mp_set_memory_functions(u3a_malloc, _cm_realloc2, _cm_free2);
+  mp_set_memory_functions(u3a_malloc, u3a_realloc, _cm_free2);
 
   //  make sure that [len_i] is a fully-addressible non-zero power of two.
   //


### PR DESCRIPTION
This PR updates the u3 realloc functions to require explicit old sizes, making it much easier to add alternative bump/arena allocator implementations. It builds on #1024 and includes a merge of #1025 to accomplish (these should be merged first). It also vendors and modifies the pdjson library used in the `+de:json` jet.