### PR TITLE
ubsan fixes, alignment in u3a_pile

### DIFF
--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -254,16 +254,20 @@ u3a_wealloc(void* lag_v, c3_w old_w, c3_w len_w)
 /* u3a_pile_prep(): initialize stack control.
 */
 void
-u3a_pile_prep(u3a_pile* pil_u, c3_w len_w)
+u3a_pile_prep(u3a_pile* pil_u, c3_w len_w, c3_w alg_w)
 {
   //  frame size, in words
   //
   c3_w wor_w = (len_w + 3) >> 2;
+  c3_w wal_w = alg_w >> 2;
   c3_o nor_o = u3a_is_north(u3R);
 
   pil_u->mov_ws = (c3y == nor_o) ? -wor_w :  wor_w;
   pil_u->off_ws = (c3y == nor_o) ?      0 : -wor_w;
-  pil_u->top_p  = u3R->cap_p;
+  pil_u->beg_p  = u3R->cap_p;
+
+  align_dir dir_u = pil_u->mov_ws > 0 ? C3_ALGHI : C3_ALGLO;
+  pil_u->top_p = u3R->cap_p = c3_align_w(u3R->cap_p, wal_w, dir_u);
 
 #ifdef U3_MEMORY_DEBUG
   pil_u->rod_u  = u3R;
@@ -704,7 +708,7 @@ _ca_take_north(u3_noun veb)
   u3_noun     pro;
   _ca_take* fam_u;
   u3a_pile  pil_u;
-  u3a_pile_prep(&pil_u, sizeof(*fam_u));
+  u3a_pile_prep(&pil_u, sizeof(*fam_u), __alignof__(*fam_u));
 
   //  commence taking
   //
@@ -744,7 +748,7 @@ _ca_take_south(u3_noun veb)
   u3_noun     pro;
   _ca_take* fam_u;
   u3a_pile  pil_u;
-  u3a_pile_prep(&pil_u, sizeof(*fam_u));
+  u3a_pile_prep(&pil_u, sizeof(*fam_u), __alignof__(*fam_u));
 
   //  commence taking
   //
@@ -2077,7 +2081,7 @@ u3a_walk_fore(u3_noun    a,
 
   //  initialize stack control; push argument
   //
-  u3a_pile_prep(&pil_u, sizeof(u3_noun));
+  u3a_pile_prep(&pil_u, sizeof(u3_noun), alignof(u3_noun));
   top  = u3a_push(&pil_u);
   *top = a;
 

--- a/pkg/noun/allocate.c
+++ b/pkg/noun/allocate.c
@@ -258,8 +258,8 @@ u3a_pile_prep(u3a_pile* pil_u, c3_w len_w, c3_w alg_w)
 {
   //  frame size, in words
   //
-  c3_w wor_w = (len_w + 3) >> 2;
-  c3_w wal_w = alg_w >> 2;
+  c3_w wor_w = (len_w + sizeof(c3_w) - 1) / sizeof(c3_w);
+  c3_w wal_w = alg_w / sizeof(c3_w);
   c3_o nor_o = u3a_is_north(u3R);
 
   pil_u->mov_ws = (c3y == nor_o) ? -wor_w :  wor_w;

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -229,6 +229,7 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
         c3_ws    mov_ws;
         c3_ws    off_ws;
         u3_post   top_p;
+        u3_post   beg_p;
 #ifdef U3_MEMORY_DEBUG
         u3a_road* rod_u;
 #endif
@@ -540,7 +541,9 @@ typedef struct {
           inline c3_o
           u3a_pile_done(const u3a_pile* pil_u)
           {
-            return (pil_u->top_p == u3R->cap_p) ? c3y : c3n;
+            if (pil_u->top_p != u3R->cap_p) return c3n;
+            u3R->cap_p = pil_u->beg_p;
+            return c3y;
           }
 
   /**  Functions.
@@ -613,7 +616,7 @@ u3a_post_info(u3_post);
         /* u3a_pile_prep(): initialize stack control.
         */
           void
-          u3a_pile_prep(u3a_pile* pil_u, c3_w len_w);
+          u3a_pile_prep(u3a_pile* pil_u, c3_w len_w, c3_w alg_w);
 
       /* C-style aligned allocation - *not* compatible with above.
       */

--- a/pkg/noun/hashtable.c
+++ b/pkg/noun/hashtable.c
@@ -397,7 +397,7 @@ _ch_node_del(u3h_slot* sot_w, u3_noun key, c3_w lef_w, c3_w rem_w)
     else {
       // shrink node in place; don't reallocate, we could be low on memory
       //
-      han_u->map_w &= ~(1 << bit_w);
+      han_u->map_w &= ~((c3_w)1 << bit_w);
       --len_w;
 
       for ( i_w = inx_w; i_w < len_w; i_w++ ) {
@@ -497,7 +497,7 @@ _ch_trim_node(u3h_root* har_u, u3h_slot* sot_w, c3_w lef_w, c3_w rem_w)
     else {
       // shrink node in place; don't reallocate, we could be low on memory
       //
-      han_u->map_w &= ~(1 << bit_w);
+      han_u->map_w &= ~((c3_w)1 << bit_w);
       --len_w;
 
       for ( i_w = inx_w; i_w < len_w; i_w++ ) {

--- a/pkg/noun/jets/b/reel.c
+++ b/pkg/noun/jets/b/reel.c
@@ -17,7 +17,7 @@
       u3_noun*   top;
       u3_noun   i, t = a;
 
-      u3a_pile_prep(&pil_u, sizeof(u3_noun));
+      u3a_pile_prep(&pil_u, sizeof(u3_noun), alignof(u3_noun));
 
       //  push list onto road stack
       //

--- a/pkg/noun/jets/c/clz.c
+++ b/pkg/noun/jets/c/clz.c
@@ -37,7 +37,7 @@ u3qc_clz(u3_atom boq, u3_atom sep, u3_atom a)
 
     if ( bit_w ) {
       wor_w  = u3r_word(wid_w, a);
-      wor_w &= (1 << bit_w) - 1;
+      wor_w &= (1u << bit_w) - 1;
 
       if ( wor_w ) {
         return bit_w - (32 - c3_lz_w(wor_w));

--- a/pkg/noun/jets/c/rep.c
+++ b/pkg/noun/jets/c/rep.c
@@ -12,7 +12,7 @@
 #define TAKEBITS(n,w) \
   ((n)==32) ? (w) :   \
   ((n)==0)  ? 0   :   \
-  ((w) & ((1 << (n)) - 1))
+  ((w) & (((c3_w)1 << (n)) - 1))
 
 /*
   Divide, rounding up.

--- a/pkg/noun/jets/c/rig.c
+++ b/pkg/noun/jets/c/rig.c
@@ -18,7 +18,7 @@ u3qc_rig_s(c3_g foq_g,
   else {
     c3_g dif_g = toq_g - foq_g;
 
-    sep_d += (1 << dif_g) - 1;
+    sep_d += (1u << dif_g) - 1;
     return sep_d >> dif_g;
   }
 }

--- a/pkg/noun/jets/c/rip.c
+++ b/pkg/noun/jets/c/rip.c
@@ -12,7 +12,7 @@
 #define TAKEBITS(n,w) \
   ((n)==32) ? (w) :   \
   ((n)==0)  ? 0   :   \
-  ((w) & ((1 << (n)) - 1))
+  ((w) & (((c3_w)1 << (n)) - 1))
 
 /*
   Divide, rounding up.
@@ -106,7 +106,7 @@ _block_rip(u3_atom bloq, u3_atom b)
 
     c3_w met_w   = u3r_met(bloq_g, b);                  //  num blocks in atom
     c3_w nbits_w = 1 << bloq_g;                         //  block size in bits
-    c3_w bmask_w = (1 << nbits_w) - 1;                  //  result mask
+    c3_w bmask_w = (1u << nbits_w) - 1;                  //  result mask
 
     for ( c3_w i_w = 0; i_w < met_w; i_w++ ) {          //  `i_w` is block index
       c3_w nex_w = i_w + 1;                             //  next block
@@ -127,7 +127,7 @@ _block_rip(u3_atom bloq, u3_atom b)
   c3_w    met_w = u3r_met(bloq_g, b);
   c3_w    len_w = u3r_met(5, b);
   c3_g    san_g = (bloq_g - 5);
-  c3_w    san_w = 1 << san_g;
+  c3_w    san_w = 1u << san_g;
   c3_w    dif_w = (met_w << san_g) - len_w;
   c3_w    tub_w = ((dif_w == 0) ? san_w : (san_w - dif_w));
 

--- a/pkg/noun/jets/e/json_de.c
+++ b/pkg/noun/jets/e/json_de.c
@@ -111,7 +111,7 @@ _parse(u3_atom txt)
   }
   json_open_buffer(sam_u, byt_y, len_w);
   json_set_allocator(sam_u, &loc_u);
-  u3a_pile_prep(pil_u, sizeof(u3qedj_coll));
+  u3a_pile_prep(pil_u, sizeof(u3qedj_coll), alignof(u3qedj_coll));
 
   //
   // core logic

--- a/pkg/noun/jets/e/loss.c
+++ b/pkg/noun/jets/e/loss.c
@@ -118,7 +118,7 @@
                (inx_w == 0) ? u3_nul
                             : u3k(loc_u->kad[inx_w - 1]));
     if ( loc_u->kct_w == inx_w ) {
-      u3_assert(loc_u->kct_w < (1 << 31));
+      u3_assert(loc_u->kct_w < ((c3_w)1 << 31));
       loc_u->kct_w++;
     } else {
       u3z(loc_u->kad[inx_w]);

--- a/pkg/noun/jets/e/parse.c
+++ b/pkg/noun/jets/e/parse.c
@@ -967,7 +967,7 @@
     _stir_pair* par_u;
     u3_noun     p_wag, puq_wag, quq_wag;
 
-    u3a_pile_prep(&pil_u, sizeof(*par_u));
+    u3a_pile_prep(&pil_u, sizeof(*par_u), __alignof__(*par_u));
 
     //  push incremental, successful [fel] parse results onto road stack
     //

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1022,7 +1022,7 @@ u3m_leap(c3_w pad_w)
   {
     u3a_pile pil_u;
     c3_p     ptr_p;
-    u3a_pile_prep(&pil_u, sizeof(u3a_road) + 15); // XX refactor to wiseof
+    u3a_pile_prep(&pil_u, sizeof(u3a_road) + 15, alignof(u3a_road)); // XX refactor to wiseof
     ptr_p = (c3_p)u3a_push(&pil_u);
 
     //  XX add push_once, push_once_aligned

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -1022,17 +1022,8 @@ u3m_leap(c3_w pad_w)
   {
     u3a_pile pil_u;
     c3_p     ptr_p;
-    u3a_pile_prep(&pil_u, sizeof(u3a_road) + 15, alignof(u3a_road)); // XX refactor to wiseof
+    u3a_pile_prep(&pil_u, sizeof(u3a_road), 16);
     ptr_p = (c3_p)u3a_push(&pil_u);
-
-    //  XX add push_once, push_once_aligned
-    //
-    if ( ptr_p & 15 ) {
-      ptr_p &= ~15;
-      if ( c3n == u3a_is_north(u3R) ) {
-        ptr_p += 16;
-      }
-    }
 
     rod_u = (void*)ptr_p;
     memset(rod_u, 0, sizeof(u3a_road));

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -514,7 +514,7 @@ _cr_sing(u3_noun a, u3_noun b)
 
   //  initialize stack control, push arguments onto the stack (none-frame)
   //
-  u3a_pile_prep(&pil_u, sizeof(eqframe));
+  u3a_pile_prep(&pil_u, sizeof(eqframe), alignof(eqframe));
   fam_u = _cr_sing_push(&pil_u, a, b);
 
   //  loop while arguments are on the stack
@@ -1811,7 +1811,7 @@ u3r_mug(u3_noun veb)
   //
   u3_assert( u3_none != veb );
 
-  u3a_pile_prep(&pil_u, sizeof(*fam_u));
+  u3a_pile_prep(&pil_u, sizeof(*fam_u), __alignof__(*fam_u));
 
   //  commence mugging
   //

--- a/pkg/noun/serial.c
+++ b/pkg/noun/serial.c
@@ -433,7 +433,7 @@ u3s_cue(u3_atom a)
 
   //  initialize stack control
   //
-  u3a_pile_prep(&pil_u, sizeof(*fam_u));
+  u3a_pile_prep(&pil_u, sizeof(*fam_u), __alignof__(*fam_u));
 
   //  commence cueing at bit-position 0
   //
@@ -589,7 +589,7 @@ _cs_cue_xeno(u3_cue_xeno* sil_u,
 
   //  initialize stack control
   //
-  u3a_pile_prep(&pil_u, sizeof(*fam_u));
+  u3a_pile_prep(&pil_u, sizeof(*fam_u), __alignof__(*fam_u));
 
   //  init bitstream-reader
   //
@@ -824,7 +824,7 @@ u3s_cue_bytes(c3_d len_d, const c3_y* byt_y)
 
   //  initialize stack control
   //
-  u3a_pile_prep(&pil_u, sizeof(*fam_u));
+  u3a_pile_prep(&pil_u, sizeof(*fam_u), __alignof__(*fam_u));
 
   //  initialize a hash table for dereferencing backrefs
   //

--- a/pkg/noun/xtract.h
+++ b/pkg/noun/xtract.h
@@ -71,12 +71,12 @@
       */
 #       define u3x_mas(a_w) ({                        \
           u3_assert( 1 < a_w );                       \
-          ( (a_w & ~(1 << u3x_dep(a_w))) | (1 << (u3x_dep(a_w) - 1)) ); })
+          ( (a_w & ~(1u << u3x_dep(a_w))) | (1u << (u3x_dep(a_w) - 1)) ); })
 
       /* u3x_peg(): connect two axes.
       */
 #       define u3x_peg(a_w, b_w) \
-          ( (a_w << u3x_dep(b_w)) | (b_w &~ (1 << u3x_dep(b_w))) )
+          ( (a_w << u3x_dep(b_w)) | (b_w &~ (1u << u3x_dep(b_w))) )
 
       /* u3x_cell(): divide `a` as a cell `[b c]`.
       */

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -137,7 +137,7 @@ u3_unix_cane(const c3_c* pax_c)
       return 0;
     }
     pax_c = strchr(pax_c, '/');
-  } while ( 0 != pax_c++ );
+  } while ( NULL != pax_c && pax_c++ );
   return 1;
 }
 

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1918,8 +1918,9 @@ u3_mars_make(u3_mars* mar_u)
 *
 */
 c3_o
-u3_mars_boot(u3_mars* mar_u, c3_d len_d, c3_y* hun_y)
+u3_mars_boot(void* ram_u, c3_d len_d, c3_y* hun_y)
 {
+  u3_mars*     mar_u = ram_u;
   u3_disk*     log_u = mar_u->log_u;
   u3_boot_opts inp_u;
   u3_meta      met_u;

--- a/pkg/vere/mars.h
+++ b/pkg/vere/mars.h
@@ -64,7 +64,7 @@
     /* u3_mars_boot(): boot a new ship.
     */
       c3_o
-      u3_mars_boot(u3_mars* mar_u, c3_d len_d, c3_y* hun_y);
+      u3_mars_boot(void* ram_u, c3_d len_d, c3_y* hun_y);
 
     /* u3_mars_load(): load pier.
     */


### PR DESCRIPTION
Strange CI behavior in #1071 prompted me to run CI tests locally with UBSan, and fix all places where it complained.

The most substantial fix is introduction of alignment in `u3a_pile`. I have a faint memory that something like this was supposed to be added to Vere but was never merged, so let's discuss it again. In `u3a_pile_prep` we align the stack and store both stack offsets before and after the alignment. In `u3a_pile_done` we compare `cap_p` with the post-alignment value, and if the stack is empty we restore it to the pre-alignment value. Alignment is assumed to be a power of two, and the input alignment is in bytes, just like the length.

In unix.c ubsan complained that we increment a null pointer, which is supposed to be illegal? I refactored it slightly so that we formally increment it only if it is not null.

In mars.c the function pointer type and the actual function were technically incompatible.

The rest is `1 << X` type fixes.