### PR TITLE
noun: drop lop_p before pack to avoid SIGBUS on a poisoned loop-hint cache

### DIFF
--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -2777,6 +2777,17 @@ u3m_pack(void)
   //
   u3m_reclaim();
 
+  //  drop the loop-hint set before compacting.  a bail:meme raised mid
+  //  cache-insertion (see urbit/vere#626) can leave a dangling noun in lop_p;
+  //  u3a_rewrite_compact() then chases the corrupt pointer and faults (observed
+  //  as SIGBUS in _pack_relocate_mark, via u3h_relocate() of lop_p).  we
+  //  deliberately do NOT u3h_free() the old table -- freeing chases the same
+  //  bad pointer -- and instead re-point the root so the stale entry becomes
+  //  unreachable and the compactor skips it.  lop_p is a pure loop-detection
+  //  hint cache and is rebuilt on demand.
+  //
+  u3R->lop_p = u3h_new();
+
   //  sweep the heap, finding and saving new locations
   //
   u3a_pack_seek(u3R);


### PR DESCRIPTION
`pack`/`meld` can `Bus error` every time if a prior `bail: meme` left a dangling noun in the loop-hint cache (`lop_p`). This drops `lop_p` before compacting so the rewriter never chases the corrupt pointer. Recovered a real stuck pier; same class as #626. Opus 4.8 was used to troubleshoot this issue I experienced with my ship and to implement this resolution. WOMM.

<details>
<summary>Details</summary>

## Summary

A `bail: meme` raised mid cache-insertion can leave a partially-built noun in the loop-hint set (`u3R->lop_p`). Nothing clears `lop_p` before `u3m_pack` — `u3m_reclaim` clears `har_p` and `|meld` clears `per_p`, but `lop_p` is untouched — so `u3a_rewrite_compact` → `u3h_relocate(lop_p)` later chases the dangling child pointer and faults. On a saved snapshot this is deterministic: every `pack`/`meld` dies with `Bus error` (`SIGBUS` / `BUS_ADRERR`) and the bad entry survives reboots.

## Changes

- `pkg/noun/manage.c` (`u3m_pack`): after `u3m_reclaim` and before `u3a_pack_seek`, re-point `u3R->lop_p` to a fresh table.
  - Intentionally does **not** `u3h_free` the old table — freeing walks the same dangling pointer. Re-pointing the root makes the stale entry unreachable, so the compactor never traverses it.
  - The orphaned table is unreferenced and reclaimed by the normal mark-sweep (`u3a_sweep`, via `u3m_grab` / `|mass`) — it doesn't persist. `_free_words` reclaims at the allocator level and never dereferences the bad child pointer.
  - `lop_p` is a rebuildable loop-detection hint cache.

## Validation

Reproduced and fixed on a live v4.6 planet whose `|bump` had bailed `%meme`:

- Stock v4.6: `pack` and `meld` both `Bus error` in `_pack_relocate_mark`, via `u3h_relocate` of `lop_p` (`allocate.c:1805`); gdb showed `si_addr` (a ~15 GB loom offset) landing in the LMDB `data.mdb` mmap → `BUS_ADRERR`.
- Patched v4.6: `pack` → rc 0; `meld` → rc 0, reclaimed ~391 MiB. The pier then booted on **stock** v4.6 and `|bump` completed; the next mark-sweep reclaimed the orphaned `lop_p` (~74 MB, printed as `palloc: sweep: leaked`) with no crash.

</details>
