### PR TITLE
mesa: cap inbound packet queues

### DIFF
--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -41,6 +41,7 @@ static c3_y are_y[524288];
 #define JUMBO_CACHE_MAX_SIZE 200000000 // 200 mb
 
 #define PEEK_QUEUE_MAX       40
+#define POKE_QUEUE_MAX       30
 
 // logging and debug symbols
 #define MESA_SYM_DESC(SYM) MESA_DESC_ ## SYM
@@ -2445,6 +2446,12 @@ _mesa_hear_poke(u3_mesa_pict* pic_u, sockaddr_in lan_u)
     _mesa_forward_request(sam_u, pic_u, lan_u);
     return;
   }
+
+  if ( POKE_QUEUE_MAX <= sam_u->car_u.dep_w ) {
+    // XX log drop
+    return;
+  }
+
   //  TODO check if lane already in pit, drop dupes
   _mesa_add_lane_to_pit(sam_u, &pac_u->pek_u.nam_u, lan_u);
 

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -40,6 +40,8 @@ static c3_y are_y[524288];
 
 #define JUMBO_CACHE_MAX_SIZE 200000000 // 200 mb
 
+#define PEEK_QUEUE_MAX       40
+
 // logging and debug symbols
 #define MESA_SYM_DESC(SYM) MESA_DESC_ ## SYM
 #define MESA_SYM_FIELD(SYM) MESA_FIELD_ ## SYM
@@ -2390,6 +2392,12 @@ _mesa_hear_peek(u3_mesa_pict* pic_u, sockaddr_in lan_u)
     return;
   }
 
+  u3_pier* pir_u = sam_u->car_u.pir_u;
+
+  if ( PEEK_QUEUE_MAX <= pir_u->pec_u.dep_w ) {
+    // XX log drop
+    return;
+  }
 
   // record interest
   _mesa_add_lane_to_pit(sam_u, &pac_u->pek_u.nam_u, lan_u);
@@ -2399,7 +2407,7 @@ _mesa_hear_peek(u3_mesa_pict* pic_u, sockaddr_in lan_u)
 
   _mesa_put_jumbo_cache(sam_u, &pac_u->pek_u.nam_u, lin_u);
   u3_noun sky = _name_to_jumbo_scry(&pac_u->pek_u.nam_u);
-  u3_noun our = u3i_chubs(2, sam_u->car_u.pir_u->who_d);
+  u3_noun our = u3i_chubs(2, pir_u->who_d);
   u3_noun bem = u3nc(u3nt(our, u3_nul, u3nc(c3__ud, 1)), sky);
 
   arena are_u = arena_create(sizeof(u3_mesa_cb_data) + 1024);
@@ -2410,7 +2418,7 @@ _mesa_hear_peek(u3_mesa_pict* pic_u, sockaddr_in lan_u)
   dat_u->sam_u = sam_u;
   _mesa_copy_name(&dat_u->nam_u, &pac_u->pek_u.nam_u, &han_u->are_u);
 
-  u3_pier_peek(sam_u->car_u.pir_u, u3_nul, u3nq(1, c3__beam, c3__ax, bem), han_u, _mesa_page_scry_jumbo_cb);
+  u3_pier_peek(pir_u, u3_nul, u3nq(1, c3__beam, c3__ax, bem), han_u, _mesa_page_scry_jumbo_cb);
 }
 
 static void

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -20,10 +20,12 @@ _pier_peek_plan(u3_pier* pir_u, u3_pico* pic_u)
   if (!pir_u->pec_u.ent_u) {
     u3_assert( !pir_u->pec_u.ext_u );
     pir_u->pec_u.ent_u = pir_u->pec_u.ext_u = pic_u;
+    pir_u->pec_u.dep_w = 1;
   }
   else {
     pir_u->pec_u.ent_u->nex_u = pic_u;
     pir_u->pec_u.ent_u = pic_u;
+    pir_u->pec_u.dep_w++;
   }
 
   u3_pier_spin(pir_u);
@@ -43,6 +45,8 @@ _pier_peek_next(u3_pier* pir_u)
     }
 
     pic_u->nex_u = 0;
+
+    pir_u->pec_u.dep_w--;
   }
 
   return pic_u;

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -654,6 +654,7 @@
           struct {
             u3_pico*       ent_u;
             u3_pico*       ext_u;
+            c3_w           dep_w;
           } pec_u;
           void*            sop_p;               //  slog stream data
           void           (*sog_f)               //  slog stream callback


### PR DESCRIPTION
Inbound peek packets are capped relative to the outstanding scry requests for the whole pier; inbound pokes are capped relative to the ovum queue of the mesa driver (which also includes page responses to our own outbound requests). Both caps are low to avoid "buffer bloat".