### PR TITLE
test: tighten up CI scripts and improve error detection

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -75,6 +75,8 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # 8GB cache limit chosen at random
+          cache-size-limit: 8192
 
       - name: Build binaries
         run: |

--- a/boot-fake-ship.sh
+++ b/boot-fake-ship.sh
@@ -26,17 +26,40 @@ cleanup() {
 
 trap cleanup EXIT
 port=$(grep loopback ./pier/.http.ports | awk -F ' ' '{print $1}')
+pierpid=$(< ./pier/.vere.lock)
 
+#  fail immediately if the urbit process is no longer running
+#
+check_ship() {
+  if ! kill -0 "$pierpid" 2>/dev/null; then
+    echo "ERROR: urbit process exited unexpectedly" >&2
+    exit 1
+  fi
+}
+
+#  NB: xargs chokes on quotes in the response; tolerate that (|| true),
+#  failing the pipeline only if curl itself fails
+#
 lensd() {
+  check_ship
   curl -s                                                              \
     --data "{\"source\":{\"dojo\":\"$1\"},\"sink\":{\"stdout\":null}}" \
-    "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+    "http://localhost:$port" | { xargs printf %s | sed 's/\\n/\n/g' || true; } || {
+      check_ship
+      echo "ERROR: lens request failed" >&2
+      exit 1
+    }
 }
 
 lensa() {
+  check_ship
   curl -s                                                             \
     --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"app\":\"$1\"}}" \
-    "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+    "http://localhost:$port" | { xargs printf %s | sed 's/\\n/\n/g' || true; } || {
+      check_ship
+      echo "ERROR: lens request failed" >&2
+      exit 1
+    }
 }
 
 check() {
@@ -49,6 +72,12 @@ if check && sleep 10 && check; then
   echo "boot success"
   lensa hood '+hood/exit'
   while [ -f ./pier/.vere.lock ]; do
+    if ! kill -0 "$pierpid" 2>/dev/null; then
+      sleep 1  # grace period: a clean exit removes the lock file
+      [ -f ./pier/.vere.lock ] || break
+      echo "ERROR: urbit process crashed during shutdown" >&2
+      exit 1
+    fi
     echo "waiting for pier to shut down"
     sleep 5
   done

--- a/boot-fake-ship.sh
+++ b/boot-fake-ship.sh
@@ -66,7 +66,7 @@ check() {
   [ 3 -eq $(lensd 3) ]
 }
 
-lensd '+vat %base'
+lensd '+vats %base'
 
 if check && sleep 10 && check; then
   echo "boot success"

--- a/boot-fake-ship.sh
+++ b/boot-fake-ship.sh
@@ -12,19 +12,34 @@ mkdir ./urbit
 tar xfz urbit.tar.gz -C ./urbit --strip-components=1
 cp -RL ./urbit/tests ./urbit/pkg/arvo/tests
 
-$urbit_binary --lite-boot --daemon --fake bus \
-  --bootstrap $brass_pill                     \
-  --arvo ./urbit/pkg/arvo                     \
-  --pier ./pier
+#  stream all runtime output to the log as it accrues
+#
+#  NB: the runtime must not inherit the CI log pipe on stdout: it puts
+#  the (shared) pipe in non-blocking mode, causing spurious write
+#  errors in subsequent commands
+#
+touch urbit-output
+tail -F urbit-output >&2 &
+tailproc=$!
 
 cleanup() {
   if [ -f ./pier/.vere.lock ]; then
     kill $(< ./pier/.vere.lock) || true
   fi
-  set +x
+
+  #  give tail a moment to flush before killing it
+  #
+  sleep 1
+  kill "$tailproc" 2>/dev/null || true
 }
 
 trap cleanup EXIT
+
+$urbit_binary --lite-boot --daemon --fake bus \
+  --bootstrap $brass_pill                     \
+  --arvo ./urbit/pkg/arvo                     \
+  --pier ./pier >> urbit-output 2>&1
+
 port=$(grep loopback ./pier/.http.ports | awk -F ' ' '{print $1}')
 pierpid=$(< ./pier/.vere.lock)
 
@@ -83,7 +98,5 @@ if check && sleep 10 && check; then
   done
 else
   echo "boot failure"
-  kill $(< ./pier/.vere.lock) || true
-  set +x
   exit 1
 fi

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1204,7 +1204,9 @@ u3a_mark_noun(u3_noun som)
       c3_w* dog_w = u3a_to_ptr(som);
       c3_w  new_w = u3a_mark_rptr(dog_w);
 
-      if ( 0 == new_w || 0xffffffff == new_w ) {      //  see u3a_mark_ptr()
+      //  size of 0 means "already marked"; skip children
+      //
+      if ( !new_w ) {
         return siz_w;
       }
       else {

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -697,6 +697,11 @@ u3a_post_info(u3_post);
           c3_w
           u3a_mark_mptr(void* ptr_v);
 
+        /* u3a_mark_rptr(): mark a refcounted, word-aligned ptr for gc.
+        */
+          c3_w
+          u3a_mark_rptr(void* ptr_v);
+
         /* u3a_mark_noun(): mark a noun for gc.  Produce size.
         */
           c3_w

--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -1076,10 +1076,15 @@ static void
 _ch_mark_kev(u3_noun kev, u3h_mass* mas_u)
 {
   u3a_cell* kev_u = u3a_to_ptr(kev);
+  c3_w      kev_w = u3a_mark_rptr(kev_u);
 
-  mas_u->key_w += u3a_mark_noun(kev_u->hed);
-  mas_u->val_w += u3a_mark_noun(kev_u->tel);
-  mas_u->kev_w += u3a_mark_noun(kev);
+  //  size of 0 means "already marked"; skip children
+  //
+  if ( kev_w ) {
+    mas_u->key_w += u3a_mark_noun(kev_u->hed);
+    mas_u->val_w += u3a_mark_noun(kev_u->tel);
+    mas_u->kev_w += kev_w;
+  }
 }
 
 /* _ch_mark_buck(): mark bucket for gc.

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -370,7 +370,7 @@ _main_getopt(c3_i argc, c3_c** argv)
 
         break;
       }
-      case 13: {
+      case 13: {  // gc-abort
         u3_Host.ops_u.gab_abort = c3y;
         u3_Host.ops_u.gab = c3y;
         break;

--- a/test-fake-ship.sh
+++ b/test-fake-ship.sh
@@ -4,9 +4,29 @@ set -xeuo pipefail
 
 urbit_binary=$GITHUB_WORKSPACE/$URBIT_BINARY
 
-if ! $urbit_binary --lite-boot --daemon --gc-abort ./pier 2> urbit-output; then
-  cat urbit-output >&2
-  echo "ERROR: failed to boot fake ship"
+#  stream all runtime output to the log as it accrues
+#
+#  NB: the runtime must not inherit the CI log pipe on stdout: it puts
+#  the (shared) pipe in non-blocking mode, causing spurious write
+#  errors in subsequent commands
+#
+touch urbit-output
+tail -F urbit-output >&2 &
+tailproc=$!
+
+cleanup () {
+  kill $(cat ./pier/.vere.lock) || true
+
+  #  give tail a moment to flush before killing it
+  #
+  sleep 1
+  kill "$tailproc" 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+if ! $urbit_binary --lite-boot --daemon --gc-abort ./pier >> urbit-output 2>&1; then
+  echo "ERROR: failed to boot fake ship" >&2
   exit 1
 fi
 
@@ -17,7 +37,6 @@ pierpid=$(cat ./pier/.vere.lock)
 #
 check_ship() {
   if ! kill -0 "$pierpid" 2>/dev/null; then
-    sleep 2  # let tail -F flush any remaining output
     echo "ERROR: urbit process exited unexpectedly" >&2
     exit 1
   fi
@@ -47,19 +66,6 @@ lensa() {
       exit 1
     }
 }
-
-tail -F urbit-output >&2 &
-
-tailproc=$!
-
-cleanup () {
-  kill $(cat ./pier/.vere.lock) || true
-  kill "$tailproc" 2>/dev/null || true
-
-  set +x
-}
-
-trap cleanup EXIT
 
 #  print the arvo version
 #
@@ -179,7 +185,7 @@ hdr () {
 
 for f in $(find "$OUTDIR" -type f); do
   hdr "$(basename $f)"
-  cat "$f"
+  cat "$f" || true
 done
 
 fail=0

--- a/test-fake-ship.sh
+++ b/test-fake-ship.sh
@@ -1,23 +1,51 @@
 #!/bin/bash
 
-set -x
+set -xeuo pipefail
 
 urbit_binary=$GITHUB_WORKSPACE/$URBIT_BINARY
 
-$urbit_binary --lite-boot --daemon --gc-abort ./pier 2> urbit-output
+if ! $urbit_binary --lite-boot --daemon --gc-abort ./pier 2> urbit-output; then
+  cat urbit-output >&2
+  echo "ERROR: failed to boot fake ship"
+  exit 1
+fi
 
 port=$(grep loopback ./pier/.http.ports | awk -F ' ' '{print $1}')
+pierpid=$(cat ./pier/.vere.lock)
 
+#  fail immediately if the urbit process is no longer running
+#
+check_ship() {
+  if ! kill -0 "$pierpid" 2>/dev/null; then
+    sleep 2  # let tail -F flush any remaining output
+    echo "ERROR: urbit process exited unexpectedly" >&2
+    exit 1
+  fi
+}
+
+#  NB: xargs chokes on quotes in the response; tolerate that (|| true),
+#  failing the pipeline only if curl itself fails
+#
 lensd() {
+  check_ship
   curl -s                                                              \
     --data "{\"source\":{\"dojo\":\"$1\"},\"sink\":{\"stdout\":null}}" \
-    "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+    "http://localhost:$port" | { xargs printf %s | sed 's/\\n/\n/g' || true; } || {
+      check_ship
+      echo "ERROR: lens request failed" >&2
+      exit 1
+    }
 }
 
 lensa() {
+  check_ship
   curl -s                                                             \
     --data "{\"source\":{\"dojo\":\"$2\"},\"sink\":{\"app\":\"$1\"}}" \
-    "http://localhost:$port" | xargs printf %s | sed 's/\\n/\n/g'
+    "http://localhost:$port" | { xargs printf %s | sed 's/\\n/\n/g' || true; } || {
+      check_ship
+      echo "ERROR: lens request failed" >&2
+      exit 1
+    }
 }
 
 tail -F urbit-output >&2 &
@@ -164,9 +192,20 @@ for f in $(find "$OUTDIR" -type f); do
 
     echo "ERROR Test failure in $(basename $f)"
 
-    ((fail++))
+    fail=$((fail+1))
   fi
 done
+
+#  scan the full runtime output for fatal errors, which indicate a crash
+#  even if every test that managed to run reported success
+#
+if egrep "(unexpectedly shut down|serf error:|work exit: status|Assertion ')" urbit-output >/dev/null; then
+  hdr "Runtime Crash"
+
+  echo "ERROR fatal runtime error in urbit-output"
+
+  fail=$((fail+1))
+fi
 
 if [[ $fail -eq 0 ]]; then
   hdr "Success"


### PR DESCRIPTION
- #1014 introduced a bug in |mass, only present under `--gc` or `--gc-abort`. Key/value pairs were marked twice, causing their refcounts to be artificially increased and resulting in their being reported as memory leaks once they were no longer referenced by the hashtable. The fix was to mark them more carefully (see [9d77212](https://github.com/urbit/vere/pull/1056/commits/9d77212e2e72ab1ad6afd6635e2972cdfed5e9fc)).
- the zig-cache was exceeding the default limit of 2 GB; that limit has been explicitly bumped to 8GB and build artificats are again cached
- various vere crash conditions were not being detected as errors, so CI was reporting spurious successes. This happened in #1014 and had been previously noted in #1025

Resolves #1055.