### PR TITLE
vere: avoid gc-loop after hitting guard page at home

### DIFF
--- a/pkg/noun/palloc.c
+++ b/pkg/noun/palloc.c
@@ -1392,12 +1392,15 @@ _sweep_directory(void)
     if ( u3a_head_pg == dir_p ) {
       if ( !(u3a_Mark.bit_w[blk_w] & (1U << bit_w)) ) {
         siz_w = _free_pages(page_to_post(pag_w), pag_w, dir_p);
-        if ( 1 == siz_w ) {
-          fprintf(stderr, "palloc: leaked page %u\r\n", pag_w);
-        }
-        else {
-          fprintf(stderr, "palloc: leaked pages %u-%u\r\n",
-                          pag_w, pag_w + siz_w - 1);
+        if ( u3C.wag_w & u3o_verbose ) {
+          if ( 1 == siz_w ) {
+            fprintf(stderr, "palloc: leaked page %u (0x%x)\r\n",
+                            pag_w, page_to_post(pag_w));
+          }
+          else {
+            fprintf(stderr, "palloc: leaked pages %u-%u (0x%x)\r\n",
+                            pag_w, pag_w + siz_w - 1, page_to_post(pag_w));
+          }
         }
         leq_w += siz_w << u3a_page;
       }
@@ -1410,7 +1413,9 @@ _sweep_directory(void)
       //  entire chunk page is unmarked
       //
       if ( !(u3a_Mark.bit_w[blk_w] & (1U << bit_w)) ) {
-        fprintf(stderr, "palloc: leaked chunk page %u\r\n", pag_w);
+        if ( u3C.wag_w & u3o_verbose ) {
+          fprintf(stderr, "palloc: leaked chunk page %u\r\n", pag_w);
+        }
         (void)_free_pages(page_to_post(pag_w), pag_w, u3a_head_pg);
         leq_w += 1U << u3a_page;
       }
@@ -1441,9 +1446,12 @@ _sweep_directory(void)
               else {
                 som_p = bas_p + ((c3_w)i_s << pag_u->log_s);
 
-                fprintf(stderr, "palloc: leak: 0x%x (chunk %u in page %u)\r\n", som_p, i_s, pag_w);
+                if ( u3C.wag_w & u3o_verbose ) {
+                  fprintf(stderr, "palloc: leak: 0x%x (chunk %u in page %u)\r\n",
+                                  som_p, i_s, pag_w);
+                  _print_chunk(stderr, som_p, siz_w);
+                }
 
-                _print_chunk(stderr, som_p, siz_w);
                 _free_words(som_p, pag_w, dir_p);
                 leq_w += siz_w;
               }
@@ -1668,12 +1676,15 @@ _sweep_counts(void)
 
       if ( !(u3a_Mark.bit_w[blk_w] & (1U << bit_w)) ) {
         siz_w = _free_pages(som_p, pag_w, dir_p);
-        if ( 1 == siz_w ) {
-          fprintf(stderr, "palloc: leaked page %u (0x%x)\r\n", pag_w, page_to_post(pag_w));
-        }
-        else {
-          fprintf(stderr, "palloc: leaked pages %u-%u (0x%x)\r\n",
-                          pag_w, pag_w + siz_w - 1, page_to_post(pag_w));
+        if ( u3C.wag_w & u3o_verbose ) {
+          if ( 1 == siz_w ) {
+            fprintf(stderr, "palloc: leaked page %u (0x%x)\r\n",
+                            pag_w, page_to_post(pag_w));
+          }
+          else {
+            fprintf(stderr, "palloc: leaked pages %u-%u (0x%x)\r\n",
+                            pag_w, pag_w + siz_w - 1, page_to_post(pag_w));
+          }
         }
         leq_w += siz_w << u3a_page;
       }
@@ -1685,7 +1696,8 @@ _sweep_counts(void)
 
           if ( *use_w != u3a_Mark.buf_w[pag_w] ) {
             if ( u3C.wag_w & u3o_verbose ) {
-              fprintf(stderr, "weak: 0x%x have %u need %u\r\n", som_p, *use_w, u3a_Mark.buf_w[pag_w]);
+              fprintf(stderr, "weak: 0x%x have %u need %u\r\n",
+                              som_p, *use_w, u3a_Mark.buf_w[pag_w]);
             }
             *use_w = u3a_Mark.buf_w[pag_w];
             weq_w += siz_w << u3a_page;;
@@ -1708,7 +1720,9 @@ _sweep_counts(void)
       //  entire chunk page is unmarked
       //
       if ( !(u3a_Mark.bit_w[blk_w] & (1U << bit_w)) ) {
-        fprintf(stderr, "palloc: leaked chunk page %u\r\n", pag_w);
+        if ( u3C.wag_w & u3o_verbose ) {
+          fprintf(stderr, "palloc: leaked chunk page %u\r\n", pag_w);
+        }
         (void)_free_pages(page_to_post(pag_w), pag_w, u3a_head_pg);
         leq_w += 1U << u3a_page;
       }
@@ -1754,16 +1768,18 @@ _sweep_counts(void)
                 u3_assert(0);
               }
               else {
-                if ( (c3_ws)mar_w[pos_w] < -1 ) {
+                if ( (u3C.wag_w & u3o_verbose) && ((c3_ws)mar_w[pos_w] < -1) ) {
                   fprintf(stderr, "alias: 0x%x count %d\r\n", som_p, (c3_ws)mar_w[pos_w]);
                 }
                 tot_w += siz_w;
               }
             }
             else {
-              fprintf(stderr, "palloc: leak: 0x%x (chunk %u in page %u)\r\n", som_p, i_s, pag_w);
-
-              _print_chunk(stderr, som_p, siz_w);
+              if ( u3C.wag_w & u3o_verbose ) {
+                fprintf(stderr, "palloc: leak: 0x%x (chunk %u in page %u)\r\n",
+                                som_p, i_s, pag_w);
+                _print_chunk(stderr, som_p, siz_w);
+              }
               _free_words(som_p, pag_w, dir_p);
               leq_w += siz_w;
             }

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -120,6 +120,7 @@ _mars_grab(u3_noun sac, c3_o pri_o)
   if ( u3_nul == sac) {
     if ( u3C.wag_w & (u3o_debug_ram | u3o_check_corrupt) ) {
       u3m_grab(sac, u3_none);
+      u3C.wag_w &= ~u3o_check_corrupt;
     }
     return u3_nul;
   }


### PR DESCRIPTION
`recover: top: meme` (ie, `u3m_signal(c3__meme)` on the home road) sets the `u3o_check_corrupt` flag, which leads to a full gc in mars after the next global state mutation. This feature, while questionable, does correctly clear up memory leaks (at least in many scenarios) that were caused by abandoning the computation that caused the guard page to be hit. But it doesn't reset the flag, so gc passes are repeated after every subsequent mutation. The PR just unsets the flag after gc.

Our overall approach to OOM-on-the-home-road should be reevaluated, as this feature is only active through the `u3m_signal()` codepath -- `u3m_bail()` on the home road is simply a fatal error.