### PR TITLE
u3: adds bump allocation on inner roads

### DIFF
--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -261,24 +261,15 @@ _ca_bump(c3_w len_w)
   if ( c3y == u3a_is_north(u3R) ) {
     pot_p       = u3R->hat_p;
     u3R->hat_p += len_w;
-
-#ifndef U3_GUARD_PAGE
-    if ( u3R->hat_p >= u3R->cap_p ) {
-      u3m_bail(c3__meme);
-    }
-#endif
   }
   else {
     u3R->hat_p -= len_w;
     pot_p       = u3R->hat_p;
-
-#ifndef U3_GUARD_PAGE
-    if ( u3R->cap_p >= u3R->hat_p ) {
-      u3m_bail(c3__meme);
-    }
-#endif
   }
 
+#ifndef U3_GUARD_PAGE
+  if ( c3n == u3a_is_sound(u3R) ) return u3m_bail(c3__meme);
+#endif
   c3_dessert( !(pot_p & ((1U << u3a_min_log) - 1)) );
 
   return u3a_into(pot_p);

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -86,7 +86,23 @@ u3a_init_once(void)
 void
 u3a_init_heap(void)
 {
-  _init_heap();
+  //  empty, page-aligned heap
+  //
+  u3_assert( !(u3R->hat_p & ((1U << u3a_page) - 1)) );
+  u3_assert( u3R->hat_p == u3R->rut_p );
+
+  if ( c3y == u3a_is_north(u3R) ) {
+    u3R->hep.dir_ws = 1;
+    u3R->hep.off_ws = 0;
+  }
+  else {
+    u3R->hep.dir_ws = -1;
+    u3R->hep.off_ws = -1;
+  }
+
+  if ( !(u3R->how.fag_w & u3a_flag_sand) ) {
+    _init_heap();
+  }
 }
 
 void
@@ -229,11 +245,49 @@ _ca_reclaim_half(void)
 #endif
 }
 
+static void*
+_ca_bump(c3_w len_w)
+{
+  u3_post pot_p;
+
+  len_w +=   (1U << u3a_min_log) - 1;
+  len_w &= ~((1U << u3a_min_log) - 1);
+
+  if ( c3y == u3a_is_north(u3R) ) {
+    pot_p       = u3R->hat_p;
+    u3R->hat_p += len_w;
+
+#ifndef U3_GUARD_PAGE
+    if ( u3R->hat_p >= u3R->cap_p ) {
+      u3m_bail(c3__meme);
+    }
+#endif
+  }
+  else {
+    u3R->hat_p -= len_w;
+    pot_p       = u3R->hat_p;
+
+#ifndef U3_GUARD_PAGE
+    if ( u3R->cap_p >= u3R->hat_p ) {
+      u3m_bail(c3__meme);
+    }
+#endif
+  }
+
+  c3_dessert( !(pot_p & ((1U << u3a_min_log) - 1)) );
+
+  return u3a_into(pot_p);
+}
+
 /* u3a_walloc(): allocate storage words on hat heap.
 */
 void*
 u3a_walloc(c3_w len_w)
 {
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    return _ca_bump(len_w);
+  }
+
   return u3a_into(_imalloc(len_w));
 }
 
@@ -242,12 +296,18 @@ u3a_walloc(c3_w len_w)
 void*
 u3a_wealloc(void* lag_v, c3_w old_w, c3_w len_w)
 {
-  (void)old_w;
-
   if ( !lag_v ) {
+    (void)old_w;
     return u3a_walloc(len_w);
   }
 
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    void* new_v = _ca_bump(len_w);
+    memcpy(new_v, lag_v, (c3_z)c3_min(old_w, len_w) << 2);
+    return new_v;
+  }
+
+  (void)old_w;
   return u3a_into(_irealloc(u3a_outa(lag_v), len_w));
 }
 
@@ -275,6 +335,10 @@ u3a_pile_prep(u3a_pile* pil_u, c3_w len_w)
 void
 u3a_wfree(void* tox_v)
 {
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    return;
+  }
+
   if ( tox_v ) {
     _ifree(u3a_outa(tox_v));
   }
@@ -346,6 +410,10 @@ u3a_realloc(void* lag_v, c3_z old_z, c3_z len_z)
 void
 u3a_free(void* tox_v)
 {
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    return;
+  }
+
   u3a_wfree((c3_w*)tox_v);
 }
 
@@ -357,7 +425,10 @@ u3a_celloc(void)
   u3a_cell *cel_u;
   u3_post  *cel_p;
 
-  if ( u3R->cel.cel_p ) {
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    cel_u = _ca_bump(c3_wiseof(*cel_u));
+  }
+  else if ( u3R->cel.cel_p ) {
     cel_p = u3to(u3_post, u3R->cel.cel_p);
 
     if ( !u3R->cel.hav_w ) {
@@ -386,7 +457,10 @@ u3a_cfree(c3_w* cel_w)
 {
   u3_post *cel_p;
 
-  if ( u3R->cel.cel_p ) {
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    return;
+  }
+  else if ( u3R->cel.cel_p ) {
     if ( u3R->cel.hav_w < (1U << u3a_page) ) {
       cel_p = u3to(u3_post, u3R->cel.cel_p);
       cel_p[u3R->cel.hav_w++] = u3a_outa(cel_w);
@@ -939,6 +1013,10 @@ top:
 u3_noun
 u3a_gain(u3_noun som)
 {
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    return som;
+  }
+
   u3t_on(mal_o);
   u3_assert(u3_none != som);
 
@@ -957,6 +1035,10 @@ u3a_gain(u3_noun som)
 void
 u3a_lose(u3_noun som)
 {
+  if ( u3R->how.fag_w & u3a_flag_sand ) {
+    return;
+  }
+
   u3t_on(mal_o);
   if ( !_(u3a_is_cat(som)) ) {
     if ( _(u3a_is_north(u3R)) ) {

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -417,6 +417,32 @@ u3a_free(void* tox_v)
   u3a_wfree((c3_w*)tox_v);
 }
 
+void
+u3a_cellblock(void)
+{
+  u3_post   *cel_p = u3to(u3_post, u3R->cel.cel_p);
+  u3a_cell  *cel_u;
+  const c3_w max_w = (1U << u3a_page) / c3_wiseof(u3a_cell);
+
+  if ( u3R->cel.hav_w ) return;
+
+  u3R->cel.bat_w++;
+
+  if ( !(u3R->how.fag_w & u3a_flag_sand) ) {
+    _rake_chunks(c3_wiseof(*cel_u), (1U << u3a_page),
+                 (u3R->cel.bat_w & 1), &u3R->cel.hav_w, cel_p);
+  }
+  else {
+    cel_u = u3a_walloc(1U << u3a_page);
+
+    for ( c3_w i_w = 0; i_w < max_w; i_w++ ) {
+      cel_p[i_w] = u3a_outa(&(cel_u[i_w]));
+    }
+
+    u3R->cel.hav_w = max_w;
+  }
+}
+
 /* u3a_celloc(): allocate a cell.
 */
 c3_w*
@@ -425,17 +451,9 @@ u3a_celloc(void)
   u3a_cell *cel_u;
   u3_post  *cel_p;
 
-  if ( u3R->how.fag_w & u3a_flag_sand ) {
-    cel_u = _ca_bump(c3_wiseof(*cel_u));
-  }
-  else if ( u3R->cel.cel_p ) {
+  if ( u3R->cel.cel_p ) {
+    if ( !u3R->cel.hav_w ) u3a_cellblock();
     cel_p = u3to(u3_post, u3R->cel.cel_p);
-
-    if ( !u3R->cel.hav_w ) {
-      _rake_chunks(c3_wiseof(*cel_u), (1U << u3a_page),
-                   (u3R->cel.bat_w++ & 1), &u3R->cel.hav_w, cel_p);
-    }
-
     cel_u = u3to(u3a_cell, cel_p[--u3R->cel.hav_w]);
   }
   else {
@@ -457,10 +475,7 @@ u3a_cfree(c3_w* cel_w)
 {
   u3_post *cel_p;
 
-  if ( u3R->how.fag_w & u3a_flag_sand ) {
-    return;
-  }
-  else if ( u3R->cel.cel_p ) {
+  if ( u3R->cel.cel_p ) {
     if ( u3R->cel.hav_w < (1U << u3a_page) ) {
       cel_p = u3to(u3_post, u3R->cel.cel_p);
       cel_p[u3R->cel.hav_w++] = u3a_outa(cel_w);

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -253,6 +253,11 @@ _ca_bump(c3_w len_w)
   len_w +=   (1U << u3a_min_log) - 1;
   len_w &= ~((1U << u3a_min_log) - 1);
 
+  //  XX: branch-free version
+  //
+  // pot_p  = u3R->hat_p + (u3R->hep.off_ws * (c3_ws)len_w);
+  // u3R->hat_p += u3R->hep.dir_ws * (c3_ws)len_w;
+
   if ( c3y == u3a_is_north(u3R) ) {
     pot_p       = u3R->hat_p;
     u3R->hat_p += len_w;

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -219,7 +219,7 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
     /* u3a_flag: flags for how.fag_w.  All arena related.
     */
       enum u3a_flag {
-        u3a_flag_sand  = 1 << 1,              //  bump allocation (XX not impl)
+        u3a_flag_sand  = 1 << 1,              //  bump allocation
         u3a_flag_cash  = 1 << 2,              //  memo cache harvesting, flows forward
       };
 
@@ -356,7 +356,9 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
                          :  u3a_south_is_senior(r, som) )
 
 #     define  u3a_is_mutable(r, som) \
-                ( _(u3a_is_atom(som)) \
+                ( ((r)->how.fag_w & u3a_flag_sand) \
+                  ? c3n \
+                  : _(u3a_is_atom(som)) \
                   ? c3n \
                   : _(u3a_is_senior(r, som)) \
                   ? c3n \

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -148,7 +148,8 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
         u3p(u3h_root) lop_p;                  //  %loop hint set
         u3_noun tim;                          //  list of absolute deadlines
 
-        c3_w fut_w[28];                       //  futureproof buffer
+        c3_w san_w;                           //  saved u3o_sand, restored on fall
+        c3_w fut_w[27];                       //  futureproof buffer
 
         struct {                              //  escape buffer
           union {

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -292,6 +292,11 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
     */
 #     define  u3a_is_south(r)  !u3a_is_north((r))
 
+    /* u3a_is_sound(): yes if road [r] has not overflowed.
+    */
+#     define  u3a_is_sound(r)  __(  ((r)->mat_p > (r)->rut_p) \
+                                 == ((r)->cap_p > (r)->hat_p) )
+
     /* u3a_open(): words of contiguous free space in road [r]
     */
 #     define  u3a_open(r)  ( (c3y == u3a_is_north(r)) \

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -653,6 +653,7 @@ u3a_post_info(u3_post);
           u3a_gain(u3_weak som);
 #         define u3k(som) ({                                                    \
             u3_noun __som = som;                                                \
+            ( u3R->how.fag_w & u3a_flag_sand ) ? __som :                        \
             ( c3y == u3a_is_cat(__som) ) ? __som : u3a_gain(__som);             \
           })
 
@@ -672,6 +673,7 @@ u3a_post_info(u3_post);
           u3a_lose(u3_weak som);
 #         define u3z(som) ({                                                    \
             u3_noun __som = som;                                                \
+            ( u3R->how.fag_w & u3a_flag_sand ) ? (void)0 :                      \
             ( c3y == u3a_is_cat(__som) ) ? (void)0 : u3a_lose(__som);           \
           })
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1133,13 +1133,17 @@ u3m_leap(c3_w pad_w)
   if ( NULL != u3t_Spin ) {
     u3R->off_w = u3t_Spin->off_w;
     u3R->fow_w = u3t_Spin->fow_w;
-  } 
+  }
+
+  //  stash bump-allocation state
+  //
+  u3R->san_w = u3C.wag_w & u3o_sand;
 
   /* Set up the new road.
   */
   {
     u3R = rod_u;
-    if ( !(u3C.wag_w & u3o_no_sand) ) {
+    if ( u3C.wag_w & u3o_sand ) {
       u3R->how.fag_w |= u3a_flag_sand;
     }
     _pave_parts();
@@ -1204,6 +1208,10 @@ u3m_fall(void)
   */
   u3R = u3to(u3_road, u3R->par_p);
   u3R->kid_p = 0;
+
+  //  restore bump-allocation state
+  //
+  u3C.wag_w = (u3C.wag_w & ~u3o_sand) | u3R->san_w;
 }
 
 /* u3m_hate(): new, integrated leap mechanism (enter).

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -503,7 +503,9 @@ _pave_parts(void)
 {
   u3a_init_heap();
 
-  if ( &(u3H->rod_u) != u3R ) {
+  if (  !(u3R->how.fag_w & u3a_flag_sand)
+     && (&(u3H->rod_u) != u3R) )
+  {
     u3R->cel.cel_p = u3of(u3_post, u3a_walloc(1U << u3a_page));
   }
 
@@ -517,7 +519,6 @@ _pave_parts(void)
   u3R->byc.har_p = u3h_new();
   u3R->lop_p     = u3h_new();
   u3R->tim       = u3_nul;
-  u3R->how.fag_w = 0;
 }
 
 static c3_d
@@ -1140,6 +1141,7 @@ u3m_leap(c3_w pad_w)
   */
   {
     u3R = rod_u;
+    u3R->how.fag_w |= u3a_flag_sand;
     _pave_parts();
   }
 #ifdef U3_MEMORY_DEBUG

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -503,9 +503,7 @@ _pave_parts(void)
 {
   u3a_init_heap();
 
-  if (  !(u3R->how.fag_w & u3a_flag_sand)
-     && (&(u3H->rod_u) != u3R) )
-  {
+  if ( &(u3H->rod_u) != u3R ) {
     u3R->cel.cel_p = u3of(u3_post, u3a_walloc(1U << u3a_page));
   }
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1139,7 +1139,9 @@ u3m_leap(c3_w pad_w)
   */
   {
     u3R = rod_u;
-    u3R->how.fag_w |= u3a_flag_sand;
+    if ( !(u3C.wag_w & u3o_no_sand) ) {
+      u3R->how.fag_w |= u3a_flag_sand;
+    }
     _pave_parts();
   }
 #ifdef U3_MEMORY_DEBUG

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -1026,6 +1026,7 @@ _n_bint(u3_noun* ops, u3_noun hif, u3_noun nef, c3_o los_o, c3_o tel_o)
       default: {
         return _n_comp(ops, nef, los_o, tel_o);
       }
+      case c3__bump:
       case c3__cash:
       case c3__xray:
       case c3__meme:
@@ -1913,6 +1914,14 @@ _n_hilt_fore(u3_noun hin, u3_noun bus, u3_noun* out)
   u3x_cell(hin, &tag, &fol);
 
   switch ( tag ) {
+    //  enable bump allocation for child roads created under this hint.
+    //
+    case c3__bump: {
+      c3_o had_o = (u3C.wag_w & u3o_sand) ? c3y : c3n;
+      u3C.wag_w |= u3o_sand;
+      *out = u3i_cell(tag, had_o);
+    } break;
+
     case c3__cash: {
       u3_atom har = u3i_word(u3h_count(u3R->cax.har_p));
       u3h_discount(u3R->cax.har_p);
@@ -1979,7 +1988,14 @@ static void
 _n_hilt_hind(u3_noun tok, u3_noun pro)
 {
   u3_noun p_tok, q_tok, r_tok;
-  if ( (c3y == u3r_cell(tok, &p_tok, &q_tok)) && (c3__loop == p_tok) ) {
+  if ( (c3y == u3r_cell(tok, &p_tok, &q_tok)) && (c3__bump == p_tok) ) {
+    //  restore bump allocation to its pre-hint state
+    //
+    if ( c3n == q_tok ) {
+      u3C.wag_w &= ~u3o_sand;
+    }
+  }
+  else if ( (c3y == u3r_cell(tok, &p_tok, &q_tok)) && (c3__loop == p_tok) ) {
     u3h_del(u3R->lop_p, q_tok);
   }
   else if ( (c3y == u3r_cell(tok, &p_tok, &q_tok)) && (c3__bout == p_tok) ) {

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -47,7 +47,7 @@
         u3o_toss          = 1 << 13,          //  reclaim often
         u3o_leak_crash    = 1 << 14,          //  crash if leak when gc
         u3o_yolo          = 1 << 15,          //  no brakes!
-        u3o_no_sand       = 1 << 16,          //  disable inner-road bump allocation
+        u3o_sand          = 1 << 16,          //  enable inner-road bump allocation
       };
 
   /** Globals.

--- a/pkg/noun/options.h
+++ b/pkg/noun/options.h
@@ -47,6 +47,7 @@
         u3o_toss          = 1 << 13,          //  reclaim often
         u3o_leak_crash    = 1 << 14,          //  crash if leak when gc
         u3o_yolo          = 1 << 15,          //  no brakes!
+        u3o_no_sand       = 1 << 16,          //  disable inner-road bump allocation
       };
 
   /** Globals.

--- a/pkg/noun/palloc.c
+++ b/pkg/noun/palloc.c
@@ -87,18 +87,7 @@ _init_heap(void)
 {
   u3p(u3a_crag) *dir_u;
 
-  if ( c3y == u3a_is_north(u3R) ) {
-    HEAP.dir_ws = 1;
-    HEAP.off_ws = 0;
-  }
-  else {
-    HEAP.dir_ws = -1;
-    HEAP.off_ws = -1;
-  }
-
-  assert( !(u3R->hat_p & ((1U << u3a_page) - 1)) );
   assert( u3R->hat_p > u3a_rest_pg );
-  assert( u3R->hat_p == u3R->rut_p );
 
   //  XX check for overflow
 

--- a/pkg/noun/palloc.c
+++ b/pkg/noun/palloc.c
@@ -133,16 +133,7 @@ _extend_directory(c3_w siz_w)  // num pages
 
   //  XX depend on the guard page for these?
   //
-  if ( 1 == HEAP.dir_ws ) {
-    if ( u3R->hat_p >= u3R->cap_p ) {
-      u3m_bail(c3__meme); return;
-    }
-  }
-  else {
-    if ( u3R->hat_p <= u3R->cap_p ) {
-      u3m_bail(c3__meme); return;
-    }
-  }
+  if ( c3n == u3a_is_sound(u3R) ) u3m_bail(c3__meme);
 
   dir_u = u3to(u3p(u3a_crag), HEAP.pag_p);
   pag_w = post_to_page(HEAP.pag_p);
@@ -199,16 +190,7 @@ _extend_heap(c3_w siz_w)  // num pages
 
   //  XX depend on the guard page for these?
   //
-  if ( 1 == HEAP.dir_ws ) {
-    if ( u3R->hat_p >= u3R->cap_p ) {
-      return u3m_bail(c3__meme);
-    }
-  }
-  else {
-    if ( u3R->hat_p <= u3R->cap_p ) {
-      return u3m_bail(c3__meme);
-    }
-  }
+  if ( c3n == u3a_is_sound(u3R) ) return u3m_bail(c3__meme);
 
   HEAP.len_w += siz_w;
 

--- a/pkg/vere/benchmarks.c
+++ b/pkg/vere/benchmarks.c
@@ -5,12 +5,32 @@
 #include "ur/ur.h"
 #include "vere.h"
 
+#include <time.h>
+
 /* _setup(): prepare for tests.
 */
 static void
 _setup(void)
 {
   u3m_boot_lite(1 << 24);
+}
+
+/* _bench_ns(): monotonic timestamp in nanoseconds.
+*/
+static c3_d
+_bench_ns(void)
+{
+  struct timespec tim_u;
+  clock_gettime(CLOCK_MONOTONIC, &tim_u);
+  return ((c3_d)tim_u.tv_sec * 1000000000ULL) + (c3_d)tim_u.tv_nsec;
+}
+
+/* _bench_print(): print elapsed time under a label.
+*/
+static void
+_bench_print(const c3_c* lab_c, c3_d ned_d)
+{
+  fprintf(stderr, "  %-18s %8.2f ms\r\n", lab_c, (double)ned_d / 1e6);
 }
 
 /* _ames_writ_ex(): |hi packet from fake ~zod to fake ~nec
@@ -44,14 +64,14 @@ _ames_writ_ex(void)
 static void
 _jam_bench(void)
 {
-  struct timeval b4, f2, d0;
-  c3_w  mil_w, i_w, max_w = 10000;
+  c3_d  ber_d;
+  c3_w  i_w, max_w = 10000;
   u3_noun wit = _ames_writ_ex();
 
   fprintf(stderr, "\r\njam microbenchmark:\r\n");
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       u3i_slab sab_u;
@@ -62,14 +82,11 @@ _jam_bench(void)
       }
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  jam og: %u ms\r\n", mil_w);
+    _bench_print("jam og:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       c3_d  len_d;
@@ -81,10 +98,7 @@ _jam_bench(void)
       }
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  jam xeno: %u ms\r\n", mil_w);
+    _bench_print("jam xeno:", _bench_ns() - ber_d);
   }
 
   while ( 1 ) {
@@ -102,21 +116,18 @@ _jam_bench(void)
     c3_free(byt_y);
 
     {
-      gettimeofday(&b4, 0);
+      ber_d = _bench_ns();
 
       for ( i_w = 0; i_w < max_w; i_w++ ) {
         ur_jam(rot_u, ref, &len_d, &byt_y);
         c3_free(byt_y);
       }
 
-      gettimeofday(&f2, 0);
-      timersub(&f2, &b4, &d0);
-      mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-      fprintf(stderr, "  jam cons: %u ms\r\n", mil_w);
+      _bench_print("jam cons:", _bench_ns() - ber_d);
     }
 
     {
-      gettimeofday(&b4, 0);
+      ber_d = _bench_ns();
 
       {
         ur_jam_t *jam_u = ur_jam_init(rot_u);
@@ -131,10 +142,7 @@ _jam_bench(void)
         ur_jam_done(jam_u);
       }
 
-      gettimeofday(&f2, 0);
-      timersub(&f2, &b4, &d0);
-      mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-      fprintf(stderr, "  jam cons with: %u ms\r\n", mil_w);
+      _bench_print("jam cons with:", _bench_ns() - ber_d);
     }
 
     ur_root_free(rot_u);
@@ -147,40 +155,34 @@ _jam_bench(void)
 static void
 _cue_bench(void)
 {
-  struct timeval b4, f2, d0;
-  c3_w  mil_w, i_w, max_w = 20000;
+  c3_d  ber_d;
+  c3_w  i_w, max_w = 20000;
   u3_atom vat = u3ke_jam(_ames_writ_ex());
 
   fprintf(stderr, "\r\ncue microbenchmark:\r\n");
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     for ( i_w = 0; i_w < max_w; i_w++ ) {
       u3z(u3s_cue(vat));
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue og: %u ms\r\n", mil_w);
+    _bench_print("cue og:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     for ( i_w = 0; i_w < max_w; i_w++ ) {
       u3z(u3s_cue_atom(vat));
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue atom: %u ms\r\n", mil_w);
+    _bench_print("cue atom:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       c3_w  len_w = u3r_met(3, vat);
@@ -195,14 +197,11 @@ _cue_bench(void)
       }
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue xeno: %u ms\r\n", mil_w);
+    _bench_print("cue xeno:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       u3_cue_xeno* sil_u = u3s_cue_xeno_init();
@@ -221,14 +220,11 @@ _cue_bench(void)
       u3s_cue_xeno_done(sil_u);
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue xeno with: %u ms\r\n", mil_w);
+    _bench_print("cue xeno with:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       c3_w  len_w = u3r_met(3, vat);
@@ -243,14 +239,11 @@ _cue_bench(void)
       }
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue test: %u ms\r\n", mil_w);
+    _bench_print("cue test:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       ur_cue_test_t *t = ur_cue_test_init();
@@ -269,14 +262,11 @@ _cue_bench(void)
       ur_cue_test_done(t);
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue test with: %u ms\r\n", mil_w);
+    _bench_print("cue test with:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       ur_root_t* rot_u = ur_root_init();
@@ -295,14 +285,11 @@ _cue_bench(void)
       ur_root_free(rot_u);
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue cons: %u ms\r\n", mil_w);
+    _bench_print("cue cons:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     {
       ur_root_t* rot_u;
@@ -321,10 +308,7 @@ _cue_bench(void)
       }
     }
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue re-cons: %u ms\r\n", mil_w);
+    _bench_print("cue re-cons:", _bench_ns() - ber_d);
   }
 
   u3z(vat);
@@ -357,32 +341,25 @@ _cue_atom_loop(u3_atom a)
 static void
 _cue_soft_bench(void)
 {
-  struct timeval b4, f2, d0;
+  c3_d ber_d;
   u3_atom vat = u3ke_jam(_ames_writ_ex());
-  c3_w  mil_w;
 
   fprintf(stderr, "\r\ncue virtual microbenchmark:\r\n");
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     u3z(u3m_soft(0, _cue_loop, u3k(vat)));
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue virtual og: %u ms\r\n", mil_w);
+    _bench_print("cue virtual og:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     u3z(u3m_soft(0, _cue_atom_loop, u3k(vat)));
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  cue virtual atom: %u ms\r\n", mil_w);
+    _bench_print("cue virtual atom:", _bench_ns() - ber_d);
   }
 
   u3z(vat);
@@ -417,31 +394,24 @@ _edit_bench_impl(c3_w max_w)
 static void
 _edit_bench(void)
 {
-  struct timeval b4, f2, d0;
-  c3_w mil_w;
+  c3_d ber_d;
 
   fprintf(stderr, "\r\nopcode 10 microbenchmark:\r\n");
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     _edit_bench_impl(1000);
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  opcode 10 1k list: %u ms\r\n", mil_w);
+    _bench_print("opcode 10 1k list:", _bench_ns() - ber_d);
   }
 
   {
-    gettimeofday(&b4, 0);
+    ber_d = _bench_ns();
 
     _edit_bench_impl(10000);
 
-    gettimeofday(&f2, 0);
-    timersub(&f2, &b4, &d0);
-    mil_w = (d0.tv_sec * 1000) + (d0.tv_usec / 1000);
-    fprintf(stderr, "  opcode 10 10k list: %u ms\r\n", mil_w);
+    _bench_print("opcode 10 10k list:", _bench_ns() - ber_d);
   }
 }
 

--- a/pkg/vere/benchmarks.c
+++ b/pkg/vere/benchmarks.c
@@ -511,13 +511,11 @@ _alloc_row(const c3_c* lab_c,
 {
   c3_d bum_d, pal_d, hom_d = 0;
 
-  u3C.wag_w &= ~u3o_no_sand;
+  u3C.wag_w |= u3o_sand;
   bum_d = _alloc_run(fun_f, u3k(arg), rep_w);
 
-  u3C.wag_w |= u3o_no_sand;
+  u3C.wag_w &= ~u3o_sand;
   pal_d = _alloc_run(fun_f, u3k(arg), rep_w);
-
-  u3C.wag_w &= ~u3o_no_sand;
 
   if ( c3y == hom_o ) {
     hom_d = _alloc_run_home(fun_f, u3k(arg), rep_w);
@@ -539,8 +537,8 @@ _alloc_row(const c3_c* lab_c,
   fprintf(stderr, "\r\n");
 }
 
-/* _alloc_bench(): compare bump allocation (the inner-road default)
-**                 against the palloc free-list allocator (u3o_no_sand),
+/* _alloc_bench(): compare opt-in bump allocation (u3o_sand) against the
+**                 default palloc free-list allocator on inner roads,
 **                 with home-road timings for reference.
 */
 static void

--- a/pkg/vere/benchmarks.c
+++ b/pkg/vere/benchmarks.c
@@ -12,7 +12,7 @@
 static void
 _setup(void)
 {
-  u3m_boot_lite(1 << 24);
+  u3m_boot_lite(1 << 25);
 }
 
 /* _bench_ns(): monotonic timestamp in nanoseconds.

--- a/pkg/vere/benchmarks.c
+++ b/pkg/vere/benchmarks.c
@@ -365,6 +365,209 @@ _cue_soft_bench(void)
   u3z(vat);
 }
 
+/* _alloc_cons_work(): build and discard lists; arg=[rep len].
+*/
+static u3_noun
+_alloc_cons_work(u3_noun arg)
+{
+  c3_w rep_w = u3h(arg);
+  c3_w len_w = u3t(arg);
+  c3_w i_w;
+
+  for ( i_w = 0; i_w < rep_w; i_w++ ) {
+    u3z(u3qb_reap(len_w, u3_blip));
+  }
+
+  return u3_blip;
+}
+
+/* _alloc_keep_work(): gain and lose an indirect noun; arg=[rep noun].
+*/
+static u3_noun
+_alloc_keep_work(u3_noun arg)
+{
+  c3_w    rep_w = u3h(arg);
+  u3_noun non   = u3t(arg);
+  c3_w    i_w;
+
+  for ( i_w = 0; i_w < rep_w; i_w++ ) {
+    u3z(u3k(non));
+  }
+
+  return u3_blip;
+}
+
+/* _alloc_atom_work(): churn indirect atoms by repeated addition;
+**                     arg=[rep bex].
+*/
+static u3_noun
+_alloc_atom_work(u3_noun arg)
+{
+  c3_w    rep_w = u3h(arg);
+  u3_noun big   = u3qc_bex(u3t(arg));
+  u3_noun pro   = u3k(big);
+  c3_w    i_w;
+
+  for ( i_w = 0; i_w < rep_w; i_w++ ) {
+    pro = u3ka_add(pro, u3k(big));
+  }
+
+  u3z(pro);
+  u3z(big);
+  return u3_blip;
+}
+
+/* _alloc_cue_work(): cue a jammed noun; arg=[rep vat].
+*/
+static u3_noun
+_alloc_cue_work(u3_noun arg)
+{
+  c3_w    rep_w = u3h(arg);
+  u3_atom vat   = u3t(arg);
+  c3_w    i_w;
+
+  for ( i_w = 0; i_w < rep_w; i_w++ ) {
+    u3z(u3s_cue(vat));
+  }
+
+  return u3_blip;
+}
+
+/* _alloc_copy_work(): build a list to be copied off-road; arg=len.
+*/
+static u3_noun
+_alloc_copy_work(u3_noun arg)
+{
+  return u3qb_reap(arg, u3_blip);
+}
+
+/* _alloc_run(): time [rep_w] u3m_soft() invocations of [fun_f].
+*/
+static c3_d
+_alloc_run(u3_funk fun_f, u3_noun arg, c3_w rep_w)
+{
+  c3_d ber_d, end_d;
+  c3_w i_w;
+
+  ber_d = _bench_ns();
+
+  for ( i_w = 0; i_w < rep_w; i_w++ ) {
+    u3_noun pro = u3m_soft(0, fun_f, u3k(arg));
+
+    if ( u3_blip != u3h(pro) ) {
+      fprintf(stderr, "  alloc bench: workload failed\r\n");
+    }
+
+    u3z(pro);
+  }
+
+  end_d = _bench_ns();
+  u3z(arg);
+  return end_d - ber_d;
+}
+
+/* _alloc_run_home(): time [rep_w] direct invocations of [fun_f]
+**                    on the home road.  [fun_f] must not consume
+**                    or return allocations.
+*/
+static c3_d
+_alloc_run_home(u3_funk fun_f, u3_noun arg, c3_w rep_w)
+{
+  c3_d ber_d, end_d;
+  c3_w i_w;
+
+  ber_d = _bench_ns();
+
+  for ( i_w = 0; i_w < rep_w; i_w++ ) {
+    u3z(fun_f(arg));
+  }
+
+  end_d = _bench_ns();
+  u3z(arg);
+  return end_d - ber_d;
+}
+
+/* _alloc_cell(): print a timing and its ratio to the bump baseline.
+*/
+static void
+_alloc_cell(c3_d tim_d, c3_d bas_d)
+{
+  c3_c rat_c[16];
+
+  snprintf(rat_c, sizeof(rat_c), "(%.2fx)",
+           (double)tim_d / (double)bas_d);
+  fprintf(stderr, "  %8.2f ms %-8s", (double)tim_d / 1e6, rat_c);
+}
+
+/* _alloc_row(): run a workload under both inner-road allocators,
+**               and, if [hom_o], on the home road.
+*/
+static void
+_alloc_row(const c3_c* lab_c,
+           u3_funk     fun_f,
+           u3_noun     arg,
+           c3_w        rep_w,
+           c3_o        hom_o)
+{
+  c3_d bum_d, pal_d, hom_d = 0;
+
+  u3C.wag_w &= ~u3o_no_sand;
+  bum_d = _alloc_run(fun_f, u3k(arg), rep_w);
+
+  u3C.wag_w |= u3o_no_sand;
+  pal_d = _alloc_run(fun_f, u3k(arg), rep_w);
+
+  u3C.wag_w &= ~u3o_no_sand;
+
+  if ( c3y == hom_o ) {
+    hom_d = _alloc_run_home(fun_f, u3k(arg), rep_w);
+  }
+
+  u3z(arg);
+
+  fprintf(stderr, "  %-12s %8.2f ms", lab_c, (double)bum_d / 1e6);
+
+  _alloc_cell(pal_d, bum_d);
+
+  if ( c3y == hom_o ) {
+    _alloc_cell(hom_d, bum_d);
+  }
+  else {
+    fprintf(stderr, "  %11s %8s", "-", "");
+  }
+
+  fprintf(stderr, "\r\n");
+}
+
+/* _alloc_bench(): compare bump allocation (the inner-road default)
+**                 against the palloc free-list allocator (u3o_no_sand),
+**                 with home-road timings for reference.
+*/
+static void
+_alloc_bench(void)
+{
+  fprintf(stderr, "\r\nallocator microbenchmark "
+                  "(inner roads, ratios vs. bump):\r\n");
+  fprintf(stderr, "  %-12s %11s  %11s %8s  %11s\r\n",
+                  "", "bump", "palloc", "", "home");
+
+  _alloc_row("cons", _alloc_cons_work, u3nc(50, 10000), 10, c3y);
+
+  _alloc_row("gain/lose", _alloc_keep_work,
+             u3nc(1000000, u3i_string("a relatively unexceptional noun")),
+             10, c3y);
+
+  _alloc_row("atoms", _alloc_atom_work, u3nc(2000, 4096), 20, c3y);
+
+  _alloc_row("cue", _alloc_cue_work,
+             u3nc(2000, u3ke_jam(_ames_writ_ex())),
+             10, c3y);
+
+  //  no home-road run: the workload measures off-road copying
+  //
+  _alloc_row("copy out", _alloc_copy_work, 20000, 100, c3n);
+}
+
 static void
 _edit_bench_impl(c3_w max_w)
 {
@@ -425,6 +628,7 @@ main(int argc, char* argv[])
   _jam_bench();
   _cue_bench();
   _cue_soft_bench();
+  _alloc_bench();
   _edit_bench();
 
   //  GC


### PR DESCRIPTION
This PR implements a bump allocator (`u3a_flag_sand`) and enables it by default on all inner roads (this can be disabled before road entry with `u3o_no_sand`), targeting #1036. Included microbenchmarks show rougly 2x performance increase in cons and refcounting relative to the status quo.

Bump-allocating is not viable for some workloads -- compiling hoon.hoon used roughly 6GB on my machine. Enabling it by default would require explicit opt-out in several scenarios, it's likely safer to make it explicitly opt-in. Either scenario will require "user-space" control via a hint or somesuch.