### PR TITLE
ext/natpmp: switch tarball mirror to Debian (Ubuntu pool 404)

### DIFF
--- a/ext/natpmp/build.zig.zon
+++ b/ext/natpmp/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.0.1",
     .dependencies = .{
         .natpmp = .{
-            .url = "https://mirrors.wikimedia.org/ubuntu/ubuntu/pool/main/libn/libnatpmp/libnatpmp_20230423.orig.tar.gz",
-            // .url = "https://debian.mirror.root.lu/debian/pool/main/libn/libnatpmp/libnatpmp_20230423.orig.tar.gz",
+            // .url = "https://mirrors.wikimedia.org/ubuntu/ubuntu/pool/main/libn/libnatpmp/libnatpmp_20230423.orig.tar.gz",  // 404: Ubuntu pool drops superseded versions
+            .url = "https://debian.mirror.root.lu/debian/pool/main/libn/libnatpmp/libnatpmp_20230423.orig.tar.gz",
             .hash = "N-V-__8AAKudAQA_d3eW8d8dskxBlLzGBg0qe-4u6ohSfCM2",
         },
     },


### PR DESCRIPTION
CI has been failing at the dependency-fetch step on every fresh runner:

```
ext/natpmp/build.zig.zon:7:20: error: bad HTTP response code: '404 Not Found'
```

The `natpmp` dep fetched `libnatpmp_20230423.orig.tar.gz` from an **Ubuntu pool mirror** (`mirrors.wikimedia.org`), and Ubuntu's pool drops source tarballs for superseded versions — that URL now 404s (confirmed; `develop`'s last green runs were June 20–25, before it rotted). This is unrelated to any code change; it breaks `zig build` before compilation.

Fix: point `.url` at the **Debian pool mirror** (`debian.mirror.root.lu`) that was already in the file as a comment. `orig.tar.gz` is byte-identical upstream source, so the package hash is **unchanged** — verified with `zig fetch`, which returns the same `N-V-__8AAKudAQA_d3eW8d8dskxBlLzGBg0qe-4u6ohSfCM2`.

Unblocks all vere PRs once they rebase on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)