### PR TITLE
http: actually unlink first item; return early

### DIFF
--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1908,6 +1908,7 @@ _http_serv_unlink(u3_http* htp_u)
     while ( pre_u ) {
       if ( pre_u->nex_u == htp_u ) {
         pre_u->nex_u = htp_u->nex_u;
+        return;
       }
       else pre_u = pre_u->nex_u;
     }

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1900,7 +1900,7 @@ _http_serv_unlink(u3_http* htp_u)
   u3_http* pre_u = htp_u->htd_u->htp_u;
 
   if ( pre_u == htp_u ) {
-    pre_u = htp_u->nex_u;
+    htp_u->htd_u->htp_u = htp_u->nex_u;
   }
   else {
     //  XX glories of linear search
@@ -1908,6 +1908,7 @@ _http_serv_unlink(u3_http* htp_u)
     while ( pre_u ) {
       if ( pre_u->nex_u == htp_u ) {
         pre_u->nex_u = htp_u->nex_u;
+        return;
       }
       else pre_u = pre_u->nex_u;
     }

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1908,7 +1908,6 @@ _http_serv_unlink(u3_http* htp_u)
     while ( pre_u ) {
       if ( pre_u->nex_u == htp_u ) {
         pre_u->nex_u = htp_u->nex_u;
-        return;
       }
       else pre_u = pre_u->nex_u;
     }


### PR DESCRIPTION
If the first element of the linked list `htp_u->htd_u->htp_u` was the element we wanted to unlink, then the function would noop. 

Also, if an element got unlinked, we would keep iterating over the linked list instead of returning early. I am assuming that the linked list does not hold duplicate entries.

There is potential for more optimizations: if the linked list is guaranteed to hold `htp_u` then the while loop could be made unconditional, removing extra checks. Though I do not know if this actually holds.