### PR TITLE
noun: fix |mass reporting

### DIFF
--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1598,7 +1598,7 @@ u3a_prof(FILE* fil_u, u3_noun mas)
       c3_w siz_w = _ca_prof_mark(tt_mas);
 
       pro_u->nam_c = u3r_string(h_mas);
-      pro_u->siz_w = siz_w*4;
+      pro_u->siz_z = (c3_z)siz_w * 4;
       pro_u->qua_u = NULL;
       return pro_u;
 
@@ -1613,7 +1613,7 @@ u3a_prof(FILE* fil_u, u3_noun mas)
           bad_t = 1;
         } else {
           pro_u->qua_u = c3_realloc(pro_u->qua_u, (i_w + 2) * sizeof(pro_u->qua_u));
-          pro_u->siz_w += new_u->siz_w;
+          pro_u->siz_z += new_u->siz_z;
           pro_u->qua_u[i_w] = new_u;
         }
         tt_mas = u3t(tt_mas);
@@ -1652,11 +1652,11 @@ u3a_print_quac(FILE* fil_u, c3_w den_w, u3m_quac* mas_u)
 {
   u3_assert( 0 != fil_u );
 
-  if ( mas_u->siz_w ) {
+  if ( mas_u->siz_z ) {
     fprintf(fil_u, "%*s%s: ", den_w, "", mas_u->nam_c);
 
     if ( mas_u->qua_u == NULL ) {
-      _ca_print_memory(fil_u, mas_u->siz_w);
+      _ca_print_memory(fil_u, mas_u->siz_z);
     } else {
       fprintf(fil_u, "\r\n");
       c3_w i_w = 0;
@@ -1665,7 +1665,7 @@ u3a_print_quac(FILE* fil_u, c3_w den_w, u3m_quac* mas_u)
         i_w++;
       }
       fprintf(fil_u, "%*s--", den_w, "");
-      _ca_print_memory(fil_u, mas_u->siz_w);
+      _ca_print_memory(fil_u, mas_u->siz_z);
     }
   }
 }
@@ -1679,31 +1679,31 @@ u3a_mark_road()
 
   qua_u[0] = c3_calloc(sizeof(*qua_u[0]));
   qua_u[0]->nam_c = strdup("namespace");
-  qua_u[0]->siz_w = u3a_mark_noun(u3R->ski.gul) * 4;
+  qua_u[0]->siz_z = u3a_mark_noun(u3R->ski.gul) * 4;
 
   qua_u[1] = c3_calloc(sizeof(*qua_u[1]));
   qua_u[1]->nam_c = strdup("trace stack");
-  qua_u[1]->siz_w = u3a_mark_noun(u3R->bug.tax) * 4;
+  qua_u[1]->siz_z = u3a_mark_noun(u3R->bug.tax) * 4;
 
   qua_u[2] = c3_calloc(sizeof(*qua_u[2]));
   qua_u[2]->nam_c = strdup("trace buffer");
-  qua_u[2]->siz_w = u3a_mark_noun(u3R->bug.mer) * 4;
+  qua_u[2]->siz_z = u3a_mark_noun(u3R->bug.mer) * 4;
 
   qua_u[3] = c3_calloc(sizeof(*qua_u[3]));
   qua_u[3]->nam_c = strdup("profile batteries");
-  qua_u[3]->siz_w = u3a_mark_noun(u3R->pro.don) * 4;
+  qua_u[3]->siz_z = u3a_mark_noun(u3R->pro.don) * 4;
 
   qua_u[4] = c3_calloc(sizeof(*qua_u[4]));
   qua_u[4]->nam_c = strdup("profile doss");
-  qua_u[4]->siz_w = u3a_mark_noun(u3R->pro.day) * 4;
+  qua_u[4]->siz_z = u3a_mark_noun(u3R->pro.day) * 4;
 
   qua_u[5] = c3_calloc(sizeof(*qua_u[5]));
   qua_u[5]->nam_c = strdup("new profile trace");
-  qua_u[5]->siz_w = u3a_mark_noun(u3R->pro.trace) * 4;
+  qua_u[5]->siz_z = u3a_mark_noun(u3R->pro.trace) * 4;
 
   qua_u[6] = c3_calloc(sizeof(*qua_u[6]));
   qua_u[6]->nam_c = strdup("transient memoization cache");
-  qua_u[6]->siz_w = u3h_mark_tot(u3R->cax.har_p) * 4;
+  qua_u[6]->siz_z = u3h_mark_tot(u3R->cax.har_p) * 4;
 
   qua_u[7] = c3_calloc(sizeof(*qua_u[7]));
   qua_u[7]->nam_c = strdup("persistent memoization cache");
@@ -1715,29 +1715,29 @@ u3a_mark_road()
 
     mua_u[0] = c3_calloc(sizeof(*mua_u[0]));
     mua_u[0]->nam_c = strdup("keys");
-    mua_u[0]->siz_w = mas_u.key_w * 4;
+    mua_u[0]->siz_z = mas_u.key_w * 4;
 
     mua_u[1] = c3_calloc(sizeof(*mua_u[1]));
     mua_u[1]->nam_c = strdup("vals");
-    mua_u[1]->siz_w = mas_u.val_w * 4;
+    mua_u[1]->siz_z = mas_u.val_w * 4;
 
     mua_u[2] = c3_calloc(sizeof(*mua_u[2]));
     mua_u[2]->nam_c = strdup("pairs");
-    mua_u[2]->siz_w = mas_u.kev_w * 4;
+    mua_u[2]->siz_z = mas_u.kev_w * 4;
 
     mua_u[3] = c3_calloc(sizeof(*mua_u[3]));
     mua_u[3]->nam_c = strdup("nodes");
-    mua_u[3]->siz_w = mas_u.nod_w * 4;
+    mua_u[3]->siz_z = mas_u.nod_w * 4;
 
     mua_u[4] = NULL;
 
     qua_u[7]->qua_u = mua_u;
-    qua_u[7]->siz_w = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
+    qua_u[7]->siz_z = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
   }
 
   qua_u[8] = c3_calloc(sizeof(*qua_u[8]));
   qua_u[8]->nam_c = strdup("page directory");
-  qua_u[8]->siz_w = u3a_mark_ptr(u3a_into(u3R->hep.pag_p)) * 4;
+  qua_u[8]->siz_z = u3a_mark_ptr(u3a_into(u3R->hep.pag_p)) * 4;
 
   qua_u[9] = c3_calloc(sizeof(*qua_u[9]));
   qua_u[9]->nam_c = strdup("cell pool");
@@ -1755,7 +1755,7 @@ u3a_mark_road()
       }
     }
 
-    qua_u[9]->siz_w = cel_w * 4;
+    qua_u[9]->siz_z = cel_w * 4;
   }
 
   qua_u[10] = c3_calloc(sizeof(*qua_u[10]));
@@ -1774,7 +1774,7 @@ u3a_mark_road()
       fre_w += u3a_mark_ptr(u3a_into(u3R->hep.cac_p));
     }
 
-    qua_u[10]->siz_w = fre_w * 4;
+    qua_u[10]->siz_z = fre_w * 4;
   }
 
   qua_u[11] = c3_calloc(sizeof(*qua_u[11]));
@@ -1787,7 +1787,7 @@ u3a_mark_road()
       wee_w += u3a_Mark.wee_w[i_w];
     }
 
-    qua_u[11]->siz_w = wee_w * 4;
+    qua_u[11]->siz_z = wee_w * 4;
   }
 
   qua_u[12] = c3_calloc(sizeof(*qua_u[12]));
@@ -1800,30 +1800,30 @@ u3a_mark_road()
 
     mua_u[0] = c3_calloc(sizeof(*mua_u[0]));
     mua_u[0]->nam_c = strdup("keys");
-    mua_u[0]->siz_w = mas_u.key_w * 4;
+    mua_u[0]->siz_z = mas_u.key_w * 4;
 
     mua_u[1] = c3_calloc(sizeof(*mua_u[1]));
     mua_u[1]->nam_c = strdup("vals");
-    mua_u[1]->siz_w = mas_u.val_w * 4;
+    mua_u[1]->siz_z = mas_u.val_w * 4;
 
     mua_u[2] = c3_calloc(sizeof(*mua_u[2]));
     mua_u[2]->nam_c = strdup("pairs");
-    mua_u[2]->siz_w = mas_u.kev_w * 4;
+    mua_u[2]->siz_z = mas_u.kev_w * 4;
 
     mua_u[3] = c3_calloc(sizeof(*mua_u[3]));
     mua_u[3]->nam_c = strdup("nodes");
-    mua_u[3]->siz_w = mas_u.nod_w * 4;
+    mua_u[3]->siz_z = mas_u.nod_w * 4;
 
     mua_u[4] = NULL;
 
     qua_u[12]->qua_u = mua_u;
-    qua_u[12]->siz_w = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
+    qua_u[12]->siz_z = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
   }
-  
+
   qua_u[13] = c3_calloc(sizeof(*qua_u[13]));
   qua_u[13]->nam_c = strdup("timer stack");
-  qua_u[13]->siz_w = u3a_mark_noun(u3R->tim) * 4;
-  
+  qua_u[13]->siz_z = u3a_mark_noun(u3R->tim) * 4;
+
   qua_u[14] = c3_calloc(sizeof(*qua_u[14]));
   qua_u[14]->nam_c = strdup("ford memoization cache");
   {
@@ -1834,36 +1834,36 @@ u3a_mark_road()
 
     mua_u[0] = c3_calloc(sizeof(*mua_u[0]));
     mua_u[0]->nam_c = strdup("keys");
-    mua_u[0]->siz_w = mas_u.key_w * 4;
+    mua_u[0]->siz_z = mas_u.key_w * 4;
 
     mua_u[1] = c3_calloc(sizeof(*mua_u[1]));
     mua_u[1]->nam_c = strdup("vals");
-    mua_u[1]->siz_w = mas_u.val_w * 4;
+    mua_u[1]->siz_z = mas_u.val_w * 4;
 
     mua_u[2] = c3_calloc(sizeof(*mua_u[2]));
     mua_u[2]->nam_c = strdup("pairs");
-    mua_u[2]->siz_w = mas_u.kev_w * 4;
+    mua_u[2]->siz_z = mas_u.kev_w * 4;
 
     mua_u[3] = c3_calloc(sizeof(*mua_u[3]));
     mua_u[3]->nam_c = strdup("nodes");
-    mua_u[3]->siz_w = mas_u.nod_w * 4;
+    mua_u[3]->siz_z = mas_u.nod_w * 4;
 
     mua_u[4] = NULL;
 
     qua_u[14]->qua_u = mua_u;
-    qua_u[14]->siz_w = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
+    qua_u[14]->siz_z = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
   }
 
   qua_u[15] = NULL;
 
-  c3_w sum_w = 0;
+  c3_z sum_z = 0;
   for (c3_w i_w = 0; qua_u[i_w]; i_w++) {
-    sum_w += qua_u[i_w]->siz_w;
+    sum_z += qua_u[i_w]->siz_z;
   }
 
   u3m_quac* tot_u = c3_malloc(sizeof(*tot_u));
   tot_u->nam_c = strdup("total road stuff");
-  tot_u->siz_w = sum_w;
+  tot_u->siz_z = sum_z;
   tot_u->qua_u = qua_u;
 
   return tot_u;

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -1414,27 +1414,27 @@ u3a_print_time(c3_c* str_c, c3_c* cap_c, c3_d mic_d)
 /* u3a_print_memory: print memory amount to file descriptor.
 */
 void
-u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
+u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_z wor_z)
 {
   u3_assert( 0 != fil_u );
 
-  c3_z byt_z = ((c3_z)wor_w * 4);
-  c3_z gib_z = (byt_z / 1000000000);
-  c3_z mib_z = (byt_z % 1000000000) / 1000000;
-  c3_z kib_z = (byt_z % 1000000) / 1000;
-  c3_z bib_z = (byt_z % 1000);
+  c3_z byt_z = (wor_z * 4);
+  c3_z gib_z = (byt_z / (1UL << 30));
+  c3_z mib_z = (byt_z % (1UL << 30)) / (1UL << 20);
+  c3_z kib_z = (byt_z % (1UL << 20)) / (1UL << 10);
+  c3_z bib_z = (byt_z % (1UL << 10));
 
   if ( byt_z ) {
     if ( gib_z ) {
-      fprintf(fil_u, "%s: GB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+      fprintf(fil_u, "%s: GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, gib_z, mib_z, kib_z, bib_z);
     }
     else if ( mib_z ) {
-      fprintf(fil_u, "%s: MB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+      fprintf(fil_u, "%s: MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, mib_z, kib_z, bib_z);
     }
     else if ( kib_z ) {
-      fprintf(fil_u, "%s: KB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
+      fprintf(fil_u, "%s: KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, kib_z, bib_z);
     }
     else if ( bib_z ) {
@@ -1447,27 +1447,27 @@ u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
 /* u3a_print_memory_str: print memory amount to string.
 */
 void
-u3a_print_memory_str(c3_c* str_c, c3_c* cap_c, c3_w wor_w)
+u3a_print_memory_str(c3_c* str_c, c3_c* cap_c, c3_z wor_z)
 {
   u3_assert( 0 != str_c );
 
-  c3_z byt_z = ((c3_z)wor_w * 4);
-  c3_z gib_z = (byt_z / 1000000000);
-  c3_z mib_z = (byt_z % 1000000000) / 1000000;
-  c3_z kib_z = (byt_z % 1000000) / 1000;
-  c3_z bib_z = (byt_z % 1000);
+  c3_z byt_z = (wor_z * 4);
+  c3_z gib_z = (byt_z / (1UL << 30));
+  c3_z mib_z = (byt_z % (1UL << 30)) / (1UL << 20);
+  c3_z kib_z = (byt_z % (1UL << 20)) / (1UL << 10);
+  c3_z bib_z = (byt_z % (1UL << 10));
 
   if ( byt_z ) {
     if ( gib_z ) {
-      sprintf(str_c, "%s: GB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+      sprintf(str_c, "%s: GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, gib_z, mib_z, kib_z, bib_z);
     }
     else if ( mib_z ) {
-      sprintf(str_c, "%s: MB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+      sprintf(str_c, "%s: MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, mib_z, kib_z, bib_z);
     }
     else if ( kib_z ) {
-      sprintf(str_c, "%s: KB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
+      sprintf(str_c, "%s: KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n",
               cap_c, kib_z, bib_z);
     }
     else if ( bib_z ) {
@@ -1479,37 +1479,37 @@ u3a_print_memory_str(c3_c* str_c, c3_c* cap_c, c3_w wor_w)
 
 /* u3a_maid(): maybe print memory.
 */
-c3_w
-u3a_maid(FILE* fil_u, c3_c* cap_c, c3_w wor_w)
+c3_z
+u3a_maid(FILE* fil_u, c3_c* cap_c, c3_z wor_z)
 {
   if ( 0 != fil_u ) {
-    u3a_print_memory(fil_u, cap_c, wor_w);
+    u3a_print_memory(fil_u, cap_c, wor_z);
   }
-  return wor_w;
+  return wor_z;
 }
 
 /* _ca_print_memory(): un-captioned u3a_print_memory().
 */
 static void
-_ca_print_memory(FILE* fil_u, c3_w byt_w)
+_ca_print_memory(FILE* fil_u, c3_z byt_z)
 {
-  c3_w gib_w = (byt_w / 1000000000);
-  c3_w mib_w = (byt_w % 1000000000) / 1000000;
-  c3_w kib_w = (byt_w % 1000000) / 1000;
-  c3_w bib_w = (byt_w % 1000);
+  c3_z gib_z = (byt_z / (1UL << 30));
+  c3_z mib_z = (byt_z % (1UL << 30)) / (1UL << 20);
+  c3_z kib_z = (byt_z % (1UL << 20)) / (1UL << 10);
+  c3_z bib_z = (byt_z % (1UL << 10));
 
-  if ( gib_w ) {
-    fprintf(fil_u, "GB/%d.%03d.%03d.%03d\r\n",
-            gib_w, mib_w, kib_w, bib_w);
+  if ( gib_z ) {
+    fprintf(fil_u, "GiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n",
+            gib_z, mib_z, kib_z, bib_z);
   }
-  else if ( mib_w ) {
-    fprintf(fil_u, "MB/%d.%03d.%03d\r\n", mib_w, kib_w, bib_w);
+  else if ( mib_z ) {
+    fprintf(fil_u, "MiB/%" PRIc3_z ".%03" PRIc3_z ".%03" PRIc3_z "\r\n", mib_z, kib_z, bib_z);
   }
-  else if ( kib_w ) {
-    fprintf(fil_u, "KB/%d.%03d\r\n", kib_w, bib_w);
+  else if ( kib_z ) {
+    fprintf(fil_u, "KiB/%" PRIc3_z ".%03" PRIc3_z "\r\n", kib_z, bib_z);
   }
   else {
-    fprintf(fil_u, "B/%d\r\n", bib_w);
+    fprintf(fil_u, "B/%" PRIc3_z "\r\n", bib_z);
   }
 }
 

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -814,12 +814,12 @@ u3a_dash(void);
         /* u3a_print_memory(): print memory amount to file descriptor.
         */
           void
-          u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_w wor_w);
+          u3a_print_memory(FILE* fil_u, c3_c* cap_c, c3_z wor_z);
 
         /* u3a_print_memory(): print memory amount to string.
         */
           void
-          u3a_print_memory_str(c3_c* str_c, c3_c* cap_c, c3_w wor_w);
+          u3a_print_memory_str(c3_c* str_c, c3_c* cap_c, c3_z wor_z);
 
         /* u3a_prof(): mark/measure/print memory profile. RETAIN.
         */
@@ -828,8 +828,8 @@ u3a_dash(void);
 
         /* u3a_maid(): maybe print memory.
         */
-          c3_w
-          u3a_maid(FILE* fil_u, c3_c* cap_c, c3_w wor_w);
+          c3_z
+          u3a_maid(FILE* fil_u, c3_c* cap_c, c3_z wor_z);
 
         /* u3a_quac_free(): free quac memory.
         */

--- a/pkg/noun/jets.c
+++ b/pkg/noun/jets.c
@@ -2336,24 +2336,24 @@ u3j_mark()
 
     mua_u[0] = c3_calloc(sizeof(*mua_u[0]));
     mua_u[0]->nam_c = strdup("keys");
-    mua_u[0]->siz_w = mas_u.key_w * 4;
+    mua_u[0]->siz_z = mas_u.key_w * 4;
 
     mua_u[1] = c3_calloc(sizeof(*mua_u[1]));
     mua_u[1]->nam_c = strdup("vals");
-    mua_u[1]->siz_w = mas_u.val_w * 4;
+    mua_u[1]->siz_z = mas_u.val_w * 4;
 
     mua_u[2] = c3_calloc(sizeof(*mua_u[2]));
     mua_u[2]->nam_c = strdup("pairs");
-    mua_u[2]->siz_w = mas_u.kev_w * 4;
+    mua_u[2]->siz_z = mas_u.kev_w * 4;
 
     mua_u[3] = c3_calloc(sizeof(*mua_u[3]));
     mua_u[3]->nam_c = strdup("nodes");
-    mua_u[3]->siz_w = mas_u.nod_w * 4;
+    mua_u[3]->siz_z = mas_u.nod_w * 4;
 
     mua_u[4] = NULL;
 
     qua_u[0]->qua_u = mua_u;
-    qua_u[0]->siz_w = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
+    qua_u[0]->siz_z = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
   }
 
   qua_u[1] = c3_calloc(sizeof(*qua_u[1]));
@@ -2366,42 +2366,45 @@ u3j_mark()
 
     mua_u[0] = c3_calloc(sizeof(*mua_u[0]));
     mua_u[0]->nam_c = strdup("keys");
-    mua_u[0]->siz_w = mas_u.key_w * 4;
+    mua_u[0]->siz_z = mas_u.key_w * 4;
 
     mua_u[1] = c3_calloc(sizeof(*mua_u[1]));
     mua_u[1]->nam_c = strdup("vals");
-    mua_u[1]->siz_w = mas_u.val_w * 4;
+    mua_u[1]->siz_z = mas_u.val_w * 4;
 
     mua_u[2] = c3_calloc(sizeof(*mua_u[2]));
     mua_u[2]->nam_c = strdup("pairs");
-    mua_u[2]->siz_w = mas_u.kev_w * 4;
+    mua_u[2]->siz_z = mas_u.kev_w * 4;
 
     mua_u[3] = c3_calloc(sizeof(*mua_u[3]));
     mua_u[3]->nam_c = strdup("nodes");
-    mua_u[3]->siz_w = mas_u.nod_w * 4;
+    mua_u[3]->siz_z = mas_u.nod_w * 4;
 
     mua_u[4] = NULL;
 
     qua_u[1]->qua_u = mua_u;
-    qua_u[1]->siz_w = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
+    qua_u[1]->siz_z = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
   }
 
   qua_u[2] = c3_calloc(sizeof(*qua_u[2]));
   qua_u[2]->nam_c = strdup("hank cache");
-  qua_u[2]->siz_w = u3h_mark_tot(u3R->jed.han_p) * 4;
+  qua_u[2]->siz_z = u3h_mark_tot(u3R->jed.han_p) * 4;
 
   qua_u[3] = c3_calloc(sizeof(*qua_u[3]));
   qua_u[3]->nam_c = strdup("battery hash cache");
-  qua_u[3]->siz_w = u3h_mark_tot(u3R->jed.bas_p) * 4;
+  qua_u[3]->siz_z = u3h_mark_tot(u3R->jed.bas_p) * 4;
 
   qua_u[4] = c3_calloc(sizeof(*qua_u[4]));
   qua_u[4]->nam_c = strdup("call site cache");
-  u3h_walk_with(u3R->jed.han_p, _cj_mark_hank, &qua_u[4]->siz_w);
-  qua_u[4]->siz_w *= 4;
+  {
+    c3_w hnk_w = 0;
+    u3h_walk_with(u3R->jed.han_p, _cj_mark_hank, &hnk_w);
+    qua_u[4]->siz_z = (c3_z)hnk_w * 4;
+  }
 
-  c3_w sum_w = 0;
+  c3_z sum_z = 0;
   for ( c3_w i_w = 0; i_w < 5; i_w++ ) {
-    sum_w += qua_u[i_w]->siz_w;
+    sum_z += qua_u[i_w]->siz_z;
   }
 
   u3m_quac* tot_u = c3_calloc(sizeof(*tot_u));
@@ -2410,20 +2413,20 @@ u3j_mark()
   if ( u3R == &(u3H->rod_u) ) {
     qua_u[5] = c3_calloc(sizeof(*qua_u[5]));
     qua_u[5]->nam_c = strdup("hot jet state");
-    qua_u[5]->siz_w = u3h_mark_tot(u3R->jed.hot_p) * 4;
+    qua_u[5]->siz_z = u3h_mark_tot(u3R->jed.hot_p) * 4;
 
-    sum_w += qua_u[5]->siz_w;
+    sum_z += qua_u[5]->siz_z;
 
     qua_u[6] = NULL;
 
-    tot_u->siz_w = sum_w;
+    tot_u->siz_z = sum_z;
     tot_u->qua_u = qua_u;
 
     return tot_u;
   } else {
     qua_u[5] = NULL;
 
-    tot_u->siz_w = sum_w;
+    tot_u->siz_z = sum_z;
     tot_u->qua_u = qua_u;
 
     return tot_u;

--- a/pkg/noun/manage.h
+++ b/pkg/noun/manage.h
@@ -164,7 +164,7 @@ extern c3_w u3m_Ford_fresh_road_depth_w;
       */
         typedef struct _u3m_quac {
           c3_c* nam_c;
-          c3_w  siz_w;
+          c3_z  siz_z;
           struct _u3m_quac** qua_u;
         } u3m_quac;
 

--- a/pkg/noun/nock.c
+++ b/pkg/noun/nock.c
@@ -3215,13 +3215,15 @@ u3m_quac*
 u3n_mark()
 {
   u3m_quac** qua_u = c3_malloc(sizeof(*qua_u) * 3);
+  u3p(u3h_root) har_p = u3R->byc.har_p;
 
   qua_u[0] = c3_calloc(sizeof(*qua_u[0]));
   qua_u[0]->nam_c = strdup("bytecode programs");
-
-  u3p(u3h_root) har_p = u3R->byc.har_p;
-  u3h_walk_with(har_p, _n_bam, &qua_u[0]->siz_w);
-  qua_u[0]->siz_w = qua_u[0]->siz_w * 4;
+  {
+    c3_w bam_w = 0;
+    u3h_walk_with(har_p, _n_bam, &bam_w);
+    qua_u[0]->siz_z = (c3_z)bam_w * 4;
+  }
 
   qua_u[1] = c3_calloc(sizeof(*qua_u[1]));
   qua_u[1]->nam_c = strdup("bytecode cache");
@@ -3233,31 +3235,31 @@ u3n_mark()
 
     mua_u[0] = c3_calloc(sizeof(*mua_u[0]));
     mua_u[0]->nam_c = strdup("keys");
-    mua_u[0]->siz_w = mas_u.key_w * 4;
+    mua_u[0]->siz_z = mas_u.key_w * 4;
 
     mua_u[1] = c3_calloc(sizeof(*mua_u[1]));
     mua_u[1]->nam_c = strdup("vals");
-    mua_u[1]->siz_w = mas_u.val_w * 4;
+    mua_u[1]->siz_z = mas_u.val_w * 4;
 
     mua_u[2] = c3_calloc(sizeof(*mua_u[2]));
     mua_u[2]->nam_c = strdup("pairs");
-    mua_u[2]->siz_w = mas_u.kev_w * 4;
+    mua_u[2]->siz_z = mas_u.kev_w * 4;
 
     mua_u[3] = c3_calloc(sizeof(*mua_u[3]));
     mua_u[3]->nam_c = strdup("nodes");
-    mua_u[3]->siz_w = mas_u.nod_w * 4;
+    mua_u[3]->siz_z = mas_u.nod_w * 4;
 
     mua_u[4] = NULL;
 
     qua_u[1]->qua_u = mua_u;
-    qua_u[1]->siz_w = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
+    qua_u[1]->siz_z = (mas_u.key_w + mas_u.val_w + mas_u.kev_w + mas_u.nod_w) * 4;
   }
 
   qua_u[2] = NULL;
 
   u3m_quac* tot_u = c3_malloc(sizeof(*tot_u));
   tot_u->nam_c = strdup("total nock stuff");
-  tot_u->siz_w = qua_u[0]->siz_w + qua_u[1]->siz_w;
+  tot_u->siz_z = qua_u[0]->siz_z + qua_u[1]->siz_z;
   tot_u->qua_u = qua_u;
 
   return tot_u;

--- a/pkg/noun/vortex.c
+++ b/pkg/noun/vortex.c
@@ -380,17 +380,17 @@ u3v_mark()
 
   qua_u[0] = c3_calloc(sizeof(*qua_u[0]));
   qua_u[0]->nam_c = strdup("kernel");
-  qua_u[0]->siz_w = u3a_mark_noun(arv_u->roc) * 4;
+  qua_u[0]->siz_z = u3a_mark_noun(arv_u->roc) * 4;
 
   qua_u[1] = c3_calloc(sizeof(*qua_u[2]));
   qua_u[1]->nam_c = strdup("wish cache");
-  qua_u[1]->siz_w = u3a_mark_noun(arv_u->yot) * 4;
+  qua_u[1]->siz_z = u3a_mark_noun(arv_u->yot) * 4;
 
   qua_u[2] = NULL;
 
   u3m_quac* tot_u = c3_malloc(sizeof(*tot_u));
   tot_u->nam_c = strdup("total arvo stuff");
-  tot_u->siz_w = qua_u[0]->siz_w + qua_u[1]->siz_w;
+  tot_u->siz_z = qua_u[0]->siz_z + qua_u[1]->siz_z;
   tot_u->qua_u = qua_u;
 
   return tot_u;

--- a/pkg/ur/hashcons.c
+++ b/pkg/ur/hashcons.c
@@ -761,22 +761,22 @@ _print_memory(FILE *f, const char *c, uint64_t bytes)
     fprintf(f, "%s: B/0\r\n", c);
   }
   else {
-    uint32_t g = (bytes / 1000000000);
-    uint32_t m = (bytes % 1000000000) / 1000000;
-    uint32_t k = (bytes % 1000000) / 1000;
-    uint32_t b = (bytes % 1000);
+    uint64_t g = (bytes / (1UL << 30));
+    uint64_t m = (bytes % (1UL << 30)) / (1UL << 20);
+    uint64_t k = (bytes % (1UL << 20)) / (1UL << 10);
+    uint64_t b = (bytes % (1UL << 10));
 
     if ( g ) {
-      fprintf(f, "%s: GB/%d.%03d.%03d.%03d\r\n", c, g, m, k, b);
+      fprintf(f, "%s: GiB/%" PRIu64 ".%03" PRIu64 ".%03" PRIu64 ".%03" PRIu64 "\r\n", c, g, m, k, b);
     }
     else if ( m ) {
-      fprintf(f, "%s: MB/%d.%03d.%03d\r\n", c, m, k, b);
+      fprintf(f, "%s: MiB/%" PRIu64 ".%03" PRIu64 ".%03" PRIu64 "\r\n", c, m, k, b);
     }
     else if ( k ) {
-      fprintf(f, "%s: KB/%d.%03d\r\n", c, k, b);
+      fprintf(f, "%s: KiB/%" PRIu64 ".%03" PRIu64 "\r\n", c, k, b);
     }
     else if ( b ) {
-      fprintf(f, "%s: B/%d\r\n", c, b);
+      fprintf(f, "%s: B/%" PRIu64 "\r\n", c, b);
     }
   }
 }

--- a/pkg/vere/auto.c
+++ b/pkg/vere/auto.c
@@ -436,43 +436,44 @@ _mark_ova(u3_ovum* egg_u)
 }
 
 u3m_quac**
-u3_auto_mark(u3_auto* car_u, c3_w *out_w)
+u3_auto_mark(u3_auto* car_u, c3_z *out_z)
 {
   u3m_quac** all_u;
-  c3_w       tot_w = 0, len_w = 0;
+  c3_z       tot_z = 0;
+  c3_z       len_z = 0;
 
   {
     u3_auto* rac_u = car_u;
     while ( car_u ) {
       car_u = car_u->nex_u;
-      len_w++;
+      len_z++;
     }
     car_u = rac_u;
   }
 
-  all_u = c3_calloc(sizeof(*all_u) * (len_w + 1));
-  len_w = 0;
+  all_u = c3_calloc(sizeof(*all_u) * (len_z + 1));
+  len_z = 0;
 
   while ( car_u ) {
-    all_u[len_w] = c3_malloc(sizeof(**all_u));
-    all_u[len_w]->nam_c = u3r_string(car_u->nam_m);
-    all_u[len_w]->siz_w = 0;
-    all_u[len_w]->qua_u = 0;
+    all_u[len_z] = c3_malloc(sizeof(**all_u));
+    all_u[len_z]->nam_c = u3r_string(car_u->nam_m);
+    all_u[len_z]->siz_z = 0;
+    all_u[len_z]->qua_u = 0;
 
     if ( car_u->io.mark_f ) {
-      all_u[len_w]->qua_u = car_u->io.mark_f(car_u, &(all_u[len_w]->siz_w));
+      all_u[len_z]->qua_u = car_u->io.mark_f(car_u, &(all_u[len_z]->siz_z));
     }
 
-    all_u[len_w]->siz_w += _mark_ova(car_u->ext_u) * 4;
+    all_u[len_z]->siz_z += (c3_z)_mark_ova(car_u->ext_u) * 4;
 
-    tot_w += all_u[len_w]->siz_w;
+    tot_z += all_u[len_z]->siz_z;
     car_u  = car_u->nex_u;
-    len_w++;
+    len_z++;
   }
 
-  all_u[len_w] = 0;
+  all_u[len_z] = 0;
 
-  *out_w = tot_w;
+  *out_z = tot_z;
 
   return all_u;
 }

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2827,24 +2827,24 @@ _ames_io_slog(u3_auto* car_u)
 }
 
 static u3m_quac**
-_ames_io_mark(u3_auto* car_u, c3_w *out_w)
+_ames_io_mark(u3_auto* car_u, c3_z *out_z)
 {
   u3m_quac** all_u = c3_malloc(4 * sizeof(*all_u));
   u3_ames   *sam_u = (u3_ames*)car_u;
 
   all_u[0] = c3_malloc(sizeof(**all_u));
   all_u[0]->nam_c = strdup("scry cache");
-  all_u[0]->siz_w = 4 * u3h_mark_tot(sam_u->fin_s.sac_p);
+  all_u[0]->siz_z = 4 * u3h_mark_tot(sam_u->fin_s.sac_p);
   all_u[0]->qua_u = 0;
 
   all_u[1] = c3_malloc(sizeof(**all_u));
   all_u[1]->nam_c = strdup("lane cache");
-  all_u[1]->siz_w = 4 * u3h_mark_tot(sam_u->lax_p);
+  all_u[1]->siz_z = 4 * u3h_mark_tot(sam_u->lax_p);
   all_u[1]->qua_u = 0;
 
   all_u[2] = 0;
 
-  *out_w = all_u[0]->siz_w + all_u[1]->siz_w;
+  *out_z = all_u[0]->siz_z + all_u[1]->siz_z;
 
   return all_u;
 }

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -3094,30 +3094,30 @@ _http_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
 }
 
 static u3m_quac**
-_http_io_mark(u3_auto* car_u, c3_w *out_w)
+_http_io_mark(u3_auto* car_u, c3_z *out_z)
 {
   u3m_quac** all_u = c3_malloc(4 * sizeof(*all_u));
   u3_httd*   htd_u = (u3_httd*)car_u;
 
   all_u[0] = c3_malloc(sizeof(**all_u));
   all_u[0]->nam_c = strdup("session tokens");
-  all_u[0]->siz_w = 4 * u3a_mark_noun(htd_u->fig_u.ses);
+  all_u[0]->siz_z = 4 * u3a_mark_noun(htd_u->fig_u.ses);
   all_u[0]->qua_u = 0;
 
 
   all_u[1] = c3_malloc(sizeof(**all_u));
   all_u[1]->nam_c = strdup("url->scry cache");
-  all_u[1]->siz_w = 4 * u3h_mark_tot(htd_u->sax_p);
+  all_u[1]->siz_z = 4 * u3h_mark_tot(htd_u->sax_p);
   all_u[1]->qua_u = 0;
 
   all_u[2] = c3_malloc(sizeof(**all_u));
   all_u[2]->nam_c = strdup("scry->noun cache");
-  all_u[2]->siz_w = 4 * u3h_mark_tot(htd_u->nax_p);
+  all_u[2]->siz_z = 4 * u3h_mark_tot(htd_u->nax_p);
   all_u[2]->qua_u = 0;
 
   all_u[3] = 0;
 
-  *out_w = all_u[0]->siz_w + all_u[1]->siz_w + all_u[2]->siz_w;
+  *out_z = all_u[0]->siz_z + all_u[1]->siz_z + all_u[2]->siz_z;
 
   return all_u;
 }

--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -1773,37 +1773,38 @@ _term_io_exit_cb(uv_handle_t* han_u)
 }
 
 static u3m_quac**
-_term_io_mark(u3_auto* car_u, c3_w *out_w)
+_term_io_mark(u3_auto* car_u, c3_z *out_z)
 {
   u3m_quac** all_u;
   u3_utty*   uty_u;
-  c3_w       tot_w = 0, len_w = 0;
+  c3_z       tot_z = 0;
+  c3_z       len_z = 0;
 
   for ( uty_u = u3_Host.uty_u; uty_u; uty_u = uty_u->nex_u ) {
-    len_w++;
+    len_z++;
   }
 
-  all_u = c3_malloc(sizeof(*all_u) * (len_w + 1));
-  len_w = 0;
+  all_u = c3_malloc(sizeof(*all_u) * (len_z + 1));
+  len_z = 0;
 
   for ( uty_u = u3_Host.uty_u; uty_u; uty_u = uty_u->nex_u ) {
-    all_u[len_w] = c3_malloc(sizeof(**all_u));
-    all_u[len_w]->qua_u = 0;
-    all_u[len_w]->siz_w = 0;
+    all_u[len_z] = c3_malloc(sizeof(**all_u));
+    all_u[len_z]->qua_u = 0;
+    all_u[len_z]->siz_z = 0;
 
-    all_u[len_w]->siz_w += u3a_mark_noun(uty_u->tat_u.mir.lin);
-    all_u[len_w]->siz_w += u3a_mark_noun(uty_u->tat_u.fut.imp);
-    all_u[len_w]->siz_w *= 4;
+    all_u[len_z]->siz_z += u3a_mark_noun(uty_u->tat_u.mir.lin);
+    all_u[len_z]->siz_z += u3a_mark_noun(uty_u->tat_u.fut.imp);
+    all_u[len_z]->siz_z *= 4;
 
-    asprintf(&(all_u[len_w]->nam_c), "term-%u-%d", uty_u->tid_l, uty_u->fid_i);
+    asprintf(&(all_u[len_z]->nam_c), "term-%u-%d", uty_u->tid_l, uty_u->fid_i);
 
-    tot_w += all_u[len_w]->siz_w;
-    len_w++;
+    tot_z += all_u[len_z]->siz_z;
+    len_z++;
   }
 
-  all_u[len_w] = 0;
+  all_u[len_z] = 0;
 
-  *out_w = tot_w;
+  *out_z = tot_z;
 
   return all_u;
 }

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -1563,18 +1563,18 @@ _unix_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
 }
 
 static u3m_quac**
-_unix_io_mark(u3_auto* car_u, c3_w *out_w)
+_unix_io_mark(u3_auto* car_u, c3_z *out_z)
 {
   u3m_quac** all_u = c3_malloc(2 * sizeof(*all_u));
 
   all_u[0] = c3_malloc(sizeof(**all_u));
   all_u[0]->nam_c = strdup("+sane handle");
-  all_u[0]->siz_w = 4 * u3a_mark_noun(((u3_unix*)car_u)->sat);
+  all_u[0]->siz_z = 4 * u3a_mark_noun(((u3_unix*)car_u)->sat);
   all_u[0]->qua_u = 0;
 
   all_u[1] = 0;
 
-  *out_w = all_u[0]->siz_w;
+  *out_z = all_u[0]->siz_z;
 
   return all_u;
 }

--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -1820,7 +1820,7 @@ u3_king_grab(void* vod_p)
 
   all_u[0] = c3_malloc(sizeof(**all_u));
   all_u[0]->nam_c = strdup("pier");
-  all_u[0]->qua_u = u3_pier_mark(u3_king_stub(), &(all_u[0]->siz_w));
+  all_u[0]->qua_u = u3_pier_mark(u3_king_stub(), &(all_u[0]->siz_z));
 
   u3m_quac** var_u = u3m_mark();
   all_u[1] = var_u[0];
@@ -1829,18 +1829,18 @@ u3_king_grab(void* vod_p)
   all_u[4] = var_u[3];
   c3_free(var_u);
 
-  c3_w tot_w = all_u[0]->siz_w + all_u[1]->siz_w
-                 + all_u[2]->siz_w + all_u[3]->siz_w + all_u[4]->siz_w;
+  c3_z tot_z = all_u[0]->siz_z + all_u[1]->siz_z
+                 + all_u[2]->siz_z + all_u[3]->siz_z + all_u[4]->siz_z;
 
   all_u[5] = c3_calloc(sizeof(*all_u[4]));
   all_u[5]->nam_c = strdup("total marked");
-  all_u[5]->siz_w = tot_w;
+  all_u[5]->siz_z = tot_z;
 
   //  XX sweep could be optional, gated on u3o_debug_ram or somesuch
   //  only u3a_mark_done() is required
   all_u[6] = c3_calloc(sizeof(*all_u[5]));
   all_u[6]->nam_c = strdup("sweep");
-  all_u[6]->siz_w = u3a_sweep();
+  all_u[6]->siz_z = u3a_sweep();
 
   all_u[7] = 0;
 

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -977,7 +977,7 @@ u3_lord_mark(u3_lord* god_u)
 
   u3m_quac* qac_u = c3_malloc(sizeof(*qac_u));
   qac_u->nam_c = strdup("lord ipc");
-  qac_u->siz_w = siz_w * 4;
+  qac_u->siz_z = (c3_z)siz_w * 4;
   qac_u->qua_u = 0;
 
   return qac_u;

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -75,7 +75,7 @@ _mars_quac(u3m_quac* mas_u)
   }
   list = u3kb_flop(list);
 
-  u3_noun mas = u3nt(u3i_string(mas_u->nam_c), u3i_word(mas_u->siz_w), list);
+  u3_noun mas = u3nt(u3i_string(mas_u->nam_c), u3i_chub(mas_u->siz_z), list);
 
   c3_free(mas_u->nam_c);
   c3_free(mas_u->qua_u);
@@ -185,32 +185,32 @@ _mars_grab(u3_noun sac, c3_o pri_o)
       all_u[4] = var_u[3];
       c3_free(var_u);
 
-      c3_w tot_w = all_u[0]->siz_w + all_u[1]->siz_w + all_u[2]->siz_w
-                     + all_u[3]->siz_w + all_u[4]->siz_w;
+      c3_z tot_z = all_u[0]->siz_z + all_u[1]->siz_z + all_u[2]->siz_z
+                     + all_u[3]->siz_z + all_u[4]->siz_z;
 
       all_u[5] = c3_calloc(sizeof(*all_u[5]));
       all_u[5]->nam_c = strdup("space profile");
-      all_u[5]->siz_w = sac_w * 4;
+      all_u[5]->siz_z = (c3_z)sac_w * 4;
 
-      tot_w += all_u[5]->siz_w;
+      tot_z += all_u[5]->siz_z;
 
       all_u[6] = c3_calloc(sizeof(*all_u[6]));
       all_u[6]->nam_c = strdup("total marked");
-      all_u[6]->siz_w = tot_w;
+      all_u[6]->siz_z = tot_z;
 
       all_u[7] = c3_calloc(sizeof(*all_u[7]));
       all_u[7]->nam_c = strdup("free lists");
-      all_u[7]->siz_w = u3a_idle(u3R) * 4;
+      all_u[7]->siz_z = (c3_z)u3a_idle(u3R) * 4;
 
       //  XX sweep could be optional, gated on u3o_debug_ram or somesuch
       //  only u3a_mark_done() is required
       all_u[8] = c3_calloc(sizeof(*all_u[8]));
       all_u[8]->nam_c = strdup("sweep");
-      all_u[8]->siz_w = u3a_sweep() * 4;
+      all_u[8]->siz_z = (c3_z)u3a_sweep() * 4;
 
       all_u[9] = c3_calloc(sizeof(*all_u[9]));
       all_u[9]->nam_c = strdup("loom");
-      all_u[9]->siz_w = u3C.wor_i * 4;
+      all_u[9]->siz_z = u3C.wor_i * 4;
 
       all_u[10] = NULL;
 
@@ -2038,16 +2038,16 @@ u3_mars_grab(c3_o pri_o)
     u3a_mark_init();
     u3m_quac** var_u = u3m_mark();
 
-    c3_w tot_w = 0;
+    c3_z tot_z = 0;
     c3_w i_w = 0;
     while ( var_u[i_w] != NULL ) {
-      tot_w += var_u[i_w]->siz_w;
+      tot_z += var_u[i_w]->siz_z;
       u3a_quac_free(var_u[i_w]);
       i_w++;
     }
     c3_free(var_u);
 
-    u3a_print_memory(stderr, "total marked", tot_w / 4);
+    u3a_print_memory(stderr, "total marked", tot_z / 4);
     u3a_print_memory(stderr, "free lists", u3a_idle(u3R));
     //  XX sweep could be optional, gated on u3o_debug_ram or somesuch
     //  only u3a_mark_done() is required

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1492,14 +1492,15 @@ _pier_mark_pico(u3_pico* pic_u)
 /* u3_pier_mark(): mark all Loom allocations in all u3_pier structs.
 */
 u3m_quac**
-u3_pier_mark(u3_pier* pir_u, c3_w *out_w)
+u3_pier_mark(u3_pier* pir_u, c3_z *out_z)
 {
   u3m_quac** all_u = c3_malloc(4 * sizeof(*all_u));
 
   all_u[0] = c3_malloc(sizeof(**all_u));
   all_u[0]->nam_c = strdup("drivers");
+  all_u[0]->siz_z = 0;
   if ( pir_u->wok_u ) {
-    all_u[0]->qua_u = u3_auto_mark(pir_u->wok_u->car_u, &(all_u[0]->siz_w));
+    all_u[0]->qua_u = u3_auto_mark(pir_u->wok_u->car_u, &(all_u[0]->siz_z));
   }
   else {
     all_u[0]->qua_u = 0;
@@ -1509,12 +1510,12 @@ u3_pier_mark(u3_pier* pir_u, c3_w *out_w)
 
   all_u[2] = c3_malloc(sizeof(**all_u));
   all_u[2]->nam_c = strdup("peeks");
-  all_u[2]->siz_w = 4 * _pier_mark_pico(pir_u->pec_u.ext_u);
+  all_u[2]->siz_z = (c3_z)_pier_mark_pico(pir_u->pec_u.ext_u) * 4;
   all_u[2]->qua_u = 0;
 
   all_u[3] = 0;
 
-  *out_w = all_u[0]->siz_w + all_u[1]->siz_w + all_u[2]->siz_w;
+  *out_z = all_u[0]->siz_z + all_u[1]->siz_z + all_u[2]->siz_z;
 
   return all_u;
 }

--- a/pkg/vere/vere.h
+++ b/pkg/vere/vere.h
@@ -613,7 +613,7 @@
           u3_noun (*info_f)(struct _u3_auto*);
           void    (*slog_f)(struct _u3_auto*);
           c3_o    (*kick_f)(struct _u3_auto*, u3_noun, u3_noun);
-          u3m_quac** (*mark_f)(struct _u3_auto*, c3_w*);
+          u3m_quac** (*mark_f)(struct _u3_auto*, c3_z*);
           void    (*exit_f)(struct _u3_auto*);  // XX close_cb?
         } u3_auto_cb;
 
@@ -762,7 +762,7 @@
       /* u3_auto_mark(): mark drivers for gc.
       */
         u3m_quac**
-        u3_auto_mark(u3_auto* car_u, c3_w *out_w);
+        u3_auto_mark(u3_auto* car_u, c3_z *out_z);
       /* u3_auto_init(): initialize all drivers.
       */
         u3_auto*
@@ -1363,7 +1363,7 @@
       /* u3_pier_mark(): mark all Loom allocations in all u3_pier structs.
       */
         u3m_quac**
-        u3_pier_mark(u3_pier*, c3_w*);
+        u3_pier_mark(u3_pier*, c3_z*);
 
       /* u3_pier_mase(): construct a $mass leaf.
       */


### PR DESCRIPTION
There are two different changes:

Inclusion of base10 -> base2 memory printing function changes introduced in an
unapproved PR a long time ago. This just makes reasoning about the size of
things in your loom much easier 26746e3c0d8718892a07419f4b92c3b4111e1184 #311

The other change is larger but basically just a c3_w -> c3_z search and
replace. I noticed that when running a pier with --loom 32,33,34 the final
"loom:" summary line always dropped. This is because the c3_w type in
u3m_quac.siz_w was overflowing to zero and would therefore get silently dropped
in the |mass summary since we conditionally exclude zero values.

So I widened the type to c3_z and fixed all references with the exception of the
two u3h_walk_with callbacks in jets.c and nock.c since they accumulate a *word*
count and 2^32-1 is sufficient to address anything in a 16GiB loom.

The `|mass` printout of a 16GiB loom after these changes:
```
~zod:dojo> |mass\
arvo: 
  hoon: 
    one: KiB/16.128
    two: KiB/134.784
    tri: KiB/186.208
    qua: KiB/446.1008
    pen: MiB/2.031.496
  --MiB/2.815.576
  hex: KiB/397.064
  pit: B/128
  lull: 
    dot: MiB/2.622.848
    typ: B/96
  --MiB/2.622.944
  zuse: 
    dot: KiB/677.400
    typ: KiB/482.960
  --MiB/1.136.336
  vane: 
    ames: 
      peers-known: KiB/13.720
      dot: MiB/8.763.560
      typ: KiB/10.624
      sac: KiB/266.032
    --MiB/9.029.912
    behn: 
      timers: KiB/3.064
      dot: KiB/298.688
      typ: KiB/3.128
      sac: KiB/18.192
    --KiB/323.048
    clay: 
      object-store: 
        commits: KiB/218.656
        pages: MiB/251.984.688
      --MiB/252.179.320
      domestic: 
        base: 
          dojo: B/736
        --B/736
        groups: 
          dojo: B/832
        --B/832
        kids: 
          dojo: B/752
        --B/752
        landscape: 
          dojo: B/832
        --B/832
        webterm: 
          dojo: B/832
        --B/832
      --KiB/3.912
      foreign: KiB/1.768
      dot: MiB/3.724.896
      typ: KiB/6.336
      sac: KiB/142.944
    --MiB/256.035.080
    dill: 
      hey: B/48
      dug: B/80
      dot: KiB/358.128
      typ: KiB/4.256
      sac: KiB/93.096
    --KiB/455.608
    eyre: 
      bindings: KiB/4.400
      cache: MiB/22.602.048
      axle: B/400
      dot: MiB/2.545.656
      typ: KiB/2.096
      sac: KiB/55.608
    --MiB/25.186.160
    gall: 
      foreign: B/96
      active: 
        acme: MiB/1.280.928
        activity: MiB/9.466.640
        azimuth: MiB/1.820.704
        bait: KiB/305.304
        bark: KiB/82.496
        channels: 
          negotiate: B/528
          dot: MiB/9.017.912
        --MiB/9.018.416
        channels-server: 
          negotiate: B/400
          dot: MiB/1.119.528
        --MiB/1.119.928
        chat: 
          negotiate: B/240
          dot: MiB/2.616.512
        --MiB/2.616.752
        contacts: 
          negotiate: B/208
          dot: KiB/504.160
        --KiB/504.368
        dbug: MiB/2.703.112
        docket: KiB/708.640
        dojo: MiB/3.828.768
        dumb-proxy: KiB/88.368
        eth-watcher: KiB/327.048
        expose: KiB/743.048
        gateway-status: KiB/91.896
        genuine: KiB/29.192
        grouper: KiB/146.400
        groups: 
          negotiate: B/704
          dot: MiB/3.752.928
        --MiB/3.753.608
        groups-ui: KiB/365.160
        growl: KiB/236.128
        hark: KiB/640.448
        herm: KiB/123.912
        hood: MiB/3.193.192
        lanyard: 
          negotiate: B/496
          dot: KiB/515.080
        --KiB/515.576
        lens: KiB/152.672
        logs: KiB/60.000
        metagrab: KiB/820.224
        notify: KiB/570.640
        ping: KiB/91.880
        presence: KiB/405.1008
        profile: KiB/352.240
        reel: KiB/466.768
        settings: KiB/76.000
        spider: KiB/494.272
        steward: KiB/185.352
        storage: KiB/143.816
        treaty: KiB/171.1008
        vitals: KiB/177.064
      --MiB/47.566.544
      dot: KiB/2.608
      typ: KiB/2.016
      sac: KiB/75.080
    --MiB/47.646.320
    iris: 
      outbound: B/128
      axle: B/96
      dot: KiB/89.208
      typ: KiB/59.928
      sac: KiB/18.976
    --KiB/168.288
    jael: 
      pki: B/640
      dot: KiB/649.304
      typ: KiB/3.416
      sac: KiB/17.784
    --KiB/671.096
    khan: 
      dot: KiB/56.928
      typ: KiB/42.864
      sac: KiB/19.720
    --KiB/119.464
    lick: 
      dot: KiB/54.976
      typ: KiB/2.288
      sac: KiB/12.032
    --KiB/69.272
  --MiB/339.656.176
--MiB/346.580.176
total arvo stuff: 
  kernel: KiB/17.240
--KiB/17.240
total jet stuff: 
  warm jet state: 
    keys: KiB/24.064
    vals: KiB/25.576
    pairs: KiB/4.784
    nodes: KiB/2.624
  --KiB/57.000
  cold jet state: 
    keys: KiB/513.928
    vals: KiB/33.352
    pairs: KiB/4.768
    nodes: KiB/2.592
  --KiB/554.592
  hank cache: B/768
  battery hash cache: B/512
  call site cache: B/336
  hot jet state: KiB/150.256
--KiB/763.416
total nock stuff: 
  bytecode programs: MiB/6.868.800
  bytecode cache: 
    keys: KiB/429.992
    pairs: KiB/131.128
    nodes: KiB/70.624
  --KiB/631.720
--MiB/7.476.496
total road stuff: 
  trace buffer: B/256
  transient memoization cache: B/512
  persistent memoization cache: 
    keys: MiB/2.507.272
    vals: KiB/964.352
    pairs: KiB/58.144
    nodes: KiB/30.224
  --MiB/3.535.992
  page directory: KiB/256.000
  free list: B/624
  metadata: MiB/1.261.672
  loop hint set: 
    nodes: B/512
  --B/512
  ford memoization cache: 
    keys: MiB/3.704.944
    vals: MiB/2.466.704
    pairs: KiB/150.944
    nodes: KiB/81.048
  --MiB/6.379.592
--MiB/11.411.064
space profile: KiB/6.944
total marked: MiB/366.207.288
free lists: MiB/383.263.720
sweep: MiB/366.248.304
loom: GiB/16.000.000.000
> |mass
>=
```