### PR TITLE
trace: key spin hint with ship name in addition to process id

### DIFF
--- a/pkg/noun/trace.c
+++ b/pkg/noun/trace.c
@@ -1131,10 +1131,17 @@ u3t_etch_meme(c3_l mod_l)
 /* u3t_sstack_init: initalize a root node on the spin stack 
 */
 void
-u3t_sstack_init()
+u3t_sstack_init(c3_d* who_d)
 {
   c3_c shm_name[256];
-  snprintf(shm_name, sizeof(shm_name), SLOW_STACK_NAME, getppid());
+
+  u3_atom who = u3dc("scot", c3__p, u3i_chubs(2, who_d));
+  c3_c*   nam_c = u3r_string(who);
+
+  snprintf(shm_name, sizeof(shm_name), SLOW_STACK_NAME, nam_c, getppid());
+  u3z(who);
+  c3_free(nam_c);
+
 #ifndef U3_OS_windows
   c3_w shm_fd = shm_open(shm_name, O_CREAT | O_RDWR, 0666);
   if ( -1 == shm_fd) {
@@ -1181,11 +1188,17 @@ u3t_sstack_init()
 /* u3t_sstack_open: initalize a root node on the spin stack 
 */
 u3t_spin*
-u3t_sstack_open()
+u3t_sstack_open(c3_d* who_d)
 {
   //Setup spin stack
   c3_c shm_name[256];
-  snprintf(shm_name, sizeof(shm_name), SLOW_STACK_NAME, getpid());
+
+  u3_atom who = u3dc("scot", c3__p, u3i_chubs(2, who_d));
+  c3_c*   nam_c = u3r_string(who);
+
+  snprintf(shm_name, sizeof(shm_name), SLOW_STACK_NAME, nam_c, getpid());
+  u3z(who);
+  c3_free(nam_c);
 #ifndef U3_OS_windows
   c3_w shm_fd = shm_open(shm_name, O_CREAT | O_RDWR, 0);
   if ( -1 == shm_fd) {

--- a/pkg/noun/trace.h
+++ b/pkg/noun/trace.h
@@ -15,7 +15,7 @@
 # include "options.h"
 #endif
 
-#define SLOW_STACK_NAME  "/spin_stack_page_%d"
+#define SLOW_STACK_NAME  "/spin_stack_page_%s_%d"
 #define TRACE_PSIZE (1U << (u3a_page +2))
 
   /** Data structures.
@@ -192,15 +192,15 @@
       u3_noun
       u3t_etch_meme(c3_l mod_l);
 
-    /* u3t_sstack_init: initalize a root node on the spin stack 
+    /* u3t_sstack_init: initalize a root node on the spin stack
      */
       void
-      u3t_sstack_init(void);
+      u3t_sstack_init(c3_d* who_d);
 
     /* u3t_sstack_init: initalize a root node on the spin stack 
      */
       u3t_spin*
-      u3t_sstack_open(void);
+      u3t_sstack_open(c3_d* who_d);
 
     /* u3t_sstack_exit: initalize a root node on the spin stack 
      */

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -2746,7 +2746,7 @@ _http_io_talk(u3_auto* car_u)
   u3_auto_plan(car_u, u3_ovum_init(0, c3__e, wir, cad));
 
   //Setup spin stack
-  htd_u->stk_u = u3t_sstack_open();
+  htd_u->stk_u = u3t_sstack_open(htd_u->car_u.pir_u->who_d);
   
   if ( NULL == htd_u->stk_u ) {
     u3l_log("http.c: failed to open spin stack");

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1485,7 +1485,7 @@ u3_mars_work(u3_mars* mar_u)
   _mars_sign_move();
 
   //  Initalize the spin stack
-  u3t_sstack_init();
+  u3t_sstack_init(mar_u->met_u.who_d);
 
   //  wire up signal controls
   //


### PR DESCRIPTION
Tlon hosting hosts several ships in multiple kubernetes containers inside a single pod. I had the misfortune of learning that /dev/shm is shared between the containers and this fact in conjunction with their deterministic process ids causes these ships to thrash eachothers spin pages with explosive consequences. I have personally verified this using a local kubernetes cluster and the posix shared memory tests at https://github.com/abcdesktopio/podshmtest.

Here I key the shared memory by ship name in addition to the process id, if anybody is running the same ship inside multiple containers at the same time they're gonna have bigger problems than the binary crashing.

The thing I don't understand is how vere-v4.3 is relatively stable even though this bug already exists. It must be the case that the limited offsets caused by the bug I fixed in a38528f were somehow guarding us from segfaults...