### PR TITLE
noun: /lib/twoc two's-complement jets (scalar + Lagoon %int2 arrays)

### DIFF
--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -389,6 +389,7 @@ const c_source_files = [_][]const u8{
     "jets/f/ut_rest.c",
     "jets/g/plot.c",
     "jets/i/lagoon.c",
+    "jets/i/twoc.c",
     "jets/tree.c",
     "jets/137/tree.c",
     "jets/136/tree.c",

--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -391,6 +391,7 @@ const c_source_files = [_][]const u8{
     "jets/f/ut_rest.c",
     "jets/g/plot.c",
     "jets/i/lagoon.c",
+    "jets/i/twoc.c",
     "jets/tree.c",
     "jets/137/tree.c",
     "jets/136/tree.c",

--- a/pkg/noun/jets/135/tree.c
+++ b/pkg/noun/jets/135/tree.c
@@ -944,9 +944,38 @@ static u3j_core _135_non__la_core_d[] =
     {}
   };
 
+static u3j_harm _135_non__twid_add_a[] = {{".2", u3wi_twid_add}, {}};
+static u3j_harm _135_non__twid_sub_a[] = {{".2", u3wi_twid_sub}, {}};
+static u3j_harm _135_non__twid_neg_a[] = {{".2", u3wi_twid_neg}, {}};
+static u3j_harm _135_non__twid_mul_a[] = {{".2", u3wi_twid_mul}, {}};
+static u3j_harm _135_non__twid_div_a[] = {{".2", u3wi_twid_div}, {}};
+static u3j_harm _135_non__twid_rem_a[] = {{".2", u3wi_twid_rem}, {}};
+static u3j_harm _135_non__twid_pow_a[] = {{".2", u3wi_twid_pow}, {}};
+static u3j_harm _135_non__twid_abs_a[] = {{".2", u3wi_twid_abs}, {}};
+static u3j_harm _135_non__twid_gth_a[] = {{".2", u3wi_twid_gth}, {}};
+static u3j_harm _135_non__twid_lth_a[] = {{".2", u3wi_twid_lth}, {}};
+static u3j_harm _135_non__twid_lte_a[] = {{".2", u3wi_twid_lte}, {}};
+static u3j_harm _135_non__twid_gte_a[] = {{".2", u3wi_twid_gte}, {}};
+static u3j_core _135_non__twid_d[] =
+  { { "add", 7, _135_non__twid_add_a, 0, no_hashes },
+    { "sub", 7, _135_non__twid_sub_a, 0, no_hashes },
+    { "neg", 7, _135_non__twid_neg_a, 0, no_hashes },
+    { "mul", 7, _135_non__twid_mul_a, 0, no_hashes },
+    { "div", 7, _135_non__twid_div_a, 0, no_hashes },
+    { "rem", 7, _135_non__twid_rem_a, 0, no_hashes },
+    { "pow", 7, _135_non__twid_pow_a, 0, no_hashes },
+    { "abs", 7, _135_non__twid_abs_a, 0, no_hashes },
+    { "gth", 7, _135_non__twid_gth_a, 0, no_hashes },
+    { "lth", 7, _135_non__twid_lth_a, 0, no_hashes },
+    { "lte", 7, _135_non__twid_lte_a, 0, no_hashes },
+    { "gte", 7, _135_non__twid_gte_a, 0, no_hashes },
+    {}
+  };
+
 static u3j_core _135_non_d[] =
   { { "lagoon", 7, 0, _135_non__la_core_d, no_hashes },
     { "mice", 7, _135_non__mice_a, 0, no_hashes },
+    { "twid", 7, 0, _135_non__twid_d, no_hashes },
     {}
   };
 

--- a/pkg/noun/jets/135/tree.c
+++ b/pkg/noun/jets/135/tree.c
@@ -945,9 +945,38 @@ static u3j_core _135_non__la_core_d[] =
     {}
   };
 
+static u3j_harm _135_non__twid_add_a[] = {{".2", u3wi_twid_add}, {}};
+static u3j_harm _135_non__twid_sub_a[] = {{".2", u3wi_twid_sub}, {}};
+static u3j_harm _135_non__twid_neg_a[] = {{".2", u3wi_twid_neg}, {}};
+static u3j_harm _135_non__twid_mul_a[] = {{".2", u3wi_twid_mul}, {}};
+static u3j_harm _135_non__twid_div_a[] = {{".2", u3wi_twid_div}, {}};
+static u3j_harm _135_non__twid_rem_a[] = {{".2", u3wi_twid_rem}, {}};
+static u3j_harm _135_non__twid_pow_a[] = {{".2", u3wi_twid_pow}, {}};
+static u3j_harm _135_non__twid_abs_a[] = {{".2", u3wi_twid_abs}, {}};
+static u3j_harm _135_non__twid_gth_a[] = {{".2", u3wi_twid_gth}, {}};
+static u3j_harm _135_non__twid_lth_a[] = {{".2", u3wi_twid_lth}, {}};
+static u3j_harm _135_non__twid_lte_a[] = {{".2", u3wi_twid_lte}, {}};
+static u3j_harm _135_non__twid_gte_a[] = {{".2", u3wi_twid_gte}, {}};
+static u3j_core _135_non__twid_d[] =
+  { { "add", 7, _135_non__twid_add_a, 0, no_hashes },
+    { "sub", 7, _135_non__twid_sub_a, 0, no_hashes },
+    { "neg", 7, _135_non__twid_neg_a, 0, no_hashes },
+    { "mul", 7, _135_non__twid_mul_a, 0, no_hashes },
+    { "div", 7, _135_non__twid_div_a, 0, no_hashes },
+    { "rem", 7, _135_non__twid_rem_a, 0, no_hashes },
+    { "pow", 7, _135_non__twid_pow_a, 0, no_hashes },
+    { "abs", 7, _135_non__twid_abs_a, 0, no_hashes },
+    { "gth", 7, _135_non__twid_gth_a, 0, no_hashes },
+    { "lth", 7, _135_non__twid_lth_a, 0, no_hashes },
+    { "lte", 7, _135_non__twid_lte_a, 0, no_hashes },
+    { "gte", 7, _135_non__twid_gte_a, 0, no_hashes },
+    {}
+  };
+
 static u3j_core _135_non_d[] =
   { { "lagoon", 7, 0, _135_non__la_core_d, no_hashes },
     { "mice", 7, _135_non__mice_a, 0, no_hashes },
+    { "twid", 7, 0, _135_non__twid_d, no_hashes },
     {}
   };
 

--- a/pkg/noun/jets/136/tree.c
+++ b/pkg/noun/jets/136/tree.c
@@ -945,9 +945,38 @@ static u3j_core _136_non__la_core_d[] =
     {}
   };
 
+static u3j_harm _136_non__twid_add_a[] = {{".2", u3wi_twid_add}, {}};
+static u3j_harm _136_non__twid_sub_a[] = {{".2", u3wi_twid_sub}, {}};
+static u3j_harm _136_non__twid_neg_a[] = {{".2", u3wi_twid_neg}, {}};
+static u3j_harm _136_non__twid_mul_a[] = {{".2", u3wi_twid_mul}, {}};
+static u3j_harm _136_non__twid_div_a[] = {{".2", u3wi_twid_div}, {}};
+static u3j_harm _136_non__twid_rem_a[] = {{".2", u3wi_twid_rem}, {}};
+static u3j_harm _136_non__twid_pow_a[] = {{".2", u3wi_twid_pow}, {}};
+static u3j_harm _136_non__twid_abs_a[] = {{".2", u3wi_twid_abs}, {}};
+static u3j_harm _136_non__twid_gth_a[] = {{".2", u3wi_twid_gth}, {}};
+static u3j_harm _136_non__twid_lth_a[] = {{".2", u3wi_twid_lth}, {}};
+static u3j_harm _136_non__twid_lte_a[] = {{".2", u3wi_twid_lte}, {}};
+static u3j_harm _136_non__twid_gte_a[] = {{".2", u3wi_twid_gte}, {}};
+static u3j_core _136_non__twid_d[] =
+  { { "add", 7, _136_non__twid_add_a, 0, no_hashes },
+    { "sub", 7, _136_non__twid_sub_a, 0, no_hashes },
+    { "neg", 7, _136_non__twid_neg_a, 0, no_hashes },
+    { "mul", 7, _136_non__twid_mul_a, 0, no_hashes },
+    { "div", 7, _136_non__twid_div_a, 0, no_hashes },
+    { "rem", 7, _136_non__twid_rem_a, 0, no_hashes },
+    { "pow", 7, _136_non__twid_pow_a, 0, no_hashes },
+    { "abs", 7, _136_non__twid_abs_a, 0, no_hashes },
+    { "gth", 7, _136_non__twid_gth_a, 0, no_hashes },
+    { "lth", 7, _136_non__twid_lth_a, 0, no_hashes },
+    { "lte", 7, _136_non__twid_lte_a, 0, no_hashes },
+    { "gte", 7, _136_non__twid_gte_a, 0, no_hashes },
+    {}
+  };
+
 static u3j_core _136_non_d[] =
   { { "lagoon", 7, 0, _136_non__la_core_d, no_hashes },
     { "mice", 7, _136_non__mice_a, 0, no_hashes },
+    { "twid", 7, 0, _136_non__twid_d, no_hashes },
     {}
   };
 

--- a/pkg/noun/jets/137/tree.c
+++ b/pkg/noun/jets/137/tree.c
@@ -871,8 +871,37 @@ static u3j_core _137_non__la_core_d[] =
     {}
   };
 
+static u3j_harm _137_non__twid_add_a[] = {{".2", u3wi_twid_add}, {}};
+static u3j_harm _137_non__twid_sub_a[] = {{".2", u3wi_twid_sub}, {}};
+static u3j_harm _137_non__twid_neg_a[] = {{".2", u3wi_twid_neg}, {}};
+static u3j_harm _137_non__twid_mul_a[] = {{".2", u3wi_twid_mul}, {}};
+static u3j_harm _137_non__twid_div_a[] = {{".2", u3wi_twid_div}, {}};
+static u3j_harm _137_non__twid_rem_a[] = {{".2", u3wi_twid_rem}, {}};
+static u3j_harm _137_non__twid_pow_a[] = {{".2", u3wi_twid_pow}, {}};
+static u3j_harm _137_non__twid_abs_a[] = {{".2", u3wi_twid_abs}, {}};
+static u3j_harm _137_non__twid_gth_a[] = {{".2", u3wi_twid_gth}, {}};
+static u3j_harm _137_non__twid_lth_a[] = {{".2", u3wi_twid_lth}, {}};
+static u3j_harm _137_non__twid_lte_a[] = {{".2", u3wi_twid_lte}, {}};
+static u3j_harm _137_non__twid_gte_a[] = {{".2", u3wi_twid_gte}, {}};
+static u3j_core _137_non__twid_d[] =
+  { { "add", 7, _137_non__twid_add_a, 0, no_hashes },
+    { "sub", 7, _137_non__twid_sub_a, 0, no_hashes },
+    { "neg", 7, _137_non__twid_neg_a, 0, no_hashes },
+    { "mul", 7, _137_non__twid_mul_a, 0, no_hashes },
+    { "div", 7, _137_non__twid_div_a, 0, no_hashes },
+    { "rem", 7, _137_non__twid_rem_a, 0, no_hashes },
+    { "pow", 7, _137_non__twid_pow_a, 0, no_hashes },
+    { "abs", 7, _137_non__twid_abs_a, 0, no_hashes },
+    { "gth", 7, _137_non__twid_gth_a, 0, no_hashes },
+    { "lth", 7, _137_non__twid_lth_a, 0, no_hashes },
+    { "lte", 7, _137_non__twid_lte_a, 0, no_hashes },
+    { "gte", 7, _137_non__twid_gte_a, 0, no_hashes },
+    {}
+  };
+
 static u3j_core _137_non_d[] =
   { { "lagoon", 7, 0, _137_non__la_core_d, no_hashes },
+    { "twid", 7, 0, _137_non__twid_d, no_hashes },
     {}
   };
 

--- a/pkg/noun/jets/i/lagoon.c
+++ b/pkg/noun/jets/i/lagoon.c
@@ -8,6 +8,7 @@
 #include "noun.h"
 #include "softfloat.h"
 #include "softblas.h"
+#include "jets/i/twoc.h"  // shared two's-complement kernels (%int2 array ops)
 
 #include <math.h>  // for pow()
 #include <stdio.h>
@@ -2143,6 +2144,67 @@
     return u3nc(u3nq(u3nt(M_, P_, u3_nul), u3k(bloq), c3__i754, u3_nul), r_data);
   }
 
+/* %int2 element-wise binary op over a ray: native two's-complement per lane
+** (lane width = 2^bloq bits, always a machine width 8..128, so all native --
+** c3_b/s/w/d/__int128).  Mirrors the i754 byte-marshalling (the data atom's
+** leading 0x1 sentinel sits just past the last lane and is preserved).  add/
+** sub/mul are direct typed wraps; div/mod use the shared signed twoc kernels
+** and DECLINE (u3_none -> Hoon, which crashes) on a zero divisor.  Result is
+** the new data atom; the caller re-wraps it with the (unchanged) meta.
+*/
+  typedef enum { _LA_ADD, _LA_SUB, _LA_MUL, _LA_DIV, _LA_REM } _la_iop;
+
+  static u3_noun
+  _la_int2_binop(u3_noun x_data,
+                 u3_noun y_data,
+                 u3_noun shape,
+                 u3_noun bloq,
+                 _la_iop op)
+  {
+    c3_d bl = u3x_atom(bloq);
+    if ( bl < 3 || bl > 7 ) {
+      return u3_none;
+    }
+    c3_d len = _get_length(shape);
+    c3_d lb  = (c3_d)1 << (bl - 3);          // bytes per lane
+    c3_d syz = len * lb;
+    c3_d w   = (c3_d)1 << bl;                // lane width in bits
+
+    c3_y* xb = (c3_y*)u3a_malloc(syz * sizeof(c3_y));
+    c3_y* yb = (c3_y*)u3a_malloc((syz + 1) * sizeof(c3_y));
+    u3r_bytes(0, syz, xb, x_data);
+    u3r_bytes(0, syz + 1, yb, y_data);
+
+#define _LA_EW(TY, MSK, SB, DIVFN, REMFN)                                    \
+  { TY* X = (TY*)xb;  TY* Y = (TY*)yb;                                       \
+    for ( c3_d i = 0; i < len; i++ ) {                                       \
+      switch ( op ) {                                                        \
+        case _LA_ADD: Y[i] = (TY)(X[i] + Y[i]); break;                       \
+        case _LA_SUB: Y[i] = (TY)(X[i] - Y[i]); break;                       \
+        case _LA_MUL: Y[i] = (TY)(X[i] * Y[i]); break;                       \
+        case _LA_DIV:                                                        \
+          if ( 0 == Y[i] ) { u3a_free(xb); u3a_free(yb); return u3_none; }   \
+          Y[i] = (TY)DIVFN(X[i], Y[i], (MSK), (SB)); break;                  \
+        case _LA_REM:                                                        \
+          if ( 0 == Y[i] ) { u3a_free(xb); u3a_free(yb); return u3_none; }   \
+          Y[i] = (TY)REMFN(X[i], Y[i], (MSK), (SB)); break;                  \
+      } } }
+
+    switch ( bl ) {
+      case 3: _LA_EW(c3_b,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 4: _LA_EW(c3_s,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 5: _LA_EW(c3_w,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 6: _LA_EW(c3_d,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 7: _LA_EW(_twoc_u128,  _tn_msk128(w), w - 1, _tn_div128, _tn_rem128); break;
+    }
+#undef _LA_EW
+
+    u3_noun r_data = u3i_bytes((syz + 1) * sizeof(c3_y), yb);
+    u3a_free(xb);
+    u3a_free(yb);
+    return r_data;
+  }
+
   u3_noun
   u3wi_la_add(u3_noun cor)
   {
@@ -2182,6 +2244,12 @@
             u3_noun r_data = u3qi_la_add_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_ADD);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;
@@ -2230,6 +2298,12 @@
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_SUB);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
+
           default:
             return u3_none;
         }
@@ -2276,6 +2350,12 @@
             u3_noun r_data = u3qi_la_mul_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_MUL);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;
@@ -2324,6 +2404,12 @@
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_DIV);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
+
           default:
             return u3_none;
         }
@@ -2370,6 +2456,12 @@
             u3_noun r_data = u3qi_la_mod_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_REM);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;

--- a/pkg/noun/jets/i/lagoon.c
+++ b/pkg/noun/jets/i/lagoon.c
@@ -8,6 +8,7 @@
 #include "noun.h"
 #include "softfloat.h"
 #include "softblas.h"
+#include "jets/i/twoc.h"  // shared two's-complement kernels (%int2 array ops)
 
 #include <math.h>  // for pow()
 #include <stdio.h>
@@ -2304,6 +2305,67 @@
     return u3nc(u3nq(u3nt(M_, P_, u3_nul), u3k(bloq), c3__i754, u3_nul), r_data);
   }
 
+/* %int2 element-wise binary op over a ray: native two's-complement per lane
+** (lane width = 2^bloq bits, always a machine width 8..128, so all native --
+** c3_b/s/w/d/__int128).  Mirrors the i754 byte-marshalling (the data atom's
+** leading 0x1 sentinel sits just past the last lane and is preserved).  add/
+** sub/mul are direct typed wraps; div/mod use the shared signed twoc kernels
+** and DECLINE (u3_none -> Hoon, which crashes) on a zero divisor.  Result is
+** the new data atom; the caller re-wraps it with the (unchanged) meta.
+*/
+  typedef enum { _LA_ADD, _LA_SUB, _LA_MUL, _LA_DIV, _LA_REM } _la_iop;
+
+  static u3_weak
+  _la_int2_binop(u3_noun x_data,
+                 u3_noun y_data,
+                 u3_noun shape,
+                 u3_noun bloq,
+                 _la_iop op)
+  {
+    c3_d bl = u3x_atom(bloq);
+    if ( bl < 3 || bl > 7 ) {
+      return u3_none;
+    }
+    c3_d len = _get_length(shape);
+    c3_d lb  = (c3_d)1 << (bl - 3);          // bytes per lane
+    c3_d syz = len * lb;
+    c3_d w   = (c3_d)1 << bl;                // lane width in bits
+
+    c3_y* xb = (c3_y*)u3a_malloc(syz * sizeof(c3_y));
+    c3_y* yb = (c3_y*)u3a_malloc((syz + 1) * sizeof(c3_y));
+    u3r_bytes(0, syz, xb, x_data);
+    u3r_bytes(0, syz + 1, yb, y_data);
+
+#define _LA_EW(TY, MSK, SB, DIVFN, REMFN)                                    \
+  { TY* X = (TY*)xb;  TY* Y = (TY*)yb;                                       \
+    for ( c3_d i = 0; i < len; i++ ) {                                       \
+      switch ( op ) {                                                        \
+        case _LA_ADD: Y[i] = (TY)(X[i] + Y[i]); break;                       \
+        case _LA_SUB: Y[i] = (TY)(X[i] - Y[i]); break;                       \
+        case _LA_MUL: Y[i] = (TY)(X[i] * Y[i]); break;                       \
+        case _LA_DIV:                                                        \
+          if ( 0 == Y[i] ) { u3a_free(xb); u3a_free(yb); return u3_none; }   \
+          Y[i] = (TY)DIVFN(X[i], Y[i], (MSK), (SB)); break;                  \
+        case _LA_REM:                                                        \
+          if ( 0 == Y[i] ) { u3a_free(xb); u3a_free(yb); return u3_none; }   \
+          Y[i] = (TY)REMFN(X[i], Y[i], (MSK), (SB)); break;                  \
+      } } }
+
+    switch ( bl ) {
+      case 3: _LA_EW(c3_b,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 4: _LA_EW(c3_s,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 5: _LA_EW(c3_w,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 6: _LA_EW(c3_d,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 7: _LA_EW(_twoc_u128,  _tn_msk128(w), w - 1, _tn_div128, _tn_rem128); break;
+    }
+#undef _LA_EW
+
+    u3_noun r_data = u3i_bytes((syz + 1) * sizeof(c3_y), yb);
+    u3a_free(xb);
+    u3a_free(yb);
+    return r_data;
+  }
+
   u3_weak
   u3wi_la_add(u3_noun cor)
   {
@@ -2344,6 +2406,12 @@
             u3_weak r_data = u3qi_la_add_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_weak r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_ADD);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;
@@ -2393,6 +2461,12 @@
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
+          case c3__int2: {
+            u3_weak r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_SUB);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
+
           default:
             return u3_none;
         }
@@ -2440,6 +2514,12 @@
             u3_weak r_data = u3qi_la_mul_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_weak r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_MUL);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;
@@ -2489,6 +2569,12 @@
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
+          case c3__int2: {
+            u3_weak r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_DIV);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
+
           default:
             return u3_none;
         }
@@ -2536,6 +2622,12 @@
             u3_weak r_data = u3qi_la_mod_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_weak r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_REM);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;

--- a/pkg/noun/jets/i/twoc.c
+++ b/pkg/noun/jets/i/twoc.c
@@ -1,0 +1,290 @@
+/// @file
+///
+/// Jets for the numerics `/lib/twoc` library: two's-complement signed integer
+/// arithmetic, MODULAR (operations wrap mod 2^width rather than crashing on
+/// overflow).  Userspace, registered under the `non` chapter alongside `math`,
+/// `lagoon`, and `unum`.  Jet output is bit-identical to the unjetted Hoon.
+///
+/// `/lib/twoc` defines all its logic in ONE width-keyed door `++twid`
+/// (`|_ wid=@`); the bloq-keyed `++twoc` facade just re-exports `twid` gates at
+/// width `(bex bloq)`.  So we register a SINGLE `%twid` core and every caller --
+/// `twid`-direct (`/lib/fixed`) and via the `twoc` facade (`/lib/unum`, Lagoon
+/// `%int2`) -- dispatches here.  We read `wid` from the door sample (gate axis
+/// 7 = door, door axis 6 = `wid`, so wid at gate axis 30; same shape `unum`
+/// uses for `bloq`).
+///
+/// DISPATCH on `wid`:
+///   - wid <= 64   : native c3_d (uint64), masked to wid bits.
+///   - wid <= 128  : native unsigned __int128, masked to wid bits.
+///   - wid  > 128  : GNU MP (mpz), masked to wid bits.
+/// The power-of-two bloq widths (8/16/32/64/128 for bloq 3..7) all land in the
+/// native paths; GMP is the exact backstop for genuinely arbitrary precision.
+///
+/// We DECLINE (return u3_none, so the pure-Hoon arm runs) when:
+///   - any operand does not fit in wid bits (u3r_met(0,x) > wid) -- the Hoon
+///     determines sign from the raw bit-width (xeb), which diverges from naive
+///     masking only off the contract; declining keeps us bit-exact for free.
+///   - a divisor is zero in div/rem -- the Hoon `div`/`rem` crash; let it.
+///
+/// MASTER COPY lives in urbit/numerics libmath/vere/noun/jets/i/twoc.c; applied
+/// by hand to the vere runtime.  GMP is already vendored (ext/gmp) and linked
+/// into pkg/noun.
+
+#include "jets/q.h"
+#include "jets/w.h"
+#include "noun.h"
+#include "jets/i/twoc.h"   // shared native + GMP two's-complement kernels
+
+//  wid from the twid door sample: gate axis 7 = door, door axis 6 = wid.
+#define _TWOC_WID_AXIS 30
+
+//  Read wid (the door sample) from a gate core; c3n if absent/not-atom.
+static inline c3_t
+_twoc_wid(u3_noun cor, c3_d* out)
+{
+  u3_noun w = u3r_at(_TWOC_WID_AXIS, cor);
+  if ( u3_none == w || c3n == u3ud(w) ) {
+    return c3n;
+  }
+  *out = u3r_chub(0, w);
+  return c3y;
+}
+
+//  Does atom [a] fit in [wid] bits?  (Operands wider than wid are out of
+//  contract; the Hoon's xeb-based sign detection would diverge from masking,
+//  so we decline and let the Hoon run.)
+static inline c3_t
+_twoc_fits(u3_atom a, c3_d wid)
+{
+  return ( (c3_d)u3r_met(0, a) <= wid ) ? c3y : c3n;
+}
+
+//  loobean negation (c3y == 0, c3n == 1; C's ! would invert the convention).
+static inline c3_t
+_twoc_not(c3_t b)
+{
+  return ( c3y == b ) ? c3n : c3y;
+}
+
+//  read a wid<=128 operand (one or two chubs) into a __int128.
+static inline _twoc_u128
+_tn_rd128(u3_atom a)
+{
+  return ( ((_twoc_u128)u3r_chub(1, a)) << 64 ) | (_twoc_u128)u3r_chub(0, a);
+}
+
+//  emit a wid<=128 result (two chubs; u3i_chubs strips high zeros).
+static inline u3_noun
+_tn_em128(_twoc_u128 r)
+{
+  c3_d buf[2];
+  buf[0] = (c3_d)r;
+  buf[1] = (c3_d)(r >> 64);
+  return u3i_chubs(2, buf);
+}
+
+/* ----------------------------------------------------------------------------
+** Per-arm cores and wrappers.  Each wrapper extracts the sample, validates
+** atoms, reads wid, applies the fits-guard, and dispatches to the core.
+** -------------------------------------------------------------------------- */
+
+//  binary op: (wid, a, b) -> @.  [g64]/[g128] are native; [gmp] block runs for
+//  wid>128 and must set the result noun [res].
+#define _TWOC_BINOP(nam, e64, e128, GMPBLOCK)                                  \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), ub = u3r_chub(0, b);     \
+      c3_d r = (e64);  return u3i_chubs(1, &r);                                \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a), ub = _tn_rd128(b);  \
+      _twoc_u128 r = (e128);  return _tn_em128(r);                             \
+    }                                                                          \
+    { u3_noun res;  mpz_t am, bm;                                              \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      GMPBLOCK                                                                 \
+      return res;                                                              \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+//  binary comparison: (wid, a, b) -> ?.  [c64]/[c128] native loobeans; GMP
+//  block sets c3_t [v] from signed mpz compare.
+#define _TWOC_CMP(nam, c64, c128, GMPCMP)                                      \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d sb = wid - 1, ua = u3r_chub(0, a), ub = u3r_chub(0, b);             \
+      return (c64);                                                            \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      c3_d sb = wid - 1;  _twoc_u128 ua = _tn_rd128(a), ub = _tn_rd128(b);     \
+      return (c128);                                                           \
+    }                                                                          \
+    { c3_t v;  mpz_t am, bm, as, bs;                                           \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      mpz_init(as);  mpz_init(bs);                                             \
+      _tg_signed(as, am, wid);  _tg_signed(bs, bm, wid);                       \
+      v = (GMPCMP) ? c3y : c3n;                                                \
+      mpz_clear(am); mpz_clear(bm); mpz_clear(as); mpz_clear(bs);              \
+      return v;                                                                \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+//  unary op: (wid, a) -> @.
+#define _TWOC_UNOP(nam, e64, e128, GMPBLOCK)                                   \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a) {                                \
+    if ( c3n == _twoc_fits(a, wid) ) return u3_none;                           \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), sb = wid - 1, ua = u3r_chub(0, a);            \
+      c3_d r = (e64);  (void)sb;  return u3i_chubs(1, &r);                     \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid);  c3_d sb = wid - 1;                    \
+      _twoc_u128 ua = _tn_rd128(a);                                            \
+      _twoc_u128 r = (e128);  (void)sb;  return _tn_em128(r);                  \
+    }                                                                          \
+    { u3_noun res;  mpz_t am;                                                  \
+      u3r_mp(am, a);                                                           \
+      GMPBLOCK                                                                 \
+      return res;                                                              \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a = u3r_at(u3x_sam, cor);  c3_d wid;                               \
+    if ( u3_none == a || c3n == u3ud(a) ) return u3m_bail(c3__exit);           \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a);                                            \
+  }
+
+//  add / sub / mul -- pure modular, GMP via add/sub/mul then mask.
+_TWOC_BINOP(add, _tn_add64(ua, ub, msk), _tn_add128(ua, ub, msk),
+  { mpz_add(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+_TWOC_BINOP(sub, _tn_sub64(ua, ub, msk), _tn_sub128(ua, ub, msk),
+  { mpz_sub(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+_TWOC_BINOP(mul, _tn_mul64(ua, ub, msk), _tn_mul128(ua, ub, msk),
+  { mpz_mul(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+
+/* ++div / ++rem:pp -- signed, truncating toward zero (C-style); the remainder's
+** sign follows the DIVIDEND.  A zero divisor crashes the Hoon (`div`/`rem`),
+** so we DECLINE (u3_none) and let the Hoon bail -- in every path, including
+** native, where `qa / qb` with qb==0 would otherwise SIGFPE the serf.
+*/
+#define _TWOC_DIVREM(nam, e64, e128, GMPDIVR)                                  \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), ub = u3r_chub(0, b);     \
+      if ( 0 == (ub & msk) ) return u3_none;          /* zero divisor */       \
+      c3_d r = (e64);  return u3i_chubs(1, &r);                                \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a), ub = _tn_rd128(b);  \
+      if ( 0 == (ub & msk) ) return u3_none;                                   \
+      _twoc_u128 r = (e128);  return _tn_em128(r);                             \
+    }                                                                          \
+    { mpz_t am, bm, as, bs;                                                    \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      _tg_mask(am, am, wid);  _tg_mask(bm, bm, wid);                           \
+      if ( 0 == mpz_sgn(bm) ) {                       /* zero divisor */       \
+        mpz_clear(am);  mpz_clear(bm);  return u3_none;                        \
+      }                                                                        \
+      mpz_init(as);  mpz_init(bs);                                             \
+      _tg_signed(as, am, wid);  _tg_signed(bs, bm, wid);                       \
+      GMPDIVR                                                                  \
+      _tg_mask(as, as, wid);                                                   \
+      mpz_clear(am);  mpz_clear(bm);  mpz_clear(bs);                           \
+      return u3i_mp(as);                                                       \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+_TWOC_DIVREM(div, _tn_div64(ua, ub, msk, wid - 1), _tn_div128(ua, ub, msk, wid - 1),
+             mpz_tdiv_q(as, as, bs);)
+_TWOC_DIVREM(rem, _tn_rem64(ua, ub, msk, wid - 1), _tn_rem128(ua, ub, msk, wid - 1),
+             mpz_tdiv_r(as, as, bs);)
+
+//  comparisons -- two's-complement order.
+_TWOC_CMP(gth, _tn_gth64(ua, ub, sb), _tn_gth128(ua, ub, sb), mpz_cmp(as, bs) > 0)
+_TWOC_CMP(lth, _tn_gth64(ub, ua, sb), _tn_gth128(ub, ua, sb), mpz_cmp(as, bs) < 0)
+_TWOC_CMP(lte, _twoc_not(_tn_gth64(ua, ub, sb)), _twoc_not(_tn_gth128(ua, ub, sb)),
+          mpz_cmp(as, bs) <= 0)
+_TWOC_CMP(gte, _twoc_not(_tn_gth64(ub, ua, sb)), _twoc_not(_tn_gth128(ub, ua, sb)),
+          mpz_cmp(as, bs) >= 0)
+
+//  neg / abs -- unary.
+_TWOC_UNOP(neg, _tn_neg64(ua, msk), _tn_neg128(ua, msk),
+  { mpz_neg(am, am);  _tg_mask(am, am, wid);  res = u3i_mp(am); })
+_TWOC_UNOP(abs, _tn_abs64(ua, msk, sb), _tn_abs128(ua, msk, sb),
+  { mpz_t m;  mpz_init(m);  _tg_mask(m, am, wid);
+    if ( _tg_sign(m, wid) == c3y ) { mpz_neg(m, m);  _tg_mask(m, m, wid); }
+    mpz_clear(am);  res = u3i_mp(m); })
+
+/* ++pow:pp -- a ^ n, n a NON-NEGATIVE raw integer (read as a plain chub for the
+** native paths; full mpz for GMP).  We decline a >64-bit exponent on the native
+** paths (absurd loop count) and let the Hoon run.
+*/
+  u3_noun
+  u3qi_twid_pow(c3_d wid, u3_atom a, u3_atom n)
+  {
+    if ( c3n == _twoc_fits(a, wid) ) return u3_none;
+    if ( wid <= 128 && (c3_d)u3r_met(0, n) > 64 ) return u3_none;
+    if ( wid <= 64 ) {
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), en = u3r_chub(0, n);
+      c3_d r = _tn_pow64(ua, en, msk);
+      return u3i_chubs(1, &r);
+    }
+    if ( wid <= 128 ) {
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a);
+      c3_d en = u3r_chub(0, n);
+      _twoc_u128 r = _tn_pow128(ua, en, msk);
+      return _tn_em128(r);
+    }
+    { u3_noun res;  mpz_t am, nm, mod;
+      u3r_mp(am, a);  u3r_mp(nm, n);
+      mpz_init(mod);  mpz_ui_pow_ui(mod, 2, wid);
+      _tg_mask(am, am, wid);
+      mpz_powm(am, am, nm, mod);                     /* a^n mod 2^wid */
+      mpz_clear(nm);  mpz_clear(mod);
+      res = u3i_mp(am);
+      return res;
+    }
+  }
+  u3_noun
+  u3wi_twid_pow(u3_noun cor)
+  {
+    u3_noun a, n;  c3_d wid;
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &n, 0) ||
+         c3n == u3ud(a) || c3n == u3ud(n) ) return u3m_bail(c3__exit);
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;
+    return u3qi_twid_pow(wid, a, n);
+  }

--- a/pkg/noun/jets/i/twoc.c
+++ b/pkg/noun/jets/i/twoc.c
@@ -1,0 +1,290 @@
+/// @file
+///
+/// Jets for the numerics `/lib/twoc` library: two's-complement signed integer
+/// arithmetic, MODULAR (operations wrap mod 2^width rather than crashing on
+/// overflow).  Userspace, registered under the `non` chapter alongside `math`,
+/// `lagoon`, and `unum`.  Jet output is bit-identical to the unjetted Hoon.
+///
+/// `/lib/twoc` defines all its logic in ONE width-keyed door `++twid`
+/// (`|_ wid=@`); the bloq-keyed `++twoc` facade just re-exports `twid` gates at
+/// width `(bex bloq)`.  So we register a SINGLE `%twid` core and every caller --
+/// `twid`-direct (`/lib/fixed`) and via the `twoc` facade (`/lib/unum`, Lagoon
+/// `%int2`) -- dispatches here.  We read `wid` from the door sample (gate axis
+/// 7 = door, door axis 6 = `wid`, so wid at gate axis 30; same shape `unum`
+/// uses for `bloq`).
+///
+/// DISPATCH on `wid`:
+///   - wid <= 64   : native c3_d (uint64), masked to wid bits.
+///   - wid <= 128  : native unsigned __int128, masked to wid bits.
+///   - wid  > 128  : GNU MP (mpz), masked to wid bits.
+/// The power-of-two bloq widths (8/16/32/64/128 for bloq 3..7) all land in the
+/// native paths; GMP is the exact backstop for genuinely arbitrary precision.
+///
+/// We DECLINE (return u3_none, so the pure-Hoon arm runs) when:
+///   - any operand does not fit in wid bits (u3r_met(0,x) > wid) -- the Hoon
+///     determines sign from the raw bit-width (xeb), which diverges from naive
+///     masking only off the contract; declining keeps us bit-exact for free.
+///   - a divisor is zero in div/rem -- the Hoon `div`/`rem` crash; let it.
+///
+/// MASTER COPY lives in urbit/numerics libmath/vere/noun/jets/i/twoc.c; applied
+/// by hand to the vere runtime.  GMP is already vendored (ext/gmp) and linked
+/// into pkg/noun.
+
+#include "jets/q.h"
+#include "jets/w.h"
+#include "noun.h"
+#include "jets/i/twoc.h"   // shared native + GMP two's-complement kernels
+
+//  wid from the twid door sample: gate axis 7 = door, door axis 6 = wid.
+#define _TWOC_WID_AXIS 30
+
+//  Read wid (the door sample) from a gate core; c3n if absent/not-atom.
+static inline c3_t
+_twoc_wid(u3_noun cor, c3_d* out)
+{
+  u3_weak w = u3r_at(_TWOC_WID_AXIS, cor);
+  if ( u3_none == w || c3n == u3ud(w) ) {
+    return c3n;
+  }
+  *out = u3r_chub(0, w);
+  return c3y;
+}
+
+//  Does atom [a] fit in [wid] bits?  (Operands wider than wid are out of
+//  contract; the Hoon's xeb-based sign detection would diverge from masking,
+//  so we decline and let the Hoon run.)
+static inline c3_t
+_twoc_fits(u3_atom a, c3_d wid)
+{
+  return ( (c3_d)u3r_met(0, a) <= wid ) ? c3y : c3n;
+}
+
+//  loobean negation (c3y == 0, c3n == 1; C's ! would invert the convention).
+static inline c3_t
+_twoc_not(c3_t b)
+{
+  return ( c3y == b ) ? c3n : c3y;
+}
+
+//  read a wid<=128 operand (one or two chubs) into a __int128.
+static inline _twoc_u128
+_tn_rd128(u3_atom a)
+{
+  return ( ((_twoc_u128)u3r_chub(1, a)) << 64 ) | (_twoc_u128)u3r_chub(0, a);
+}
+
+//  emit a wid<=128 result (two chubs; u3i_chubs strips high zeros).
+static inline u3_noun
+_tn_em128(_twoc_u128 r)
+{
+  c3_d buf[2];
+  buf[0] = (c3_d)r;
+  buf[1] = (c3_d)(r >> 64);
+  return u3i_chubs(2, buf);
+}
+
+/* ----------------------------------------------------------------------------
+** Per-arm cores and wrappers.  Each wrapper extracts the sample, validates
+** atoms, reads wid, applies the fits-guard, and dispatches to the core.
+** -------------------------------------------------------------------------- */
+
+//  binary op: (wid, a, b) -> @.  [g64]/[g128] are native; [gmp] block runs for
+//  wid>128 and must set the result noun [res].
+#define _TWOC_BINOP(nam, e64, e128, GMPBLOCK)                                  \
+  u3_weak u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), ub = u3r_chub(0, b);     \
+      c3_d r = (e64);  return u3i_chubs(1, &r);                                \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a), ub = _tn_rd128(b);  \
+      _twoc_u128 r = (e128);  return _tn_em128(r);                             \
+    }                                                                          \
+    { u3_noun res;  mpz_t am, bm;                                              \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      GMPBLOCK                                                                 \
+      return res;                                                              \
+    }                                                                          \
+  }                                                                            \
+  u3_weak u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+//  binary comparison: (wid, a, b) -> ?.  [c64]/[c128] native loobeans; GMP
+//  block sets c3_t [v] from signed mpz compare.
+#define _TWOC_CMP(nam, c64, c128, GMPCMP)                                      \
+  u3_weak u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d sb = wid - 1, ua = u3r_chub(0, a), ub = u3r_chub(0, b);             \
+      return (c64);                                                            \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      c3_d sb = wid - 1;  _twoc_u128 ua = _tn_rd128(a), ub = _tn_rd128(b);     \
+      return (c128);                                                           \
+    }                                                                          \
+    { c3_t v;  mpz_t am, bm, as, bs;                                           \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      mpz_init(as);  mpz_init(bs);                                             \
+      _tg_signed(as, am, wid);  _tg_signed(bs, bm, wid);                       \
+      v = (GMPCMP) ? c3y : c3n;                                                \
+      mpz_clear(am); mpz_clear(bm); mpz_clear(as); mpz_clear(bs);              \
+      return v;                                                                \
+    }                                                                          \
+  }                                                                            \
+  u3_weak u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+//  unary op: (wid, a) -> @.
+#define _TWOC_UNOP(nam, e64, e128, GMPBLOCK)                                   \
+  u3_weak u3qi_twid_##nam(c3_d wid, u3_atom a) {                                \
+    if ( c3n == _twoc_fits(a, wid) ) return u3_none;                           \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), sb = wid - 1, ua = u3r_chub(0, a);            \
+      c3_d r = (e64);  (void)sb;  return u3i_chubs(1, &r);                     \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid);  c3_d sb = wid - 1;                    \
+      _twoc_u128 ua = _tn_rd128(a);                                            \
+      _twoc_u128 r = (e128);  (void)sb;  return _tn_em128(r);                  \
+    }                                                                          \
+    { u3_noun res;  mpz_t am;                                                  \
+      u3r_mp(am, a);                                                           \
+      GMPBLOCK                                                                 \
+      return res;                                                              \
+    }                                                                          \
+  }                                                                            \
+  u3_weak u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_weak a = u3r_at(u3x_sam, cor);  c3_d wid;                               \
+    if ( u3_none == a || c3n == u3ud(a) ) return u3m_bail(c3__exit);           \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a);                                            \
+  }
+
+//  add / sub / mul -- pure modular, GMP via add/sub/mul then mask.
+_TWOC_BINOP(add, _tn_add64(ua, ub, msk), _tn_add128(ua, ub, msk),
+  { mpz_add(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+_TWOC_BINOP(sub, _tn_sub64(ua, ub, msk), _tn_sub128(ua, ub, msk),
+  { mpz_sub(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+_TWOC_BINOP(mul, _tn_mul64(ua, ub, msk), _tn_mul128(ua, ub, msk),
+  { mpz_mul(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+
+/* ++div / ++rem:pp -- signed, truncating toward zero (C-style); the remainder's
+** sign follows the DIVIDEND.  A zero divisor crashes the Hoon (`div`/`rem`),
+** so we DECLINE (u3_none) and let the Hoon bail -- in every path, including
+** native, where `qa / qb` with qb==0 would otherwise SIGFPE the serf.
+*/
+#define _TWOC_DIVREM(nam, e64, e128, GMPDIVR)                                  \
+  u3_weak u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), ub = u3r_chub(0, b);     \
+      if ( 0 == (ub & msk) ) return u3_none;          /* zero divisor */       \
+      c3_d r = (e64);  return u3i_chubs(1, &r);                                \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a), ub = _tn_rd128(b);  \
+      if ( 0 == (ub & msk) ) return u3_none;                                   \
+      _twoc_u128 r = (e128);  return _tn_em128(r);                             \
+    }                                                                          \
+    { mpz_t am, bm, as, bs;                                                    \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      _tg_mask(am, am, wid);  _tg_mask(bm, bm, wid);                           \
+      if ( 0 == mpz_sgn(bm) ) {                       /* zero divisor */       \
+        mpz_clear(am);  mpz_clear(bm);  return u3_none;                        \
+      }                                                                        \
+      mpz_init(as);  mpz_init(bs);                                             \
+      _tg_signed(as, am, wid);  _tg_signed(bs, bm, wid);                       \
+      GMPDIVR                                                                  \
+      _tg_mask(as, as, wid);                                                   \
+      mpz_clear(am);  mpz_clear(bm);  mpz_clear(bs);                           \
+      return u3i_mp(as);                                                       \
+    }                                                                          \
+  }                                                                            \
+  u3_weak u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &b}) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+_TWOC_DIVREM(div, _tn_div64(ua, ub, msk, wid - 1), _tn_div128(ua, ub, msk, wid - 1),
+             mpz_tdiv_q(as, as, bs);)
+_TWOC_DIVREM(rem, _tn_rem64(ua, ub, msk, wid - 1), _tn_rem128(ua, ub, msk, wid - 1),
+             mpz_tdiv_r(as, as, bs);)
+
+//  comparisons -- two's-complement order.
+_TWOC_CMP(gth, _tn_gth64(ua, ub, sb), _tn_gth128(ua, ub, sb), mpz_cmp(as, bs) > 0)
+_TWOC_CMP(lth, _tn_gth64(ub, ua, sb), _tn_gth128(ub, ua, sb), mpz_cmp(as, bs) < 0)
+_TWOC_CMP(lte, _twoc_not(_tn_gth64(ua, ub, sb)), _twoc_not(_tn_gth128(ua, ub, sb)),
+          mpz_cmp(as, bs) <= 0)
+_TWOC_CMP(gte, _twoc_not(_tn_gth64(ub, ua, sb)), _twoc_not(_tn_gth128(ub, ua, sb)),
+          mpz_cmp(as, bs) >= 0)
+
+//  neg / abs -- unary.
+_TWOC_UNOP(neg, _tn_neg64(ua, msk), _tn_neg128(ua, msk),
+  { mpz_neg(am, am);  _tg_mask(am, am, wid);  res = u3i_mp(am); })
+_TWOC_UNOP(abs, _tn_abs64(ua, msk, sb), _tn_abs128(ua, msk, sb),
+  { mpz_t m;  mpz_init(m);  _tg_mask(m, am, wid);
+    if ( _tg_sign(m, wid) == c3y ) { mpz_neg(m, m);  _tg_mask(m, m, wid); }
+    mpz_clear(am);  res = u3i_mp(m); })
+
+/* ++pow:pp -- a ^ n, n a NON-NEGATIVE raw integer (read as a plain chub for the
+** native paths; full mpz for GMP).  We decline a >64-bit exponent on the native
+** paths (absurd loop count) and let the Hoon run.
+*/
+  u3_weak
+  u3qi_twid_pow(c3_d wid, u3_atom a, u3_atom n)
+  {
+    if ( c3n == _twoc_fits(a, wid) ) return u3_none;
+    if ( wid <= 128 && (c3_d)u3r_met(0, n) > 64 ) return u3_none;
+    if ( wid <= 64 ) {
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), en = u3r_chub(0, n);
+      c3_d r = _tn_pow64(ua, en, msk);
+      return u3i_chubs(1, &r);
+    }
+    if ( wid <= 128 ) {
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a);
+      c3_d en = u3r_chub(0, n);
+      _twoc_u128 r = _tn_pow128(ua, en, msk);
+      return _tn_em128(r);
+    }
+    { u3_noun res;  mpz_t am, nm, mod;
+      u3r_mp(am, a);  u3r_mp(nm, n);
+      mpz_init(mod);  mpz_ui_pow_ui(mod, 2, wid);
+      _tg_mask(am, am, wid);
+      mpz_powm(am, am, nm, mod);                     /* a^n mod 2^wid */
+      mpz_clear(nm);  mpz_clear(mod);
+      res = u3i_mp(am);
+      return res;
+    }
+  }
+  u3_weak
+  u3wi_twid_pow(u3_noun cor)
+  {
+    u3_noun a, n;  c3_d wid;
+    if ( c3n == u3r_mean(cor, {u3x_sam_2, &a}, {u3x_sam_3, &n}) ||
+         c3n == u3ud(a) || c3n == u3ud(n) ) return u3m_bail(c3__exit);
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;
+    return u3qi_twid_pow(wid, a, n);
+  }

--- a/pkg/noun/jets/i/twoc.h
+++ b/pkg/noun/jets/i/twoc.h
@@ -1,0 +1,116 @@
+/// @file
+///
+/// Shared two's-complement integer kernels for the numerics jets.  These are
+/// the bit-exact arithmetic primitives validated standalone (see numerics
+/// libmath/tools/twoc/), used by BOTH the scalar `/lib/twoc` jet (twoc.c) and
+/// the Lagoon `%int2` element-wise array jets (lagoon.c), so there is one
+/// validated source of truth.
+///
+/// Native paths: the op set is generated for uint64 (lanes/values <=64 bits)
+/// and unsigned __int128 (<=128) via a type-templated macro.  [msk] is the
+/// low-width-bit mask, [sb] the sign-bit position (width-1).  All arithmetic is
+/// unsigned with explicit masking, so there is no signed-overflow UB (e.g.
+/// div(min,-1) wraps to min, as in the Hoon).  GMP helpers cover widths >128.
+///
+/// REQUIRES noun.h (c3 types, gmp.h) to be included before this header.
+
+#ifndef _NOUN_JETS_I_TWOC_H
+#define _NOUN_JETS_I_TWOC_H
+
+typedef unsigned __int128 _twoc_u128;
+typedef          __int128 _twoc_s128;
+
+#define _TWOC_NATIVE(SUF, UT)                                                  \
+  static inline UT _tn_neg##SUF(UT a, UT msk) {                                \
+    return (UT)(((~a) + 1) & msk);                                             \
+  }                                                                            \
+  static inline UT _tn_sign##SUF(UT a, c3_d sb) {                              \
+    return (UT)((a >> sb) & 1);                                                \
+  }                                                                            \
+  static inline UT _tn_abs##SUF(UT a, UT msk, c3_d sb) {                       \
+    return _tn_sign##SUF(a, sb) ? _tn_neg##SUF(a, msk) : (UT)(a & msk);        \
+  }                                                                            \
+  static inline UT _tn_add##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)((a + b) & msk);                                                \
+  }                                                                            \
+  static inline UT _tn_sub##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)((a + _tn_neg##SUF(b, msk)) & msk);                             \
+  }                                                                            \
+  static inline UT _tn_mul##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)(((a & msk) * (b & msk)) & msk);                                \
+  }                                                                            \
+  static inline UT _tn_div##SUF(UT a, UT b, UT msk, c3_d sb) {                 \
+    UT qa = _tn_abs##SUF(a, msk, sb), qb = _tn_abs##SUF(b, msk, sb);           \
+    UT q  = (UT)(qa / qb);                                                     \
+    return ( _tn_sign##SUF(a, sb) != _tn_sign##SUF(b, sb) )                    \
+           ? _tn_neg##SUF(q, msk) : (UT)(q & msk);                            \
+  }                                                                            \
+  static inline UT _tn_rem##SUF(UT a, UT b, UT msk, c3_d sb) {                 \
+    UT r = (UT)(_tn_abs##SUF(a, msk, sb) % _tn_abs##SUF(b, msk, sb));          \
+    return _tn_sign##SUF(a, sb) ? _tn_neg##SUF(r, msk) : (UT)(r & msk);        \
+  }                                                                            \
+  static inline UT _tn_pow##SUF(UT a, c3_d n, UT msk) {                        \
+    UT base = (UT)(a & msk), acc = (UT)(1 & msk);                              \
+    while ( n ) {                                                              \
+      if ( n & 1 ) acc = (UT)((acc * base) & msk);                            \
+      base = (UT)((base * base) & msk);                                        \
+      n >>= 1;                                                                 \
+    }                                                                          \
+    return acc;                                                               \
+  }                                                                            \
+  /* two's-complement order: negatives below non-negatives. */                \
+  static inline c3_t _tn_gth##SUF(UT a, UT b, c3_d sb) {                       \
+    UT sa = _tn_sign##SUF(a, sb), sbb = _tn_sign##SUF(b, sb);                  \
+    if ( sa != sbb ) return ( 0 == sa ) ? c3y : c3n;                          \
+    return ( a > b ) ? c3y : c3n;                                             \
+  }
+
+_TWOC_NATIVE(64,  c3_d)
+_TWOC_NATIVE(128, _twoc_u128)
+
+//  low-width-bit masks, guarding the width==type-size shift (UB) case.
+static inline c3_d
+_tn_msk64(c3_d wid)
+{
+  return ( wid >= 64 ) ? (c3_d)~0ull : (((c3_d)1 << wid) - 1);
+}
+static inline _twoc_u128
+_tn_msk128(c3_d wid)
+{
+  return ( wid >= 128 ) ? (~(_twoc_u128)0)
+                        : ((((_twoc_u128)1) << wid) - 1);
+}
+
+/* GMP path (widths >128).  Masking to width bits is a floored mod 2^width
+** (mpz_fdiv_r_2exp), the canonical non-negative two's-complement rep; the
+** signed value (for div/rem/compare) subtracts 2^width when the sign bit is set.
+*/
+//  r <- a mod 2^wid (non-negative).
+static inline void
+_tg_mask(mpz_t r, const mpz_t a, c3_d wid)
+{
+  mpz_fdiv_r_2exp(r, a, wid);
+}
+//  is the wid-1 (sign) bit of a masked value set?
+static inline c3_t
+_tg_sign(const mpz_t m, c3_d wid)
+{
+  return mpz_tstbit(m, wid - 1) ? c3y : c3n;
+}
+//  s <- signed value of masked m (subtract 2^wid if negative).
+static inline void
+_tg_signed(mpz_t s, const mpz_t m, c3_d wid)
+{
+  if ( _tg_sign(m, wid) == c3y ) {
+    mpz_t pow;
+    mpz_init(pow);
+    mpz_ui_pow_ui(pow, 2, wid);
+    mpz_sub(s, m, pow);
+    mpz_clear(pow);
+  }
+  else {
+    mpz_set(s, m);
+  }
+}
+
+#endif /* _NOUN_JETS_I_TWOC_H */

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -290,6 +290,19 @@
     u3_noun u3qi_la_trace_i754(u3_noun, u3_noun, u3_noun);
     u3_noun u3qi_la_mmul_i754(u3_noun, u3_noun, u3_noun, u3_noun, u3_noun);
 
+    u3_noun u3qi_twid_add(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_sub(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_neg(c3_d, u3_atom);
+    u3_noun u3qi_twid_mul(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_div(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_rem(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_pow(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_abs(c3_d, u3_atom);
+    u3_noun u3qi_twid_gth(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_lth(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_lte(c3_d, u3_atom, u3_atom);
+    u3_noun u3qi_twid_gte(c3_d, u3_atom, u3_atom);
+
 #   define u3qfu_van_fan  28
 #   define u3qfu_van_rib  58
 #   define u3qfu_van_vet  59

--- a/pkg/noun/jets/q.h
+++ b/pkg/noun/jets/q.h
@@ -290,6 +290,19 @@
     u3_weak u3qi_la_trace_i754(u3_noun, u3_noun, u3_noun);
     u3_weak u3qi_la_mmul_i754(u3_noun, u3_noun, u3_noun, u3_noun, u3_noun);
 
+    u3_weak u3qi_twid_add(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_sub(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_neg(c3_d, u3_atom);
+    u3_weak u3qi_twid_mul(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_div(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_rem(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_pow(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_abs(c3_d, u3_atom);
+    u3_weak u3qi_twid_gth(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_lth(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_lte(c3_d, u3_atom, u3_atom);
+    u3_weak u3qi_twid_gte(c3_d, u3_atom, u3_atom);
+
 #   define u3qfu_van_fan  28
 #   define u3qfu_van_rib  58
 #   define u3qfu_van_vet  59

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -429,5 +429,18 @@
     u3_noun u3wi_la_trace(u3_noun);
     u3_noun u3wi_la_mmul(u3_noun);
 
+    u3_noun u3wi_twid_add(u3_noun);
+    u3_noun u3wi_twid_sub(u3_noun);
+    u3_noun u3wi_twid_neg(u3_noun);
+    u3_noun u3wi_twid_mul(u3_noun);
+    u3_noun u3wi_twid_div(u3_noun);
+    u3_noun u3wi_twid_rem(u3_noun);
+    u3_noun u3wi_twid_pow(u3_noun);
+    u3_noun u3wi_twid_abs(u3_noun);
+    u3_noun u3wi_twid_gth(u3_noun);
+    u3_noun u3wi_twid_lth(u3_noun);
+    u3_noun u3wi_twid_lte(u3_noun);
+    u3_noun u3wi_twid_gte(u3_noun);
+
 #endif /* ifndef U3_JETS_W_H */
 

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -430,5 +430,18 @@
     u3_weak u3wi_la_trace(u3_noun);
     u3_weak u3wi_la_mmul(u3_noun);
 
+    u3_weak u3wi_twid_add(u3_noun);
+    u3_weak u3wi_twid_sub(u3_noun);
+    u3_weak u3wi_twid_neg(u3_noun);
+    u3_weak u3wi_twid_mul(u3_noun);
+    u3_weak u3wi_twid_div(u3_noun);
+    u3_weak u3wi_twid_rem(u3_noun);
+    u3_weak u3wi_twid_pow(u3_noun);
+    u3_weak u3wi_twid_abs(u3_noun);
+    u3_weak u3wi_twid_gth(u3_noun);
+    u3_weak u3wi_twid_lth(u3_noun);
+    u3_weak u3wi_twid_lte(u3_noun);
+    u3_weak u3wi_twid_gte(u3_noun);
+
 #endif /* ifndef U3_JETS_W_H */
 


### PR DESCRIPTION
Bit-exact C jets for the numerics `/lib/twoc` two's-complement integer library, under the `non` chapter alongside `math`/`lagoon`/`unum`. Hoon side: urbit/numerics#66.

**No vendored library** — the arithmetic is plain integer C plus **GNU MP** (already linked into `pkg/noun`).

## Changes
- `jets/i/twoc.c` — one `%twid` core (the width-keyed door where `/lib/twoc` keeps its logic; the bloq-keyed facade re-exports its gates, so this fires for both call paths). Reads `wid` from the door sample (gate axis 30) and dispatches: native `c3_d` for `wid<=64`, `__int128` for `<=128`, GMP (`u3r_mp`/`u3i_mp`) for `>128`. Arms: `add sub neg mul div rem pow abs gth lth lte gte`. Declines to Hoon on out-of-width operands and zero divisors.
- `jets/i/twoc.h` — shared two's-complement kernels (used by `twoc.c` and `lagoon.c`).
- `jets/i/lagoon.c` — the element-wise array jets (`add/sub/mul/div/mod-rays`) gain a `%int2` case beside `%i754`, looping native two's-complement per lane over the ray byte buffer (one C pass vs the super-linear Hoon bit-packing loop).
- `jets/w.h`, `q.h` — `u3wi_twid_*` / `u3qi_twid_*` declarations.
- `build.zig` — add `jets/i/twoc.c` (no new `linkLibrary`; GMP already linked).
- `jets/{135,136,137}/tree.c` — register `twid` under `non` (sibling of `lagoon`).

## Validation
- Standalone vs an independent reference: 8280 native + 5692 GMP checks pass.
- Fires bit-exact on a hoon-135 fakezod. Scalar proven two ways (a planted sentinel confirmed the C path executes via both `twid`-direct and the `twoc` facade; timing toggle ~3.3×). `%int2` array ops verified jet == Hoon for all five; ~310,000× over interpreted at 200k lanes.

Built and fired on the 32-bit runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)