### PR TITLE
noun: fix Lagoon argmin/argmax jets to return the forward (ravel) index

### DIFF
--- a/pkg/noun/jets/i/lagoon.c
+++ b/pkg/noun/jets/i/lagoon.c
@@ -589,7 +589,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f16_lt(((float16_t*)x_bytes)[i], min_val16)) {
              min_val16 = ((float16_t*)x_bytes)[i];
-             min_idx = (len_x - i - 1);
+             min_idx = i;
            }
         }
         break;}
@@ -599,7 +599,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f32_lt(((float32_t*)x_bytes)[i], min_val32)) {
              min_val32 = ((float32_t*)x_bytes)[i];
-             min_idx = (len_x - i - 1);
+             min_idx = i;
            }
         }
         break;}
@@ -609,7 +609,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f64_lt(((float64_t*)x_bytes)[i], min_val64)) {
              min_val64 = ((float64_t*)x_bytes)[i];
-             min_idx = (len_x - i - 1);
+             min_idx = i;
            }
         }
         break;}
@@ -619,7 +619,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f128M_lt(&(((float128_t*)x_bytes)[i]), &min_val128)) {
              min_val128 = *f128M_min(&min_val128, &((float128_t*)x_bytes)[i]);
-             min_idx = (len_x - i - 1);
+             min_idx = i;
            }
         }
         break;}
@@ -662,7 +662,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f16_gt(((float16_t*)x_bytes)[i], max_val16)) {
              max_val16 = ((float16_t*)x_bytes)[i];
-             max_idx = (len_x - i - 1);
+             max_idx = i;
            }
         }
         break;}
@@ -672,7 +672,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f32_gt(((float32_t*)x_bytes)[i], max_val32)) {
              max_val32 = ((float32_t*)x_bytes)[i];
-             max_idx = (len_x - i - 1);
+             max_idx = i;
            }
         }
         break;}
@@ -682,7 +682,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f64_gt(((float64_t*)x_bytes)[i], max_val64)) {
              max_val64 = ((float64_t*)x_bytes)[i];
-             max_idx = (len_x - i - 1);
+             max_idx = i;
            }
         }
         break;}
@@ -692,7 +692,7 @@
         for (c3_d i = 0; i < len_x; i++) {
            if(f128M_gt(&(((float128_t*)x_bytes)[i]), &max_val128)) {
              max_val128 = *f128M_max(&max_val128, &((float128_t*)x_bytes)[i]);
-             max_idx = (len_x - i - 1);
+             max_idx = i;
            }
         }
         break;}


### PR DESCRIPTION
The Lagoon `argmin`/`argmax` jets compute the result index as `len_x - i - 1` (**reversed**), so the jetted index silently disagrees with the Hoon — which returns the forward ravel index of the *first* extremum — and with the unjetted interpreter, whenever the extremum isn't at index 0.

This was already fixed in the numerics master copy (urbit/numerics#29, `sigilante/fix-argmin-argmax-index`) but never carried into the vere runtime, so `develop` still ships the reversed index (8 occurrences across argmin + argmax).

Fix: use the forward index `i`.

**Verified** on a hoon-135 fakezod — for a 3-vector with its min/max at logical index 2, the jet now returns `2` (was `0`), matching the unjetted Hoon:
```
[jet=2 hoon=2 jet-max=2 hoon-max=2]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)