### PR TITLE
jets: refcount fixes caught by a linter

### DIFF
--- a/pkg/noun/jets/e/bytestream.c
+++ b/pkg/noun/jets/e/bytestream.c
@@ -204,7 +204,6 @@ _qe_bytestream_can_octs(u3_noun octs_list) {
     c3_w p_octs_w;
 
     if (c3n == u3r_safe_word(u3h(octs), &p_octs_w)) {
-      u3z(octs_list);
       return u3_none;
     }
     // Check for overflow

--- a/pkg/noun/jets/e/chacha.c
+++ b/pkg/noun/jets/e/chacha.c
@@ -22,7 +22,7 @@
       urcrypt_chacha_crypt(rounds_w, key_y, nonce_y, counter_d, wid_w, dat_y);
       u3_noun cry = u3i_bytes(wid_w, dat_y);
       u3a_free(dat_y);
-      return u3i_cell(wid, cry);
+      return u3i_cell(u3k(wid), cry);
     }
   }
 
@@ -33,10 +33,16 @@
     u3_noun rounds, key, nonce, counter, msg;
     u3_noun wid, dat;
 
-    if ( u3r_quil(sam, &rounds, &key, &nonce, &counter, &msg) ||
-         u3ud(rounds) || u3ud(key) || u3ud(nonce) || u3ud(counter) || u3r_cell(msg, &wid, &dat) )
+    if ( c3n == u3r_quil(sam, &rounds, &key, &nonce, &counter, &msg)
+         || c3n == u3ud(rounds)
+         || c3n == u3ud(key)
+         || c3n == u3ud(nonce)
+         || c3n == u3ud(counter)
+         || c3n == u3r_cell(msg, &wid, &dat)
+         || c3n == u3ud(wid)
+         || c3n == u3ud(dat) )
     {
-      return u3m_bail(c3__exit);
+      return u3m_bail(c3__fail);
     } else {
       return u3l_punt("chacha_crypt", _cqe_chacha_crypt(rounds, key, nonce, counter, wid, dat));
     }

--- a/pkg/noun/jets/e/hmac.c
+++ b/pkg/noun/jets/e/hmac.c
@@ -16,7 +16,8 @@
             u3_atom wid,
             u3_atom dat)
   {
-    u3_assert(_(u3a_is_cat(boq)) && _(u3a_is_cat(wik)) && _(u3a_is_cat(wid)));
+    u3_assert(_(u3a_is_cat(boq)) && _(u3a_is_cat(out)) &&
+              _(u3a_is_cat(wik)) && _(u3a_is_cat(wid)));
 
     // prep the hashing gate
     u3j_site sit_u;
@@ -52,11 +53,11 @@
 
     // append inner padding to message, then hash
     u3_atom innmsg = u3ka_add(u3kc_lsh(3, wid, innkey), dat);
-    u3_atom innhaj = u3j_gate_slam(&sit_u, u3nc((wid + boq), innmsg));
+    u3_atom innhaj = u3j_gate_slam(&sit_u, u3nc(u3i_word(wid + boq), innmsg));
 
     // prepend outer padding to result, hash again
     u3_atom outmsg = u3ka_add(u3kc_lsh(3, out, outkey), innhaj);
-    u3_atom outhaj = u3j_gate_slam(&sit_u, u3nc((out + boq), outmsg));
+    u3_atom outhaj = u3j_gate_slam(&sit_u, u3nc(u3i_word(out + boq), outmsg));
 
     u3j_gate_lose(&sit_u);
     return outhaj;

--- a/pkg/noun/jets/e/loss.c
+++ b/pkg/noun/jets/e/loss.c
@@ -72,7 +72,9 @@
     {
       c3_w i_w;
 
-      loc_u->hev = u3a_malloc(u3kb_lent(u3k(hev)) * sizeof(u3_noun));
+      u3_noun len = u3qb_lent(hev);
+      if ( c3n == u3a_is_cat(len) ) u3m_bail(c3__fail);
+      loc_u->hev = u3a_malloc(len * sizeof(u3_noun));
 
       for ( i_w = 0; u3_nul != hev; i_w++ ) {
         loc_u->hev[i_w] = u3h(hev);

--- a/pkg/noun/jets/e/mat.c
+++ b/pkg/noun/jets/e/mat.c
@@ -26,6 +26,8 @@
       p = u3qa_add(v, b);
       q = u3qc_cat(0, w, z);
 
+      u3z(b);
+      u3z(c);
       u3z(u);
       u3z(v);
       u3z(w);

--- a/pkg/noun/jets/e/rub.c
+++ b/pkg/noun/jets/e/rub.c
@@ -40,12 +40,14 @@
       }
       if ( c3y == u3r_sing(x, a) ) {
         u3z(x);
+        u3z(m);
         return u3nc(1, 0);
       }
       c = u3qa_sub(x, a);
       d = u3qa_inc(x);
 
       u3z(x);
+      u3z(m);
     }
 
     //  Compute e, p, q.
@@ -64,6 +66,7 @@
       p = u3qa_add(w, e);
       q = u3qc_cut(0, z, e, b);
 
+      u3z(c); u3z(d); u3z(e);
       u3z(w); u3z(x); u3z(y); u3z(z);
 
       return u3nc(p, q);

--- a/pkg/noun/jets/e/scow.c
+++ b/pkg/noun/jets/e/scow.c
@@ -208,7 +208,7 @@ _print_p(u3_atom cor, u3_atom p)
 
     list = u3nq(a, b, c, u3nq(d, e, f, list));
 
-    sxz = u3qc_rsh(4, 1, sxz);
+    sxz = u3kc_rsh(4, 1, sxz);
   }
 
   u3z(sxz);

--- a/pkg/noun/jets/e/shax.c
+++ b/pkg/noun/jets/e/shax.c
@@ -135,6 +135,7 @@
            u3_noun b,
            u3_noun c)
   {
+    u3k(c);
     u3_noun l = u3_nul;
 
     if ( !_(u3a_is_cat(b)) ) {
@@ -155,13 +156,15 @@
         m = u3nc(b, e);
         b = 0;
       } else {
-        m = u3nc(256, d);
+        m = u3nc(256, u3k(d));
+        u3z(c);
         c = d;
 
         b -= 256;
       }
       l = u3nc(m, l);
     }
+    u3z(c);
     return u3kb_flop(l);
   }
 

--- a/pkg/noun/jets/e/shax.c
+++ b/pkg/noun/jets/e/shax.c
@@ -135,7 +135,6 @@
            u3_noun b,
            u3_noun c)
   {
-    u3k(c);
     u3_noun l = u3_nul;
 
     if ( !_(u3a_is_cat(b)) ) {
@@ -156,15 +155,13 @@
         m = u3nc(b, e);
         b = 0;
       } else {
-        m = u3nc(256, u3k(d));
-        u3z(c);
+        m = u3nc(256, d);
         c = d;
 
         b -= 256;
       }
       l = u3nc(m, l);
     }
-    u3z(c);
     return u3kb_flop(l);
   }
 

--- a/pkg/noun/jets/e/slaw.c
+++ b/pkg/noun/jets/e/slaw.c
@@ -38,6 +38,7 @@ static u3_noun
 combine(u3_noun p, u3_noun q)
 {
   if ( (c3y == u3a_is_atom(p)) || (c3y == u3a_is_atom(q)) ) {
+    u3z(p), u3z(q);
     return 0;
   }
 
@@ -59,6 +60,15 @@ combine(u3_noun p, u3_noun q)
 #define CONSUME(x)  do {                        \
     if (*cur != x) {                            \
       u3a_free(c);                              \
+      return u3_none;                           \
+    }                                           \
+    cur++;                                      \
+  } while (0)
+
+#define CONSUME_LIST(x)  do {                   \
+    if (*cur != x) {                            \
+      u3a_free(c);                              \
+      u3z(list);                                \
       return u3_none;                           \
     }                                           \
     cur++;                                      \
@@ -121,7 +131,7 @@ _parse_p(u3_noun cor, u3_noun txt) {
     u3_noun m = combine(d_part, combine(c_part, combine(b_part, a_part)));
     u3a_free(c);
 
-    if (_(u3a_is_atom(m))) {
+    if ( 0 == m ) {
       return 0;
     }
 
@@ -155,7 +165,7 @@ _parse_p(u3_noun cor, u3_noun txt) {
                 combine(c_part, combine(b_part, a_part)))));
     u3a_free(c);
 
-    if (_(u3a_is_atom(m))) {
+    if ( 0 == m ) {
       return 0;
     }
 
@@ -191,7 +201,7 @@ _parse_p(u3_noun cor, u3_noun txt) {
                 combine(b_part, a_part)))))));
     u3a_free(c);
 
-    if (_(u3a_is_atom(m))) {
+    if ( 0 == m ) {
       return 0;
     }
 
@@ -268,8 +278,11 @@ _parse_p(u3_noun cor, u3_noun txt) {
     numname = cur[0] - '0';                         \
     cur++;                                          \
     while (isdigit(cur[0])) {                       \
-      numname = u3ka_mul(numname, 10);              \
-      numname = u3ka_add(numname, cur[0] - '0');    \
+      numname *= 10 ;                               \
+      numname += cur[0] - '0';                      \
+      if ( c3n == u3a_is_cat(numname) ) {           \
+        u3m_bail(c3__fail);                         \
+      }                                             \
       cur++;                                        \
     }                                               \
   } while (0)
@@ -284,8 +297,11 @@ _parse_p(u3_noun cor, u3_noun txt) {
     numname = cur[0] - '0';                         \
     cur++;                                          \
     while (isdigit(cur[0])) {                       \
-      numname = u3ka_mul(numname, 10);              \
-      numname = u3ka_add(numname, cur[0] - '0');    \
+      numname *= 10;                                \
+      numname += cur[0] - '0';                      \
+      if ( c3n == u3a_is_cat(numname) ) {           \
+        u3m_bail(c3__fail);                         \
+      }                                             \
       cur++;                                        \
     }                                               \
   } while (0)
@@ -298,6 +314,7 @@ _parse_p(u3_noun cor, u3_noun txt) {
       out = 10 + cur[0] - 'a';                      \
     } else {                                        \
       u3a_free(c);                                  \
+      u3z(list);                                    \
       return u3_none;                               \
     }                                               \
     cur++;                                          \
@@ -408,12 +425,13 @@ _parse_da(u3_noun cor, u3_noun txt) {
       return u3nc(0, res);
     }
 
-    CONSUME('.');
+    CONSUME_LIST('.');
   }
 }
 
 #undef ENSURE_NOT_END
 #undef CONSUME
+#undef CONSUME_LIST
 #undef TRY_GET_SYLLABLE
 #undef PARSE_NONZERO_NUMBER
 #undef PARSE_HEX_DIGIT

--- a/pkg/noun/jets/e/slaw.c
+++ b/pkg/noun/jets/e/slaw.c
@@ -34,9 +34,6 @@ u3_noun get_syllable(c3_c** cur_ptr, c3_c* one, c3_c* two, c3_c* three) {
   }
 }
 
-/* combine(): fold two @ux parts into a comet-half atom.
-** @Refcount: transfers arguments
-*/
 static u3_noun
 combine(u3_noun p, u3_noun q)
 {

--- a/pkg/noun/jets/e/slaw.c
+++ b/pkg/noun/jets/e/slaw.c
@@ -34,6 +34,9 @@ u3_noun get_syllable(c3_c** cur_ptr, c3_c* one, c3_c* two, c3_c* three) {
   }
 }
 
+/* combine(): fold two @ux parts into a comet-half atom.
+** @Refcount: transfers arguments
+*/
 static u3_noun
 combine(u3_noun p, u3_noun q)
 {
@@ -269,7 +272,7 @@ _parse_p(u3_noun cor, u3_noun txt) {
 }
 
 #define PARSE_NONZERO_NUMBER(numname)               \
-  c3_w numname = 0;                                 \
+  u3_noun numname = 0;                                 \
   do {                                              \
     if (cur[0] > '9' || cur[0] < '1') {             \
       u3a_free(c);                                  \
@@ -278,11 +281,8 @@ _parse_p(u3_noun cor, u3_noun txt) {
     numname = cur[0] - '0';                         \
     cur++;                                          \
     while (isdigit(cur[0])) {                       \
-      numname *= 10 ;                               \
-      numname += cur[0] - '0';                      \
-      if ( c3n == u3a_is_cat(numname) ) {           \
-        u3m_bail(c3__fail);                         \
-      }                                             \
+      numname = u3ka_mul(numname, 10);              \
+      numname = u3ka_add(numname, cur[0] - '0');    \
       cur++;                                        \
     }                                               \
   } while (0)
@@ -297,11 +297,8 @@ _parse_p(u3_noun cor, u3_noun txt) {
     numname = cur[0] - '0';                         \
     cur++;                                          \
     while (isdigit(cur[0])) {                       \
-      numname *= 10;                                \
-      numname += cur[0] - '0';                      \
-      if ( c3n == u3a_is_cat(numname) ) {           \
-        u3m_bail(c3__fail);                         \
-      }                                             \
+      numname = u3ka_mul(numname, 10);              \
+      numname = u3ka_add(numname, cur[0] - '0');    \
       cur++;                                        \
     }                                               \
   } while (0)
@@ -315,6 +312,11 @@ _parse_p(u3_noun cor, u3_noun txt) {
     } else {                                        \
       u3a_free(c);                                  \
       u3z(list);                                    \
+      u3z(year);                                    \
+      u3z(day);                                     \
+      u3z(hour);                                    \
+      u3z(minute);                                  \
+      u3z(second);                                  \
       return u3_none;                               \
     }                                               \
     cur++;                                          \
@@ -331,7 +333,9 @@ _parse_da(u3_noun cor, u3_noun txt) {
   // Parse out an arbitrary year number. Starts with a nonzero digit followed
   // by a series of any digits.
   PARSE_NONZERO_NUMBER(year);
-
+  //  Beyond that point we hold refcounted references to more and more nouns,
+  //  so we can't use helper macros
+  //
   // Parse the optional negative sign for BC dates.
   u3_noun bc = c3y;
   if (cur[0] == '-') {
@@ -339,7 +343,13 @@ _parse_da(u3_noun cor, u3_noun txt) {
     cur++;
   }
 
-  CONSUME('.');
+  // CONSUME('.');
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(year);
+    return u3_none;
+  }
+  cur++;
 
   // Parse out a two digit month (mot:ag). Either a single digit 1-9 or 1[012].
   c3_y month;
@@ -358,14 +368,34 @@ _parse_da(u3_noun cor, u3_noun txt) {
     cur++;
   } else {
     u3a_free(c);
+    u3z(year);
     return u3_none;
   }
 
-  CONSUME('.');
+  // CONSUME('.');
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(year);
+    return u3_none;
+  }
+  cur++;
 
   // Parse out a two digit day (dip:ag). This number can be really big, so we
   // can track number of days since September 1993.
-  PARSE_NONZERO_NUMBER(day);
+  // PARSE_NONZERO_NUMBER(day);
+  u3_noun day = 0;
+  if (cur[0] > '9' || cur[0] < '1') {
+    u3a_free(c);
+    u3z(year);
+    return u3_none;
+  }
+  day = cur[0] - '0';
+  cur++;
+  while (isdigit(cur[0])) {
+    day = u3ka_mul(day, 10);
+    day = u3ka_add(day, cur[0] - '0');
+    cur++;
+  }
 
   if (cur[0] == 0) {
     u3a_free(c);
@@ -376,14 +406,94 @@ _parse_da(u3_noun cor, u3_noun txt) {
     return u3nc(0, res);
   }
 
-  CONSUME('.');
-  CONSUME('.');
+  // CONSUME('.');
+  // CONSUME('.');
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(year);
+    u3z(day);
+    return u3_none;
+  }
+  cur++;
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(day);
+    u3z(year);
+    return u3_none;
+  }
+  cur++;
 
-  PARSE_INCLUDING_ZERO_NUMBER(hour);
-  CONSUME('.');
-  PARSE_INCLUDING_ZERO_NUMBER(minute);
-  CONSUME('.');
-  PARSE_INCLUDING_ZERO_NUMBER(second);
+  // PARSE_INCLUDING_ZERO_NUMBER(hour);
+  u3_noun hour = 0;
+  if (cur[0] > '9' || cur[0] < '0') {
+    u3z(year);
+    u3z(day);
+    u3a_free(c);
+    return u3_none;
+  }
+  hour = cur[0] - '0';
+  cur++;
+  while (isdigit(cur[0])) {
+    hour = u3ka_mul(hour, 10);
+    hour = u3ka_add(hour, cur[0] - '0');
+    cur++;
+  }
+
+  // CONSUME('.');
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(year);
+    u3z(day);
+    u3z(hour);
+    return u3_none;
+  }
+  cur++;
+
+  // PARSE_INCLUDING_ZERO_NUMBER(minute);
+  u3_noun minute = 0;
+  if (cur[0] > '9' || cur[0] < '0') {
+    u3z(year);
+    u3z(day);
+    u3z(hour);
+    u3a_free(c);
+    return u3_none;
+  }
+  minute = cur[0] - '0';
+  cur++;
+  while (isdigit(cur[0])) {
+    minute = u3ka_mul(minute, 10);
+    minute = u3ka_add(minute, cur[0] - '0');
+    cur++;
+  }
+
+  // CONSUME('.');
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(year);
+    u3z(day);
+    u3z(hour);
+    u3z(minute);
+    return u3_none;
+  }
+  cur++;
+
+  // PARSE_INCLUDING_ZERO_NUMBER(second);
+  u3_noun second = 0;
+  if (cur[0] > '9' || cur[0] < '0') {
+    u3z(year);
+    u3z(day);
+    u3z(hour);
+    u3z(minute);
+    u3a_free(c);
+    return u3_none;
+  }
+  second = cur[0] - '0';
+  cur++;
+  while (isdigit(cur[0])) {
+    second = u3ka_mul(second, 10);
+    second = u3ka_add(second, cur[0] - '0');
+    cur++;
+  }
 
   if (cur[0] == 0) {
     u3a_free(c);
@@ -394,8 +504,28 @@ _parse_da(u3_noun cor, u3_noun txt) {
     return u3nc(0, res);
   }
 
-  CONSUME('.');
-  CONSUME('.');
+  // CONSUME('.');
+  // CONSUME('.');
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(year);
+    u3z(day);
+    u3z(hour);
+    u3z(minute);
+    u3z(second);
+    return u3_none;
+  }
+  cur++;
+  if (*cur != '.') {
+    u3a_free(c);
+    u3z(year);
+    u3z(day);
+    u3z(hour);
+    u3z(minute);
+    u3z(second);
+    return u3_none;
+  }
+  cur++;
 
   // Now we have to parse a list of hexidecimal numbers 0-f of length 4 only
   // (zero padded otherwise) separated by dots.
@@ -414,8 +544,7 @@ _parse_da(u3_noun cor, u3_noun txt) {
     if (cur[0] == 0) {
       u3a_free(c);
 
-      u3_noun flopped = u3qb_flop(list);
-      u3z(list);
+      u3_noun flopped = u3kb_flop(list);
 
       u3_noun hok = u3j_cook("u3we_slaw_parse_da", u3k(cor), "year");
       u3_noun res = u3n_slam_on(hok,
@@ -425,7 +554,18 @@ _parse_da(u3_noun cor, u3_noun txt) {
       return u3nc(0, res);
     }
 
-    CONSUME_LIST('.');
+    // CONSUME('.');
+    if (*cur != '.') {
+      u3a_free(c);
+      u3z(year);
+      u3z(day);
+      u3z(hour);
+      u3z(minute);
+      u3z(second);
+      u3z(list);
+      return u3_none;
+    }
+    cur++;
   }
 }
 

--- a/pkg/noun/jets/e/slaw.c
+++ b/pkg/noun/jets/e/slaw.c
@@ -68,15 +68,6 @@ combine(u3_noun p, u3_noun q)
     cur++;                                      \
   } while (0)
 
-#define CONSUME_LIST(x)  do {                   \
-    if (*cur != x) {                            \
-      u3a_free(c);                              \
-      u3z(list);                                \
-      return u3_none;                           \
-    }                                           \
-    cur++;                                      \
-  } while (0)
-
 #define TRY_GET_SYLLABLE(prefix)                                        \
   c3_c prefix##_one, prefix##_two, prefix##_three;                      \
   if (c3n == get_syllable(&cur, & prefix##_one, & prefix##_two, & prefix##_three)) { \
@@ -571,7 +562,6 @@ _parse_da(u3_noun cor, u3_noun txt) {
 
 #undef ENSURE_NOT_END
 #undef CONSUME
-#undef CONSUME_LIST
 #undef TRY_GET_SYLLABLE
 #undef PARSE_NONZERO_NUMBER
 #undef PARSE_HEX_DIGIT

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -973,7 +973,6 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
     u3_noun monad_b = u3at(60, monad);
     u3_noun cont = u3at(61, monad);
     u3_weak yil;
-    u3_noun monad_cont;
     { // push on suspend stacks
       m3_SuspendStackPush64(sat_u->wasm_module->runtime, west_try);
       m3_SuspendStackPushExtTag(sat_u->wasm_module->runtime);
@@ -1003,25 +1002,19 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
 
       if (0 == u3h(yil))
       {
-        monad_cont = uw_slam_check(
+        u3_noun monad_cont = uw_slam_check(
           u3k(cont),
           u3k(u3t(yil)),
           sat_u->is_stateful
         );
         u3z(yil);
-        yil = u3_none;
+        u3z(monad);
+        return _reduce_monad(monad_cont, sat_u);
       }
     }
 
     u3z(monad);
-    if (u3_none == yil)
-    {
-      return _reduce_monad(monad_cont, sat_u);
-    }
-    else
-    {
-      return yil;
-    }
+    return yil;
   }
   else if (c3y == u3r_sing(monad_bat, sat_u->match->catch_bat))
   {
@@ -1030,7 +1023,6 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
     u3_noun monad_catch = u3at(121, monad);
     u3_noun cont = u3at(61, monad);
     u3_weak yil;
-    u3_noun monad_cont;
 
     {
       { // push on suspend stacks
@@ -1064,13 +1056,14 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
 
       if (0 == u3h(yil))
       {
-        monad_cont = uw_slam_check(
+        u3_noun monad_cont = uw_slam_check(
           u3k(cont),
           u3k(u3t(yil)),
           sat_u->is_stateful
         );
         u3z(yil);
-        yil = u3_none;
+        u3z(monad);
+        return _reduce_monad(monad_cont, sat_u);
       }
       else if (2 == u3h(yil))
       {
@@ -1108,26 +1101,20 @@ _reduce_monad(u3_noun monad, lia_state* sat_u)
 
         if (0 == u3h(yil))
         {
-          monad_cont = uw_slam_check(
+          u3_noun monad_cont = uw_slam_check(
             u3k(cont),
             u3k(u3t(yil)),
             sat_u->is_stateful
           );
           u3z(yil);
-          yil = u3_none;
+          u3z(monad);
+          return _reduce_monad(monad_cont, sat_u);
         }
       }
     }
 
     u3z(monad);
-    if (u3_none == yil)
-    {
-      return _reduce_monad(monad_cont, sat_u);
-    }
-    else
-    {
-      return yil;
-    }
+    return yil;
   }
   else if (c3y == u3r_sing(monad_bat, sat_u->match->return_bat))
   {
@@ -2151,7 +2138,7 @@ _move_state(
       || (c3__rand == hint && 0 == u3h(yil))
   )
   {
-    u3z_save_m(u3z_memo_keep, uw_run_m, seed_old, u3_nul);
+    u3z(u3z_save_m(u3z_memo_keep, uw_run_m, seed_old, u3_nul));
     IM3Runtime run_u = sat_u->wasm_module->runtime;
     M3MemoryHeader* mem_u = run_u->memory.mallocated;
     u3a_free(mem_u);
@@ -2212,11 +2199,9 @@ _move_state(
   sat_u->susp_list = u3_none;
   sat_u->queue = u3_none;
 
-  u3z_save_m(u3z_memo_keep, uw_run_m, seed_old, u3_nul);
+  u3z(u3z_save_m(u3z_memo_keep, uw_run_m, seed_old, u3_nul));
 
-  u3z_save_m(u3z_memo_keep, uw_run_m, seed_new, stash);
-
-  u3z(stash);
+  u3z(u3z_save_m(u3z_memo_keep, uw_run_m, seed_new, stash));
 }
 
 u3_weak
@@ -2753,14 +2738,20 @@ u3we_lia_run_v1(u3_noun cor)
   u3z(match.global_get_bat);
   u3z(match.mem_grow_bat);
   u3z(match.mem_size_bat);
+  u3z(match.get_acc_bat);
+  u3z(match.set_acc_bat);
+  u3z(match.get_all_glob_bat);
+  u3z(match.set_all_glob_bat);
 
   u3z(match.call_ctx);
   u3z(match.memread_ctx);
   u3z(match.memwrite_ctx);
-  u3z(global_set_ctx);
-  u3z(global_get_ctx);
-  u3z(mem_grow_ctx);
-  u3z(mem_size_ctx);
+  u3z(match.global_set_ctx);
+  u3z(match.global_get_ctx);
+  u3z(match.mem_grow_ctx);
+  u3z(match.mem_size_ctx);
+  u3z(match.get_all_glob_ctx);
+  u3z(match.set_all_glob_ctx);
 
   #ifdef URWASM_SUBROAD
   //  exit subroad, copying the result
@@ -3040,12 +3031,12 @@ u3we_lia_run_once(u3_noun cor)
   u3z(match.call_ctx);
   u3z(match.memread_ctx);
   u3z(match.memwrite_ctx);
-  u3z(global_set_ctx);
-  u3z(global_get_ctx);
-  u3z(mem_grow_ctx);
-  u3z(mem_size_ctx);
-  u3z(get_all_glob_ctx);
-  u3z(set_all_glob_ctx);
+  u3z(match.global_set_ctx);
+  u3z(match.global_get_ctx);
+  u3z(match.mem_grow_ctx);
+  u3z(match.mem_size_ctx);
+  u3z(match.get_all_glob_ctx);
+  u3z(match.set_all_glob_ctx);
   
   #ifdef URWASM_SUBROAD
   //  exit subroad, copying the result

--- a/pkg/noun/zave.c
+++ b/pkg/noun/zave.c
@@ -158,14 +158,17 @@ u3z_uniq(u3z_cid cid, u3_noun som)
 {
   u3_noun key = u3nc(c3__uniq, u3k(som));
   u3_noun val = u3h_get(_har(u3R, cid), key);
-
+  u3_noun pro;
   if ( u3_none != val ) {
-    u3z(key); u3z(som); return val;
+    u3z(som);
+    pro = val;
   }
   else {
     u3h_put(_har(u3R, cid), key, u3k(som));
-    return som;
+    pro = som;
   }
+  u3z(key);
+  return pro;
 }
 
 /* u3z_reap(): promote memoization cache state.


### PR DESCRIPTION
Some refcount bugs caught by a linter (WIP):

- `bytestream.c`: we lose retained `octs_list`;
- chacha: forgot to increment the refcount of retained `wid`, didn't test `wid` and `dat` for being atoms
- hmac: didn't test `out` for being a direct atom even though the code clearly assumes it; missing c3_w -> atom conversions
- mat/rub/scow: plain leaks
- shax: confusion between retained `c` and owned `d`
- slaw: leaks, ~~assumptions that `numname` is a direct atom (so no `u3k(year)`) but no checks;~~ better fix is to just get rid of leaks by not having generic macros
- urwasm: leaks in `run_once`, saner control flow which is more readable for a linter and a human;
- `u3z_uniq`: leaked `key`
- `loss.c`: an atom was used as direct with no check