### PR TITLE
u3: refactors spin-stack for safety and robustness

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -309,11 +309,6 @@ _cm_signal_recover(c3_l sig_l, u3_noun arg)
   tax = u3H->rod_u.bug.tax;
   u3H->rod_u.bug.tax = 0;
 
-  if ( NULL != u3t_Spin ) {
-    u3t_Spin->off_w = u3H->rod_u.off_w;
-    u3t_Spin->fow_w = u3H->rod_u.fow_w;
-  }
-
   if ( &(u3H->rod_u) == u3R ) {
     //  A top-level crash - rather odd.  We should GC.
     //
@@ -323,6 +318,11 @@ _cm_signal_recover(c3_l sig_l, u3_noun arg)
     //  Reset the top road - the problem could be a fat cap.
     //
     _cm_signal_reset();
+
+    if ( NULL != u3t_Spin ) {
+      u3t_Spin->off_w = u3H->rod_u.off_w;
+      u3t_Spin->fow_w = u3H->rod_u.fow_w;
+    }
 
     if ( (c3__meme == sig_l) && (u3a_open(u3R) <= 256) ) {
       // Out of memory at the top level.  Error becomes c3__full,
@@ -996,10 +996,10 @@ u3m_bail(u3_noun how)
   }
 
   // Reset the spin stack pointer
-  if ( NULL != u3t_Spin ) {
-    u3t_Spin->off_w = u3R->off_w;
-    u3t_Spin->fow_w = u3R->fow_w;
-  }
+  // if ( NULL != u3t_Spin ) {
+  //   u3t_Spin->off_w = u3R->off_w;
+  //   u3t_Spin->fow_w = u3R->fow_w;
+  // }
 
   _longjmp(u3R->esc.buf, how);
 }
@@ -1203,6 +1203,12 @@ u3m_fall(void)
   */
   u3R = u3to(u3_road, u3R->par_p);
   u3R->kid_p = 0;
+
+  // restore slow stack pointer
+  if ( NULL != u3t_Spin ) {
+    u3t_Spin->off_w = u3R->off_w;
+    u3t_Spin->fow_w = u3R->fow_w;
+  }
 }
 
 /* u3m_hate(): new, integrated leap mechanism (enter).
@@ -1365,12 +1371,6 @@ u3m_love(u3_noun pro)
   u3m_fall();
 
   if ( _(tim_o) ) _m_renew_now();
-
-  // restore slow stack pointer
-  if ( NULL != u3t_Spin ) {
-    u3t_Spin->off_w = u3R->off_w;
-    u3t_Spin->fow_w = u3R->fow_w;
-  }
 
   //  copy product and caches off our stack
   //

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -995,12 +995,6 @@ u3m_bail(u3_noun how)
     }
   }
 
-  // Reset the spin stack pointer
-  // if ( NULL != u3t_Spin ) {
-  //   u3t_Spin->off_w = u3R->off_w;
-  //   u3t_Spin->fow_w = u3R->fow_w;
-  // }
-
   _longjmp(u3R->esc.buf, how);
 }
 

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -22,10 +22,6 @@
 u3t_spin *u3t_Spin;
 u3t_trace u3t_Trace;
 
-/// %spin stack baseline: off_w right after the root sentinel is pushed.
-/// the root is never popped, so off_w must never fall below this.
-static c3_w _spin_bas_w = 0;
-
 /// %spin stack shared-memory object name, saved for shm_unlink at teardown.
 /// stored because the serf keys the name on getppid(), which is unreliable
 /// at exit (the king may have died and reparented us to init).
@@ -1191,10 +1187,6 @@ u3t_sstack_init()
   u3t_Spin->fow_w = 0;
   u3t_sstack_push(c3__root);
 
-  //  record the post-root baseline; the root sentinel is never popped.
-  //
-  _spin_bas_w = u3t_Spin->off_w;
-
   //  clobber any saved offsets restored from the snapshot
   //
   u3H->rod_u.off_w = u3t_Spin->off_w;
@@ -1325,30 +1317,20 @@ u3t_sstack_pop()
 {
   if ( !u3t_Spin ) return;
 
-  if ( u3t_Spin->fow_w ) {
+  if ( 0 < u3t_Spin->fow_w ) {
     u3t_Spin->fow_w--;
     return;
   }
 
-  //  the base entry is never popped
-  //
-  if ( u3t_Spin->off_w <= _spin_bas_w ) {
-    fprintf(stderr, "spin: pop underflow off=%u bas=%u\r\n",
-                    u3t_Spin->off_w, _spin_bas_w);
-    u3t_Spin->off_w = _spin_bas_w;
-    return;
-  }
-
-  c3_w len_w, hav_w = u3t_Spin->off_w - _spin_bas_w;
+  c3_w len_w;
   memcpy(&len_w, &u3t_Spin->dat_y[u3t_Spin->off_w - sizeof(c3_w)],
                  sizeof(c3_w));
 
-  //  guard against overflow, a corrupted length word, or a corrupted offset
+  //  guard against underflow
   //
-  if ( (len_w > TRACE_PSIZE) || ((len_w + sizeof(c3_w)) > hav_w) ) {
-    fprintf(stderr, "spin: corrupt entry off=%u len=%u bas=%u; resync to root\r\n",
-                    u3t_Spin->off_w, len_w, _spin_bas_w);
-    u3t_Spin->off_w = _spin_bas_w;
+  if ( (len_w + sizeof(c3_w)) > u3t_Spin->off_w ) {
+    fprintf(stderr, "spin: would underflow off=%u siz=%u\r\n",
+                    u3t_Spin->off_w, len_w + (c3_w)sizeof(c3_w));
     return;
   }
 

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -1209,14 +1209,20 @@ u3t_sstack_open()
   //Setup spin stack
   snprintf(_spin_nam_c, sizeof(_spin_nam_c), SLOW_STACK_NAME, getpid());
 #ifndef U3_OS_windows
-  c3_w shm_fd = shm_open(_spin_nam_c, O_CREAT | O_RDWR, 0);
+  //  the king only reads the spin stack (to render "spinning on" status);
+  //  the serf creates and writes it. open and map read-only so a king-side
+  //  bug can never corrupt the serf's view. no O_CREAT: if the serf hasn't
+  //  created the object yet, fail rather than mint a zero-length region
+  //  (which would SIGBUS on read).
+  //
+  c3_w shm_fd = shm_open(_spin_nam_c, O_RDONLY, 0);
   if ( -1 == shm_fd) {
     perror("shm_open failed");
     return NULL;
   }
 
   u3t_spin* stk_u = mmap(NULL, TRACE_PSIZE,
-                         PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+                         PROT_READ, MAP_SHARED, shm_fd, 0);
 
   //  the mapping keeps the object alive; the fd is no longer needed
   //
@@ -1227,13 +1233,13 @@ u3t_sstack_open()
     return NULL;
   }
 #else
-  HANDLE hstk_u = OpenFileMappingA(FILE_MAP_ALL_ACCESS, FALSE, _spin_nam_c);
+  HANDLE hstk_u = OpenFileMappingA(FILE_MAP_READ, FALSE, _spin_nam_c);
   if ( !hstk_u ) {
     u3l_log("OpenFileMapping error");
     return NULL;
   }
-  
-  u3t_spin* stk_u = MapViewOfFile(hstk_u, FILE_MAP_ALL_ACCESS, 0, 0, 0);
+
+  u3t_spin* stk_u = MapViewOfFile(hstk_u, FILE_MAP_READ, 0, 0, 0);
   CloseHandle(hstk_u);
   if ( !stk_u ) {
     u3l_log("MapViewOfFile error in u3t_sstack_open");

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -22,6 +22,10 @@
 u3t_spin *u3t_Spin;
 u3t_trace u3t_Trace;
 
+/// %spin stack baseline: off_w right after the root sentinel is pushed.
+/// the root is never popped, so off_w must never fall below this.
+static c3_w _spin_bas_w = 0;
+
 static c3_o _ct_lop_o;
 
 /// Nock PID.
@@ -1148,9 +1152,10 @@ u3t_sstack_init()
   }
 
   u3t_Spin = mmap(NULL, TRACE_PSIZE, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
-  
+
   if ( MAP_FAILED == u3t_Spin ) {
     perror("mmap failed");
+    u3t_Spin = NULL;
     return;
   }
 #else
@@ -1176,6 +1181,15 @@ u3t_sstack_init()
   u3t_Spin->off_w = 0;
   u3t_Spin->fow_w = 0;
   u3t_sstack_push(c3__root);
+
+  //  record the post-root baseline; the root sentinel is never popped.
+  //
+  _spin_bas_w = u3t_Spin->off_w;
+
+  //  clobber any saved offsets restored from the snapshot
+  //
+  u3H->rod_u.off_w = u3t_Spin->off_w;
+  u3H->rod_u.fow_w = u3t_Spin->fow_w;
 }
 
 /* u3t_sstack_open: initalize a root node on the spin stack 
@@ -1263,19 +1277,34 @@ void
 u3t_sstack_pop()
 {
   if ( !u3t_Spin ) return;
-  if ( 0 < u3t_Spin->fow_w ) {
-    u3t_Spin->fow_w--;
-  } else {
-    c3_w len_w;
-    memcpy(&len_w, &u3t_Spin->dat_y[u3t_Spin->off_w - sizeof(c3_w)], sizeof(c3_w));
 
-    if ( (len_w+sizeof(c3_w)) > u3t_Spin->off_w ) {
-      fprintf(stderr, "spin: would underflow off=%u siz=%u\r\n",
-                      u3t_Spin->off_w, len_w+sizeof(c3_w));
-    }
-    else {
-      u3t_Spin->off_w -= (len_w+sizeof(c3_w));
-    }
+  if ( u3t_Spin->fow_w ) {
+    u3t_Spin->fow_w--;
+    return;
   }
+
+  //  the base entry is never popped
+  //
+  if ( u3t_Spin->off_w <= _spin_bas_w ) {
+    fprintf(stderr, "spin: pop underflow off=%u bas=%u\r\n",
+                    u3t_Spin->off_w, _spin_bas_w);
+    u3t_Spin->off_w = _spin_bas_w;
+    return;
+  }
+
+  c3_w len_w, hav_w = u3t_Spin->off_w - _spin_bas_w;
+  memcpy(&len_w, &u3t_Spin->dat_y[u3t_Spin->off_w - sizeof(c3_w)],
+                 sizeof(c3_w));
+
+  //  guard against overflow, a corrupted length word, or a corrupted offset
+  //
+  if ( (len_w > TRACE_PSIZE) || ((len_w + sizeof(c3_w)) > hav_w) ) {
+    fprintf(stderr, "spin: corrupt entry off=%u len=%u bas=%u; resync to root\r\n",
+                    u3t_Spin->off_w, len_w, _spin_bas_w);
+    u3t_Spin->off_w = _spin_bas_w;
+    return;
+  }
+
+  u3t_Spin->off_w -= (len_w + sizeof(c3_w));
 }
 

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -26,6 +26,11 @@ u3t_trace u3t_Trace;
 /// the root is never popped, so off_w must never fall below this.
 static c3_w _spin_bas_w = 0;
 
+/// %spin stack shared-memory object name, saved for shm_unlink at teardown.
+/// stored because the serf keys the name on getppid(), which is unreliable
+/// at exit (the king may have died and reparented us to init).
+static c3_c _spin_nam_c[256] = {0};
+
 static c3_o _ct_lop_o;
 
 /// Nock PID.
@@ -1137,10 +1142,9 @@ u3t_etch_meme(c3_l mod_l)
 void
 u3t_sstack_init()
 {
-  c3_c shm_name[256];
-  snprintf(shm_name, sizeof(shm_name), SLOW_STACK_NAME, getppid());
+  snprintf(_spin_nam_c, sizeof(_spin_nam_c), SLOW_STACK_NAME, getppid());
 #ifndef U3_OS_windows
-  c3_w shm_fd = shm_open(shm_name, O_CREAT | O_RDWR, 0666);
+  c3_w shm_fd = shm_open(_spin_nam_c, O_CREAT | O_RDWR, 0666);
   if ( -1 == shm_fd) {
     perror("shm_open failed");
     return;
@@ -1148,10 +1152,15 @@ u3t_sstack_init()
 
   if ( -1 == ftruncate(shm_fd, TRACE_PSIZE)) {
     perror("truncate failed");
+    close(shm_fd);
     return;
   }
 
   u3t_Spin = mmap(NULL, TRACE_PSIZE, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+
+  //  the mapping keeps the object alive; the fd is no longer needed
+  //
+  close(shm_fd);
 
   if ( MAP_FAILED == u3t_Spin ) {
     perror("mmap failed");
@@ -1165,7 +1174,7 @@ u3t_sstack_init()
     PAGE_READWRITE,
     0,
     (DWORD)TRACE_PSIZE,
-    shm_name
+    _spin_nam_c
   );
   if ( !hstk_u ) {
     u3l_log("CreateFileMapping error");
@@ -1198,24 +1207,27 @@ u3t_spin*
 u3t_sstack_open()
 {
   //Setup spin stack
-  c3_c shm_name[256];
-  snprintf(shm_name, sizeof(shm_name), SLOW_STACK_NAME, getpid());
+  snprintf(_spin_nam_c, sizeof(_spin_nam_c), SLOW_STACK_NAME, getpid());
 #ifndef U3_OS_windows
-  c3_w shm_fd = shm_open(shm_name, O_CREAT | O_RDWR, 0);
+  c3_w shm_fd = shm_open(_spin_nam_c, O_CREAT | O_RDWR, 0);
   if ( -1 == shm_fd) {
     perror("shm_open failed");
-    return NULL; 
+    return NULL;
   }
 
-  u3t_spin* stk_u = mmap(NULL, TRACE_PSIZE, 
+  u3t_spin* stk_u = mmap(NULL, TRACE_PSIZE,
                          PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
-  
+
+  //  the mapping keeps the object alive; the fd is no longer needed
+  //
+  close(shm_fd);
+
   if ( MAP_FAILED == stk_u ) {
     perror("mmap failed");
-    return NULL; 
+    return NULL;
   }
 #else
-  HANDLE hstk_u = OpenFileMappingA(FILE_MAP_ALL_ACCESS, FALSE, shm_name);
+  HANDLE hstk_u = OpenFileMappingA(FILE_MAP_ALL_ACCESS, FALSE, _spin_nam_c);
   if ( !hstk_u ) {
     u3l_log("OpenFileMapping error");
     return NULL;
@@ -1231,12 +1243,41 @@ u3t_sstack_open()
 
   return stk_u;
 }
-/* u3t_sstack_exit: shutdown the shared memory for thespin stack 
+/* _sstack_unlink: remove the shm name so the region is reclaimed once every
+**                 mapping is gone (ie when both the serf and king are dead).
+**                 best-effort: the peer process may have unlinked it already.
+*/
+static void
+_sstack_unlink(void)
+{
+#ifndef U3_OS_windows
+  if ( _spin_nam_c[0] ) {
+    shm_unlink(_spin_nam_c);
+  }
+#endif
+}
+
+/* u3t_sstack_exit: tear down the spin stack (serf side).
 */
 void
 u3t_sstack_exit()
 {
-  munmap(u3t_Spin, u3a_page);
+  if ( NULL != u3t_Spin ) {
+    munmap(u3t_Spin, TRACE_PSIZE);
+    u3t_Spin = NULL;
+  }
+  _sstack_unlink();
+}
+
+/* u3t_sstack_close: tear down a spin stack mapping (king side).
+*/
+void
+u3t_sstack_close(u3t_spin* stk_u)
+{
+  if ( NULL != stk_u ) {
+    munmap(stk_u, TRACE_PSIZE);
+  }
+  _sstack_unlink();
 }
 
 /* u3t_sstack_push: push a noun on the spin stack.

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -1262,13 +1262,20 @@ u3t_sstack_push(u3_noun nam)
 void
 u3t_sstack_pop()
 {
-  if (  !u3t_Spin ) return;
+  if ( !u3t_Spin ) return;
   if ( 0 < u3t_Spin->fow_w ) {
     u3t_Spin->fow_w--;
   } else {
     c3_w len_w;
     memcpy(&len_w, &u3t_Spin->dat_y[u3t_Spin->off_w - sizeof(c3_w)], sizeof(c3_w));
-    u3t_Spin->off_w -= (len_w+sizeof(c3_w));
+
+    if ( (len_w+sizeof(c3_w)) > u3t_Spin->off_w ) {
+      fprintf(stderr, "spin: would underflow off=%u siz=%u\r\n",
+                      u3t_Spin->off_w, len_w+sizeof(c3_w));
+    }
+    else {
+      u3t_Spin->off_w -= (len_w+sizeof(c3_w));
+    }
   }
 }
 

--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -1183,6 +1183,7 @@ u3t_sstack_init()
   }
 #endif
 
+  u3t_Spin->seq_w = 0;
   u3t_Spin->off_w = 0;
   u3t_Spin->fow_w = 0;
   u3t_sstack_push(c3__root);
@@ -1278,6 +1279,27 @@ u3t_sstack_close(u3t_spin* stk_u)
   _sstack_unlink();
 }
 
+/* the serf is the spin stack's sole writer; the king (urth) maps it read-only
+** and snapshots it from another process. bracket every mutation of the shared
+** off_w/dat_y in a seqlock so the reader can detect a concurrent change: seq_w
+** is odd while a write is in flight, and bumped to the next even value once it
+** lands. single writer, so plain stores suffice -- only the ordering matters.
+** see _http_spin_timer_cb() for the consumer.
+*/
+static inline void
+_sstack_writ_beg(void)
+{
+  __atomic_store_n(&u3t_Spin->seq_w, u3t_Spin->seq_w + 1, __ATOMIC_RELAXED);
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+static inline void
+_sstack_writ_end(void)
+{
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+  __atomic_store_n(&u3t_Spin->seq_w, u3t_Spin->seq_w + 1, __ATOMIC_RELAXED);
+}
+
 /* u3t_sstack_push: push a noun on the spin stack.
 */
 void
@@ -1302,11 +1324,14 @@ u3t_sstack_push(u3_noun nam)
     return;
   }
 
+  _sstack_writ_beg();
   u3r_bytes(0, met_w, (c3_y*)(u3t_Spin->dat_y+u3t_Spin->off_w), nam);
   u3t_Spin->off_w += met_w;
 
   memcpy(&u3t_Spin->dat_y[u3t_Spin->off_w], &met_w, sizeof(c3_w));
   u3t_Spin->off_w += sizeof(c3_w);
+  _sstack_writ_end();
+
   u3z(nam);
 }
 
@@ -1334,6 +1359,8 @@ u3t_sstack_pop()
     return;
   }
 
+  _sstack_writ_beg();
   u3t_Spin->off_w -= (len_w + sizeof(c3_w));
+  _sstack_writ_end();
 }
 

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -34,9 +34,10 @@
    /* u3t_spin: %spin hint stack
     */
     typedef struct {
+      c3_w seq_w;  //  seqlock: odd while the serf is mid-write, else even
       c3_w off_w;
       c3_w fow_w;
-      c3_y dat_y[TRACE_PSIZE - 2*sizeof(c3_w)];
+      c3_y dat_y[TRACE_PSIZE - 3*sizeof(c3_w)];
     } u3t_spin;
 
   /**  Macros.

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -202,10 +202,15 @@
       u3t_spin*
       u3t_sstack_open(void);
 
-    /* u3t_sstack_exit: initalize a root node on the spin stack 
+    /* u3t_sstack_exit: tear down the spin stack (serf side).
      */
       void
       u3t_sstack_exit(void);
+
+    /* u3t_sstack_close: tear down a spin stack mapping (king side).
+     */
+      void
+      u3t_sstack_close(u3t_spin* stk_u);
 
     /* u3t_sstack_push: push a noun on the spin stack.
      */

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -2947,12 +2947,15 @@ _http_spin_timer_cb(uv_timer_t* tim_u)
       }
 
       if ( (c3y == red_o) && (sizeof(c3_w) < off_w) ) {
-        //  worst case each frame contributes its name bytes plus one '/', so
-        //  2*off_w + 1 (with NUL) always fits: size once, no realloc dance.
+        //  output buffer can't exceed stack buffer + "data:" and 2 newlines
         //
-        c3_w  pos_w = off_w;
-        c3_w  out_w = 0;
-        c3_c* buf_c = c3_malloc(2 * off_w + 1);
+        c3_c dat_c[] = "data:";
+        c3_y buf_y[sizeof(stk_u->dat_y) + sizeof(dat_c) - 1 + 2];
+        c3_w pos_w = off_w;
+        c3_w out_w = 0;
+
+        strcpy((c3_c*)buf_y, dat_c);
+        out_w += sizeof(dat_c) - 1;
 
         while ( pos_w > sizeof(c3_w) ) {
           c3_w len_w;
@@ -2961,34 +2964,26 @@ _http_spin_timer_cb(uv_timer_t* tim_u)
 
           //  malformed frame in the snapshot: stop rather than walk OOB
           //
-          if ( len_w > pos_w ) {
-            break;
-          }
+          if ( len_w > pos_w ) break;
           pos_w -= len_w;
 
-          buf_c[out_w++] = '/';
-          memcpy(buf_c + out_w, &loc_y[pos_w], len_w);
+          buf_y[out_w++] = '/';
+          memcpy(buf_y + out_w, &loc_y[pos_w], len_w);
           out_w += len_w;
         }
-        buf_c[out_w] = '\0';
+        buf_y[out_w++] = '\n';
+        buf_y[out_w++] = '\n';
 
         {
-          u3_noun tan = u3i_string(buf_c);
-          u3_noun lin = u3i_list(u3i_string("data:"),
-                                 tan,
-                                 c3_s2('\n', '\n'),
-                                 u3_none);
-          u3_atom txt = u3qc_rap(3, lin);
+          u3_atom txt = u3i_bytes(out_w, buf_y);
           u3_noun dat = u3nt(u3_nul, u3r_met(3, txt), txt);
 
           while ( 0 != siq_u ) {
             _http_continue_respond(siq_u, u3k(dat), c3n);
             siq_u = siq_u->nex_u;
           }
-          u3z(dat); u3z(lin);
+          u3z(dat);
         }
-
-        c3_free(buf_c);
       }
     }
 

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -132,6 +132,7 @@ static void _http_spin_timer_cb(uv_timer_t* tim_u);
 static const c3_i TCP_BACKLOG = 16;
 static const c3_w HEARTBEAT_TIMEOUT = 20 * 1000;
 static const c3_w SPIN_TIMER = 100; // XX make this a command line arguement
+static const c3_w SPIN_READ_TRIES = 16; // seqlock snapshot attempts per tick
 
 /* _http_close_cb(): uv_close_cb that just free's handle
 */
@@ -2906,54 +2907,91 @@ _http_spin_timer_cb(uv_timer_t* tim_u)
   u3_hreq* siq_u = htd_u->fig_u.siq_u;
 
   if ( 0 != siq_u ) {
-    c3_w siz_w      = 1024;
-    c3_c* buf_c     = c3_malloc(siz_w);
     u3t_spin* stk_u = htd_u->stk_u;
-    if ( NULL == stk_u ) return;
-    c3_w pos_w      = stk_u->off_w;
-    c3_w out_w      = 0;
 
-    while (pos_w > 4) {
-      c3_w  len_w;
-      pos_w -=4;
+    if ( NULL != stk_u ) {
+      c3_y loc_y[sizeof(stk_u->dat_y)];  //  private snapshot of the used region
+      c3_w off_w = 0;
+      c3_o red_o = c3n;
+      c3_w try_w, s1_w, s2_w;
 
-      if ( siz_w < out_w + 4 ) {
-         buf_c = c3_realloc(buf_c, siz_w*2);
-         siz_w *= 2;
+      //  seqlock read: the serf writes this shared memory concurrently. copy
+      //  the used region under a consistency check (seq_w unchanged and even
+      //  across the copy) so a push/pop mid-read can't tear or crash us; build
+      //  the response from the private copy only. retry on conflict, but bail
+      //  after a bounded number of attempts (serf churning or wedged) and just
+      //  skip this frame -- the client keeps the previous "spinning on".
+      //
+      for ( try_w = 0; try_w < SPIN_READ_TRIES; try_w++ ) {
+        s1_w = __atomic_load_n(&stk_u->seq_w, __ATOMIC_ACQUIRE);
+
+        if ( s1_w & 1 ) {
+          continue;                            //  serf mid-write
+        }
+
+        off_w = stk_u->off_w;
+
+        if ( off_w > sizeof(stk_u->dat_y) ) {
+          continue;                            //  torn/garbage offset
+        }
+
+        memcpy(loc_y, stk_u->dat_y, off_w);
+
+        __atomic_thread_fence(__ATOMIC_ACQUIRE);
+        s2_w = __atomic_load_n(&stk_u->seq_w, __ATOMIC_RELAXED);
+
+        if ( s1_w == s2_w ) {
+          red_o = c3y;                         //  consistent snapshot
+          break;
+        }
       }
 
-      memcpy(&len_w, &stk_u->dat_y[pos_w], 4);
-      pos_w -= len_w;
+      if ( (c3y == red_o) && (sizeof(c3_w) < off_w) ) {
+        //  worst case each frame contributes its name bytes plus one '/', so
+        //  2*off_w + 1 (with NUL) always fits: size once, no realloc dance.
+        //
+        c3_w  pos_w = off_w;
+        c3_w  out_w = 0;
+        c3_c* buf_c = c3_malloc(2 * off_w + 1);
 
-      if ( siz_w < out_w + 4 ) {
-         buf_c = c3_realloc(buf_c, siz_w*2);
+        while ( pos_w > sizeof(c3_w) ) {
+          c3_w len_w;
+          pos_w -= sizeof(c3_w);
+          memcpy(&len_w, &loc_y[pos_w], sizeof(c3_w));
+
+          //  malformed frame in the snapshot: stop rather than walk OOB
+          //
+          if ( len_w > pos_w ) {
+            break;
+          }
+          pos_w -= len_w;
+
+          buf_c[out_w++] = '/';
+          memcpy(buf_c + out_w, &loc_y[pos_w], len_w);
+          out_w += len_w;
+        }
+        buf_c[out_w] = '\0';
+
+        {
+          u3_noun tan = u3i_string(buf_c);
+          u3_noun lin = u3i_list(u3i_string("data:"),
+                                 tan,
+                                 c3_s2('\n', '\n'),
+                                 u3_none);
+          u3_atom txt = u3qc_rap(3, lin);
+          u3_noun dat = u3nt(u3_nul, u3r_met(3, txt), txt);
+
+          while ( 0 != siq_u ) {
+            _http_continue_respond(siq_u, u3k(dat), c3n);
+            siq_u = siq_u->nex_u;
+          }
+          u3z(dat); u3z(lin);
+        }
+
+        c3_free(buf_c);
       }
-      buf_c[out_w++] = '/';
-
-      if ( siz_w < out_w + len_w ) {
-         buf_c = c3_realloc(buf_c, siz_w*2);
-      }
-
-      memcpy(buf_c + out_w, &stk_u->dat_y[pos_w], len_w);
-      out_w += len_w;
     }
-    buf_c[out_w] = '\0';
 
-    if ( 0 != stk_u->off_w ) {
-      u3_noun tan = u3i_string(buf_c);
-      u3_noun lin = u3i_list(u3i_string("data:"),
-                             tan,
-                             c3_s2('\n', '\n'),
-                             u3_none);
-      u3_atom txt = u3qc_rap(3, lin);
-      u3_noun dat = u3nt(u3_nul, u3r_met(3, txt), txt);
-
-      while ( 0 != siq_u ) {
-        _http_continue_respond(siq_u, u3k(dat), c3n);
-        siq_u = siq_u->nex_u;
-      }
-      u3z(dat); u3z(lin); 
-    }
     uv_timer_start(htd_u->fig_u.sin_u, _http_spin_timer_cb,
                    SPIN_TIMER, 0);
   }

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -3094,9 +3094,8 @@ _http_io_exit(u3_auto* car_u)
   u3h_free(htd_u->sax_p);
   u3h_free(htd_u->nax_p);
 
-  if ( NULL != htd_u->stk_u ) {
-    munmap(htd_u->stk_u, u3a_page);
-  }
+  u3t_sstack_close(htd_u->stk_u);
+  htd_u->stk_u = NULL;
 
   //  dispose of configuration to avoid restarts
   //


### PR DESCRIPTION
This PR refactors the spin-stack writer (mars, bytecode-interpreter) and reader (urth, http driver) for safety and robustness. Overflow/underflow conditions are checked, inconsistencies in stack-restoration on error are removed, and data races between reader and writer are resolved (by adding atomic-guarded write-operation counters and detecting/retrying writes impacting reads). A memory leak in the http server is plugged, and the relevant fixes from #1029 are recapitulated.

A couple things that are not included but may be worth pursuing: the shared memory namespace still uses PIDs and is therefore liable to collision in certain cloud/containerization scenarios (could be resolved with higher-entropy names), and stack-entry lengths  are still 4 bytes (where 2 would suffice).