### PR TITLE
jets: +spin jet

### DIFF
--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -237,6 +237,7 @@ const c_source_files = [_][]const u8{
     "jets/b/slag.c",
     "jets/b/snag.c",
     "jets/b/sort.c",
+    "jets/b/spin.c",
     "jets/b/turn.c",
     "jets/b/weld.c",
     "jets/b/zing.c",

--- a/pkg/noun/jets/135/tree.c
+++ b/pkg/noun/jets/135/tree.c
@@ -673,6 +673,7 @@ static u3j_harm _135_two_need_a[] = {{".2", u3wb_need, c3y}, {}};
 static u3j_harm _135_two_reap_a[] = {{".2", u3wb_reap, c3y}, {}};
 static u3j_harm _135_two_reel_a[] = {{".2", u3wb_reel, c3y}, {}};
 static u3j_harm _135_two_roll_a[] = {{".2", u3wb_roll, c3y}, {}};
+static u3j_harm _135_two_spin_a[] = {{".2", u3wb_spin, c3y}, {}};
 static u3j_harm _135_two_skid_a[] = {{".2", u3wb_skid, c3y}, {}};
 static u3j_harm _135_two_skim_a[] = {{".2", u3wb_skim, c3y}, {}};
 static u3j_harm _135_two_skip_a[] = {{".2", u3wb_skip, c3y}, {}};
@@ -1193,6 +1194,7 @@ static u3j_core _135_two_d[] =
     { "slag", 7, _135_two_slag_a, 0, no_hashes },
     { "snag", 7, _135_two_snag_a, 0, no_hashes },
     { "sort", 7, _135_two_sort_a, 0, no_hashes },
+    { "spin", 7, _135_two_spin_a, 0, no_hashes },
     { "turn", 7, _135_two_turn_a, 0, no_hashes },
     { "weld", 7, _135_two_weld_a, 0, no_hashes },
     { "welp", 7, _135_two_welp_a, 0, no_hashes },

--- a/pkg/noun/jets/b/spin.c
+++ b/pkg/noun/jets/b/spin.c
@@ -1,0 +1,52 @@
+/// @file
+
+#include "jets/q.h"
+#include "jets/w.h"
+
+#include "noun.h"
+
+  u3_noun
+  u3kb_spin(u3_noun a,
+            u3_noun b,
+            u3_noun c)
+  {
+    if ( u3_nul == a ) {
+      u3z(c);
+      return u3nc(u3_nul, b);
+    }
+
+
+    u3j_site sit_u;
+    u3_noun pro, *lit = &pro, *hed, *tel, i, t;
+    u3j_gate_prep(&sit_u, c);
+
+    do {
+      u3x_cell(a, &i, &t);
+      u3k(i), u3k(t);
+      u3z(a);
+      a = t;
+
+      u3_noun res = u3j_gate_slam(&sit_u, u3nc(i, b));
+      b = u3k(u3t(res));
+      *lit = u3i_defcons(&hed, &tel);
+      *hed = u3k(u3h(res));
+      lit = tel;
+      u3z(res);
+    } while (u3_nul != a);
+
+    *lit = u3_nul;
+    u3j_gate_lose(&sit_u);
+    return u3nc(pro, b);
+  }
+
+  u3_noun
+  u3wb_spin(u3_noun cor)
+  {
+    u3_noun a, b, c;
+
+    a = u3h(u3h(u3t(cor)));
+    b = u3h(u3t(u3h(u3t(cor))));
+    c = u3t(u3t(u3h(u3t(cor))));
+    return u3kb_spin(u3k(a), u3k(b), u3k(c));
+  }
+

--- a/pkg/noun/jets/k.h
+++ b/pkg/noun/jets/k.h
@@ -23,6 +23,7 @@
     u3_noun u3kb_lent(u3_noun a);
     u3_noun u3kb_weld(u3_noun a, u3_noun b);
     u3_noun u3kb_flop(u3_noun a);
+    u3_noun u3kb_spin(u3_noun a, u3_noun b, u3_noun c);
 
 /* u3kc: tier 3 functions
 */

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -42,6 +42,7 @@
     u3_noun u3wb_scag(u3_noun);
     u3_noun u3wb_slag(u3_noun);
     u3_noun u3wb_snag(u3_noun);
+    u3_noun u3wb_spin(u3_noun);
     u3_noun u3wb_sort(u3_noun);
     u3_noun u3wb_turn(u3_noun);
     u3_noun u3wb_weld(u3_noun);


### PR DESCRIPTION
Happened to use +spin in SKA and decided to check whether it had a jet driver. Apparently it didn't.

Didn't measure the difference but the jet gets rid of the +flop call and removes gate calling overhead, so the performance should be much better.