### PR TITLE
build: updates zig to `0.16.0`

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
           # 8GB cache limit chosen at random
           cache-size-limit: 8192
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ MODULE.bazel.lock
 # Zig
 **/.zig-cache
 **/zig-out
+**/zig-pkg
 
 # clangd
 **/.cache

--- a/build.zig
+++ b/build.zig
@@ -24,35 +24,33 @@ const CdbGenStep = struct {
 
     fn make(step: *std.Build.Step, _: std.Build.Step.MakeOptions) anyerror!void {
         const self: *CdbGenStep = @fieldParentPtr("step", step);
+        const io = self.b.graph.io;
 
-        var cwd = std.fs.cwd();
+        var cwd = std.Io.Dir.cwd();
 
         // Open fragments directory (created by zig via -gen-cdb-fragment-path).
-        var dir = cwd.openDir(self.frags_dir, .{ .iterate = true }) catch {
+        var dir = cwd.openDir(io, self.frags_dir, .{ .iterate = true }) catch {
             return;
         };
-        defer dir.close();
+        defer dir.close(io);
 
         // Write compile_commands.json as a JSON array of fragment objects.
-        var out_file = try cwd.createFile(self.out_path, .{ .truncate = true });
-        defer out_file.close();
+        var out_file = try cwd.createFile(io, self.out_path, .{ .truncate = true });
+        defer out_file.close(io);
         var write_buffer: [4096]u8 = undefined;
 
-        var ww = out_file.writer(&write_buffer);
+        var ww = out_file.writer(io, &write_buffer);
         const w = &ww.interface;
 
         try w.writeByte('[');
 
         var it = dir.iterate();
         var first: bool = true;
-        while (try it.next()) |ent| {
+        while (try it.next(io)) |ent| {
             if (ent.kind != .file) continue;
 
             // zig emits one JSON object per file
-            var frag_file = try dir.openFile(ent.name, .{});
-            defer frag_file.close();
-
-            const frag = try frag_file.readToEndAlloc(self.b.allocator, 1024 * 1024);
+            const frag = try dir.readFileAlloc(io, ent.name, self.b.allocator, .limited(1024 * 1024));
             defer self.b.allocator.free(frag);
 
             // skip empty/whitespace-only
@@ -67,7 +65,7 @@ const CdbGenStep = struct {
         try w.writeAll("]\n");
         try w.flush();
 
-        cwd.deleteTree(self.frags_dir) catch {};
+        cwd.deleteTree(io, self.frags_dir) catch {};
     }
 };
 
@@ -198,10 +196,11 @@ pub fn build(b: *std.Build) !void {
     const tracy_no_exit = b.option(bool, "tracy-no-exit", "Wait for profiler connection before exiting") orelse false;
 
     // Parse short git rev
-    var file = try std.fs.cwd().openFile(".git/logs/HEAD", .{});
-    defer file.close();
+    const io = b.graph.io;
+    var file = try std.Io.Dir.cwd().openFile(io, ".git/logs/HEAD", .{});
+    defer file.close(io);
     var buf: [4096]u8 = undefined;
-    var reader = file.reader(&buf);
+    var reader = file.reader(io, &buf);
     var last_line: [4096]u8 = undefined;
     while (reader.interface.takeDelimiterInclusive('\n')) |line| {
         if (line.len > 0)
@@ -529,7 +528,7 @@ fn buildBinary(
     }
 
     if (t.os.tag == .windows) {
-        urbit.linkSystemLibrary("ws2_32"); // WSA*, socket, htons, inet_*, gethostbyname, etc.
+        urbit.root_module.linkSystemLibrary("ws2_32", .{}); // WSA*, socket, htons, inet_*, gethostbyname, etc.
     }
 
     const target_query: std.Target.Query = .{
@@ -554,67 +553,67 @@ fn buildBinary(
             .optimize = optimize,
         });
         if (macos_sdk != null) {
-            urbit.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-            urbit.addLibraryPath(macos_sdk.?.path("usr/lib"));
-            urbit.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+            urbit.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            urbit.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            urbit.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
         }
     }
 
-    urbit.linkLibC();
+    urbit.root_module.link_libc = true;
 
-    urbit.linkLibrary(pkg_vere.artifact("vere"));
-    urbit.linkLibrary(pkg_noun.artifact("noun"));
-    urbit.linkLibrary(pkg_past.artifact("past"));
-    urbit.linkLibrary(pkg_c3.artifact("c3"));
-    urbit.linkLibrary(pkg_ur.artifact("ur"));
+    urbit.root_module.linkLibrary(pkg_vere.artifact("vere"));
+    urbit.root_module.linkLibrary(pkg_noun.artifact("noun"));
+    urbit.root_module.linkLibrary(pkg_past.artifact("past"));
+    urbit.root_module.linkLibrary(pkg_c3.artifact("c3"));
+    urbit.root_module.linkLibrary(pkg_ur.artifact("ur"));
 
-    urbit.linkLibrary(gmp.artifact("gmp"));
+    urbit.root_module.linkLibrary(gmp.artifact("gmp"));
 
-    urbit.linkLibrary(h2o.artifact("h2o"));
-    urbit.linkLibrary(curl.artifact("curl"));
-    urbit.linkLibrary(libuv.artifact("libuv"));
-    urbit.linkLibrary(lmdb.artifact("lmdb"));
-    urbit.linkLibrary(openssl.artifact("ssl"));
+    urbit.root_module.linkLibrary(h2o.artifact("h2o"));
+    urbit.root_module.linkLibrary(curl.artifact("curl"));
+    urbit.root_module.linkLibrary(libuv.artifact("libuv"));
+    urbit.root_module.linkLibrary(lmdb.artifact("lmdb"));
+    urbit.root_module.linkLibrary(openssl.artifact("ssl"));
     if (t.os.tag != .windows)
-        urbit.linkLibrary(sigsegv.artifact("sigsegv"));
-    urbit.linkLibrary(urcrypt.artifact("urcrypt"));
-    urbit.linkLibrary(whereami.artifact("whereami"));
-    urbit.linkLibrary(wasm3.artifact("wasm3"));
+        urbit.root_module.linkLibrary(sigsegv.artifact("sigsegv"));
+    urbit.root_module.linkLibrary(urcrypt.artifact("urcrypt"));
+    urbit.root_module.linkLibrary(whereami.artifact("whereami"));
+    urbit.root_module.linkLibrary(wasm3.artifact("wasm3"));
 
     if (cfg.tracy_enable) {
-        urbit.linkLibrary(tracy.?.artifact("tracy"));
-        urbit.addIncludePath(tracy.?.path(""));
+        urbit.root_module.linkLibrary(tracy.?.artifact("tracy"));
+        urbit.root_module.addIncludePath(tracy.?.path(""));
     }
 
     if (t.os.tag.isDarwin()) {
         // Requires llvm@18 homebrew installation
         if (cfg.asan or cfg.ubsan)
-            urbit.addLibraryPath(.{
+            urbit.root_module.addLibraryPath(.{
                 .cwd_relative = "/opt/homebrew/opt/llvm@18/lib/clang/18/lib/darwin",
             });
-        if (cfg.asan) urbit.linkSystemLibrary("clang_rt.asan_osx_dynamic");
-        if (cfg.ubsan) urbit.linkSystemLibrary("clang_rt.ubsan_osx_dynamic");
+        if (cfg.asan) urbit.root_module.linkSystemLibrary("clang_rt.asan_osx_dynamic", .{});
+        if (cfg.ubsan) urbit.root_module.linkSystemLibrary("clang_rt.ubsan_osx_dynamic", .{});
     }
 
     if (t.os.tag == .linux) {
         // Requires llvm-18 and clang-18 installation
         if (cfg.asan or cfg.ubsan)
-            urbit.addLibraryPath(.{
+            urbit.root_module.addLibraryPath(.{
                 .cwd_relative = "/usr/lib/clang/18/lib/linux",
             });
         if (t.cpu.arch == .x86_64) {
-            if (cfg.asan) urbit.linkSystemLibrary("clang_rt.asan-x86_64");
+            if (cfg.asan) urbit.root_module.linkSystemLibrary("clang_rt.asan-x86_64", .{});
             if (cfg.ubsan)
-                urbit.linkSystemLibrary("clang_rt.ubsan_standalone-x86_64");
+                urbit.root_module.linkSystemLibrary("clang_rt.ubsan_standalone-x86_64", .{});
         }
         if (t.cpu.arch == .aarch64) {
-            if (cfg.asan) urbit.linkSystemLibrary("clang_rt.asan-aarch64");
+            if (cfg.asan) urbit.root_module.linkSystemLibrary("clang_rt.asan-aarch64", .{});
             if (cfg.ubsan)
-                urbit.linkSystemLibrary("clang_rt.ubsan_standalone-aarch64");
+                urbit.root_module.linkSystemLibrary("clang_rt.ubsan_standalone-aarch64", .{});
         }
     }
 
-    urbit.addCSourceFiles(.{
+    urbit.root_module.addCSourceFiles(.{
         .root = b.path("pkg/vere"),
         .files = &.{
             "main.c",
@@ -780,36 +779,43 @@ fn buildBinary(
                     .optimize = optimize,
                 });
                 if (macos_sdk != null) {
-                    test_exe.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-                    test_exe.addLibraryPath(macos_sdk.?.path("usr/lib"));
-                    test_exe.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+                    test_exe.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+                    test_exe.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+                    test_exe.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
                 }
             }
 
             if (t.os.tag == .windows) {
-                test_exe.linkSystemLibrary("ws2_32");
+                test_exe.root_module.linkSystemLibrary("ws2_32", .{});
             }
 
             if (t.os.tag.isDarwin()) {
                 // Requires llvm@18 homebrew installation
                 if (cfg.asan or cfg.ubsan)
-                    test_exe.addLibraryPath(.{
+                    test_exe.root_module.addLibraryPath(.{
                         .cwd_relative = "/opt/homebrew/opt/llvm@18/lib/clang/18/lib/darwin",
                     });
-                if (cfg.asan) test_exe.linkSystemLibrary("clang_rt.asan_osx_dynamic");
-                if (cfg.ubsan) test_exe.linkSystemLibrary("clang_rt.ubsan_osx_dynamic");
+                if (cfg.asan) test_exe.root_module.linkSystemLibrary("clang_rt.asan_osx_dynamic", .{});
+                if (cfg.ubsan) test_exe.root_module.linkSystemLibrary("clang_rt.ubsan_osx_dynamic", .{});
             }
 
             test_exe.stack_size = 0;
-            test_exe.linkLibC();
+            test_exe.root_module.link_libc = true;
             for (tst.deps) |dep| {
-                test_exe.linkLibrary(dep);
+                test_exe.root_module.linkLibrary(dep);
+            }
+            //  events-test #includes events.c, which #includes "murmur3.h".
+            //  the noun artifact already links murmur3, but the header isn't
+            //  on the test's compile include path — add it explicitly.
+            //
+            if (std.mem.eql(u8, tst.name, "events-test")) {
+                test_exe.root_module.addIncludePath(b.path("ext/murmur3/vendor"));
             }
             if (cfg.tracy_enable) {
-                test_exe.linkLibrary(tracy.?.artifact("tracy"));
-                test_exe.addIncludePath(tracy.?.path(""));
+                test_exe.root_module.linkLibrary(tracy.?.artifact("tracy"));
+                test_exe.root_module.addIncludePath(tracy.?.path(""));
             }
-            test_exe.addCSourceFiles(.{
+            test_exe.root_module.addCSourceFiles(.{
                 .files = &.{tst.file},
                 .flags = urbit_flags.items,
             });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -57,8 +57,8 @@
             .path = "./ext/whereami",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
-            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
+            .url = "https://github.com/allyourcodebase/zlib/archive/d3b5519d3b73616a6bfece0712f080029d2a9244.tar.gz",
+            .hash = "zlib-1.3.2-ZZQ7lc8NAAAHm9MDfplvwoesXvk4tVm6VCsiI8KnIbT0",
         },
         .wasm3 = .{
             .path = "./ext/wasm3",

--- a/ext/avahi/build.zig
+++ b/ext/avahi/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
             .patch = 0,
         },
     });
-    expat.linkLibC();
+    expat.root_module.link_libc = true;
 
     const expat_cmake_config = b.addConfigHeader(.{
         .style = .{
@@ -41,10 +41,10 @@ pub fn build(b: *std.Build) void {
         .SIZE_T = "unsigned",
     });
 
-    expat.addConfigHeader(expat_cmake_config);
-    expat.addIncludePath(expat_c.path("lib"));
+    expat.root_module.addConfigHeader(expat_cmake_config);
+    expat.root_module.addIncludePath(expat_c.path("lib"));
 
-    expat.addCSourceFiles(.{
+    expat.root_module.addCSourceFiles(.{
         .root = expat_c.path("lib"),
         .files = &.{
             "xmlrole.c",
@@ -76,8 +76,8 @@ pub fn build(b: *std.Build) void {
             .patch = 0,
         },
     });
-    dbus.linkLibC();
-    dbus.linkLibrary(expat);
+    dbus.root_module.link_libc = true;
+    dbus.root_module.linkLibrary(expat);
 
     dbus.root_module.addCMacro("HAVE_ERRNO_H", "");
     dbus.root_module.addCMacro("VERSION", "1.14.8");
@@ -334,13 +334,13 @@ pub fn build(b: *std.Build) void {
         },
     );
 
-    dbus.addConfigHeader(dbus_config_h);
-    dbus.addConfigHeader(dbus_arch_deps_h);
+    dbus.root_module.addConfigHeader(dbus_config_h);
+    dbus.root_module.addConfigHeader(dbus_arch_deps_h);
 
-    dbus.addIncludePath(dbus_c.path(""));
-    dbus.addIncludePath(dbus_c.path("dbus"));
+    dbus.root_module.addIncludePath(dbus_c.path(""));
+    dbus.root_module.addIncludePath(dbus_c.path("dbus"));
 
-    dbus.addCSourceFiles(.{
+    dbus.root_module.addCSourceFiles(.{
         .root = dbus_c.path("dbus"),
         .files = &.{
             // DBUS_LIB_SOURCES
@@ -392,7 +392,7 @@ pub fn build(b: *std.Build) void {
 
     // Platform specific sources
     if (target.result.os.tag == .windows) {
-        dbus.addCSourceFiles(.{
+        dbus.root_module.addCSourceFiles(.{
             .root = dbus_c.path("dbus"),
             .files = &.{
                 // LIB
@@ -410,7 +410,7 @@ pub fn build(b: *std.Build) void {
             },
         });
     } else {
-        dbus.addCSourceFiles(.{
+        dbus.root_module.addCSourceFiles(.{
             .root = dbus_c.path("dbus"),
             .files = &.{
                 // LIB
@@ -525,8 +525,8 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    avahi.linkLibC();
-    avahi.linkLibrary(dbus);
+    avahi.root_module.link_libc = true;
+    avahi.root_module.linkLibrary(dbus);
 
     avahi.root_module.addCMacro("GETTEXT_PACKAGE", "\"avahi\"");
 
@@ -685,10 +685,10 @@ pub fn build(b: *std.Build) void {
     //     .uid_t = null,
     // });
 
-    avahi.addConfigHeader(avahi_config_h);
-    avahi.addIncludePath(avahi_c.path(""));
+    avahi.root_module.addConfigHeader(avahi_config_h);
+    avahi.root_module.addIncludePath(avahi_c.path(""));
 
-    avahi.addCSourceFiles(.{
+    avahi.root_module.addCSourceFiles(.{
         .root = avahi_c.path(""),
         .files = &.{
             // "avahi-autoipd/iface-bsd.c",

--- a/ext/backtrace/build.zig
+++ b/ext/backtrace/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     var config_h: *std.Build.Step.ConfigHeader = undefined;
 
@@ -165,11 +165,11 @@ pub fn build(b: *std.Build) void {
         .BACKTRACE_SUPPORTS_DATA = 1,
     });
 
-    lib.addConfigHeader(config_h);
-    lib.addConfigHeader(backtrace_supported_h);
-    lib.addIncludePath(dep_c.path(""));
+    lib.root_module.addConfigHeader(config_h);
+    lib.root_module.addConfigHeader(backtrace_supported_h);
+    lib.root_module.addIncludePath(dep_c.path(""));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path(""),
         .files = &.{
             // libbacktrace_la_SOURCES

--- a/ext/curl/build.zig
+++ b/ext/curl/build.zig
@@ -19,9 +19,9 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    curl.linkLibC();
-    curl.linkLibrary(openssl.artifact("ssl"));
-    curl.linkLibrary(openssl.artifact("crypto"));
+    curl.root_module.link_libc = true;
+    curl.root_module.linkLibrary(openssl.artifact("ssl"));
+    curl.root_module.linkLibrary(openssl.artifact("crypto"));
 
     curl.root_module.addCMacro("BUILDING_LIBCURL", "");
     curl.root_module.addCMacro("CURL_STATICLIB", "1");
@@ -67,7 +67,7 @@ pub fn build(b: *std.Build) void {
     // curl.root_module.addCMacro("CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG", "1");
 
     if (target.result.os.tag == .windows) {
-        curl.linkSystemLibrary("bcrypt");
+        curl.root_module.linkSystemLibrary("bcrypt", .{});
     } else {
         curl.root_module.addCMacro("CURL_EXTERN_SYMBOL", "__attribute__ ((__visibility__ (\"default\"))");
 
@@ -219,10 +219,10 @@ pub fn build(b: *std.Build) void {
         curl.root_module.addCMacro("_FILE_OFFSET_BITS", "64");
     }
 
-    curl.addIncludePath(curl_c.path("lib"));
-    curl.addIncludePath(curl_c.path("include"));
+    curl.root_module.addIncludePath(curl_c.path("lib"));
+    curl.root_module.addIncludePath(curl_c.path("include"));
 
-    curl.addCSourceFiles(.{
+    curl.root_module.addCSourceFiles(.{
         .root = curl_c.path("lib"),
         .files = &.{
             "vauth/krb5_sspi.c",

--- a/ext/gmp/build.zig
+++ b/ext/gmp/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     // TODO: Finish this
     if (t.os.tag != .windows) {
@@ -35,33 +35,33 @@ pub fn build(b: *std.Build) void {
             .CFLAGS = "-O2 -pedantic -march=armv8-a",
         });
 
-        lib.addConfigHeader(gmp_h);
+        lib.root_module.addConfigHeader(gmp_h);
         lib.installConfigHeader(gmp_h);
     }
 
     // Static headers
-    lib.addIncludePath(dep_c.path("."));
-    lib.addIncludePath(dep_c.path("mpf"));
-    lib.addIncludePath(dep_c.path("mpn"));
-    lib.addIncludePath(dep_c.path("mpq"));
-    lib.addIncludePath(dep_c.path("mpz"));
-    lib.addIncludePath(dep_c.path("printf"));
-    lib.addIncludePath(dep_c.path("rand"));
-    lib.addIncludePath(dep_c.path("scanf"));
+    lib.root_module.addIncludePath(dep_c.path("."));
+    lib.root_module.addIncludePath(dep_c.path("mpf"));
+    lib.root_module.addIncludePath(dep_c.path("mpn"));
+    lib.root_module.addIncludePath(dep_c.path("mpq"));
+    lib.root_module.addIncludePath(dep_c.path("mpz"));
+    lib.root_module.addIncludePath(dep_c.path("printf"));
+    lib.root_module.addIncludePath(dep_c.path("rand"));
+    lib.root_module.addIncludePath(dep_c.path("scanf"));
     if (t.cpu.arch.isAARCH64()) {
-        lib.addIncludePath(dep_c.path("mpn/arm64"));
+        lib.root_module.addIncludePath(dep_c.path("mpn/arm64"));
     } else if (t.cpu.arch.isX86()) {
-        lib.addIncludePath(dep_c.path("mpn/x86_64"));
+        lib.root_module.addIncludePath(dep_c.path("mpn/x86_64"));
     }
 
     // Generated Sources
     if (t.os.tag == .macos and t.cpu.arch == .aarch64) {
-        lib.addIncludePath(b.path("gen/aarch64-macos"));
-        lib.addIncludePath(b.path("gen/aarch64-macos/mpn"));
+        lib.root_module.addIncludePath(b.path("gen/aarch64-macos"));
+        lib.root_module.addIncludePath(b.path("gen/aarch64-macos/mpn"));
         for (aarch64_macos_asm_sources) |rel_path| {
-            lib.addAssemblyFile(b.path(rel_path));
+            lib.root_module.addAssemblyFile(b.path(rel_path));
         }
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/aarch64-macos"),
             .files = &.{
                 "mpn/mp_bases.c",
@@ -73,12 +73,12 @@ pub fn build(b: *std.Build) void {
         });
     }
     if (t.os.tag == .macos and t.cpu.arch == .x86_64) {
-        lib.addIncludePath(b.path("gen/x86_64-macos"));
-        lib.addIncludePath(b.path("gen/x86_64-macos/mpn"));
+        lib.root_module.addIncludePath(b.path("gen/x86_64-macos"));
+        lib.root_module.addIncludePath(b.path("gen/x86_64-macos/mpn"));
         for (x86_64_macos_asm_sources) |rel_path| {
-            lib.addAssemblyFile(b.path(rel_path));
+            lib.root_module.addAssemblyFile(b.path(rel_path));
         }
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/x86_64-macos"),
             .files = &.{
                 "mpn/mp_bases.c",
@@ -90,12 +90,12 @@ pub fn build(b: *std.Build) void {
         });
     }
     if (t.os.tag == .linux and t.cpu.arch == .aarch64) {
-        lib.addIncludePath(b.path("gen/aarch64-linux"));
-        lib.addIncludePath(b.path("gen/aarch64-linux/mpn"));
+        lib.root_module.addIncludePath(b.path("gen/aarch64-linux"));
+        lib.root_module.addIncludePath(b.path("gen/aarch64-linux/mpn"));
         for (aarch64_linux_asm_sources) |rel_path| {
-            lib.addAssemblyFile(b.path(rel_path));
+            lib.root_module.addAssemblyFile(b.path(rel_path));
         }
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/aarch64-linux"),
             .files = &.{
                 "mpn/mp_bases.c",
@@ -107,12 +107,12 @@ pub fn build(b: *std.Build) void {
         });
     }
     if (t.os.tag == .linux and t.cpu.arch == .x86_64) {
-        lib.addIncludePath(b.path("gen/x86_64-linux"));
-        lib.addIncludePath(b.path("gen/x86_64-linux/mpn"));
+        lib.root_module.addIncludePath(b.path("gen/x86_64-linux"));
+        lib.root_module.addIncludePath(b.path("gen/x86_64-linux/mpn"));
         for (x86_64_linux_asm_sources) |rel_path| {
-            lib.addAssemblyFile(b.path(rel_path));
+            lib.root_module.addAssemblyFile(b.path(rel_path));
         }
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/x86_64-linux"),
             .files = &.{
                 "mpn/mp_bases.c",
@@ -125,12 +125,12 @@ pub fn build(b: *std.Build) void {
     }
 
     if (t.os.tag == .windows and t.cpu.arch == .x86_64) {
-        lib.addIncludePath(b.path("gen/x86_64-windows"));
-        lib.addIncludePath(b.path("gen/x86_64-windows/mpn"));
+        lib.root_module.addIncludePath(b.path("gen/x86_64-windows"));
+        lib.root_module.addIncludePath(b.path("gen/x86_64-windows/mpn"));
         for (x86_64_windows_asm_sources) |rel_path| {
-            lib.addAssemblyFile(b.path(rel_path));
+            lib.root_module.addAssemblyFile(b.path(rel_path));
         }
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/x86_64-windows"),
             .files = &.{
                 "mpn/mp_bases.c",
@@ -143,7 +143,7 @@ pub fn build(b: *std.Build) void {
     }
 
     // Generic C Sources
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path(""),
         .files = &generic_c_sources,
         .flags = &.{
@@ -152,7 +152,7 @@ pub fn build(b: *std.Build) void {
     });
 
     // These files need to be compiles twice with different macros
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path(""),
         .files = &.{
             "mpn/generic/sec_div.c",
@@ -166,7 +166,7 @@ pub fn build(b: *std.Build) void {
             "-DOPERATION_sec_add_1", // sec_aors_1.c
         },
     });
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path(""),
         .files = &.{
             "mpn/generic/sec_div.c",

--- a/ext/h2o/build.zig
+++ b/ext/h2o/build.zig
@@ -45,11 +45,11 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    cloexec.linkLibC();
+    cloexec.root_module.link_libc = true;
 
-    cloexec.addIncludePath(h2o_c.path("deps/cloexec"));
+    cloexec.root_module.addIncludePath(h2o_c.path("deps/cloexec"));
 
-    cloexec.addCSourceFiles(.{
+    cloexec.root_module.addCSourceFiles(.{
         .root = h2o_c.path("deps/cloexec"),
         .files = &.{"cloexec.c"},
         .flags = &.{
@@ -68,16 +68,16 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    klib.linkLibrary(curl.artifact("curl"));
-    klib.linkLibrary(zlib.artifact("z"));
-    klib.linkLibC();
+    klib.root_module.linkLibrary(curl.artifact("curl"));
+    klib.root_module.linkLibrary(zlib.artifact("z"));
+    klib.root_module.link_libc = true;
 
-    klib.addIncludePath(h2o_c.path("deps/klib"));
+    klib.root_module.addIncludePath(h2o_c.path("deps/klib"));
     if (t.cpu.arch == .aarch64) {
-        klib.addIncludePath(sse2neon_c.path("."));
+        klib.root_module.addIncludePath(sse2neon_c.path("."));
     }
 
-    klib.addCSourceFiles(.{
+    klib.root_module.addCSourceFiles(.{
         .root = h2o_c.path("deps/klib"),
         .files = &.{
             "bgzf.c",
@@ -97,7 +97,7 @@ pub fn build(b: *std.Build) !void {
             "-fno-sanitize=all",
         },
     });
-    klib.addCSourceFiles(.{
+    klib.root_module.addCSourceFiles(.{
         .root = patches.path("h2o-2.2.6/deps/klib"),
         .files = &.{
             "ksw.c",
@@ -121,11 +121,11 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    libgkc.linkLibC();
+    libgkc.root_module.link_libc = true;
 
-    libgkc.addIncludePath(h2o_c.path("deps/libgkc"));
+    libgkc.root_module.addIncludePath(h2o_c.path("deps/libgkc"));
 
-    libgkc.addCSourceFiles(.{
+    libgkc.root_module.addCSourceFiles(.{
         .root = h2o_c.path("deps/libgkc"),
         .files = &.{"gkc.c"},
         .flags = &.{
@@ -140,11 +140,11 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    libyrmcds.linkLibC();
+    libyrmcds.root_module.link_libc = true;
 
-    libyrmcds.addIncludePath(h2o_c.path("deps/libyrmcds"));
+    libyrmcds.root_module.addIncludePath(h2o_c.path("deps/libyrmcds"));
 
-    libyrmcds.addCSourceFiles(.{
+    libyrmcds.root_module.addCSourceFiles(.{
         .root = h2o_c.path("deps/libyrmcds"),
         .files = &.{
             "close.c",
@@ -178,14 +178,14 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    picohttpparser.linkLibC();
+    picohttpparser.root_module.link_libc = true;
 
-    picohttpparser.addIncludePath(h2o_c.path("deps/picohttpparser"));
+    picohttpparser.root_module.addIncludePath(h2o_c.path("deps/picohttpparser"));
     if (t.cpu.arch == .aarch64) {
-        picohttpparser.addIncludePath(sse2neon_c.path("."));
+        picohttpparser.root_module.addIncludePath(sse2neon_c.path("."));
     }
 
-    picohttpparser.addCSourceFiles(.{
+    picohttpparser.root_module.addCSourceFiles(.{
         .root = patches.path("h2o-2.2.6/deps/picohttpparser"),
         .files = &.{"picohttpparser.c"},
         .flags = &.{
@@ -205,12 +205,12 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    cifra.linkLibC();
+    cifra.root_module.link_libc = true;
 
-    cifra.addIncludePath(h2o_c.path("deps/picotls/deps/cifra/src"));
-    cifra.addIncludePath(h2o_c.path("deps/picotls/deps/cifra/src/ext"));
+    cifra.root_module.addIncludePath(h2o_c.path("deps/picotls/deps/cifra/src"));
+    cifra.root_module.addIncludePath(h2o_c.path("deps/picotls/deps/cifra/src/ext"));
 
-    cifra.addCSourceFiles(.{
+    cifra.root_module.addCSourceFiles(.{
         .root = h2o_c.path("deps/picotls/deps/cifra/src"),
         .files = &.{
             "aes.c",
@@ -252,11 +252,11 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    micro_ecc.linkLibC();
+    micro_ecc.root_module.link_libc = true;
 
-    micro_ecc.addIncludePath(h2o_c.path("deps/picotls/deps/micro-ecc"));
+    micro_ecc.root_module.addIncludePath(h2o_c.path("deps/picotls/deps/micro-ecc"));
 
-    micro_ecc.addCSourceFiles(.{
+    micro_ecc.root_module.addCSourceFiles(.{
         .root = h2o_c.path("deps/picotls/deps/micro-ecc"),
         .files = &.{"uECC.c"},
     });
@@ -270,17 +270,17 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    picotls.linkLibrary(openssl.artifact("ssl"));
-    picotls.linkLibrary(cifra);
-    picotls.linkLibrary(micro_ecc);
-    picotls.linkLibC();
+    picotls.root_module.linkLibrary(openssl.artifact("ssl"));
+    picotls.root_module.linkLibrary(cifra);
+    picotls.root_module.linkLibrary(micro_ecc);
+    picotls.root_module.link_libc = true;
 
-    picotls.addIncludePath(h2o_c.path("deps/picotls/include"));
+    picotls.root_module.addIncludePath(h2o_c.path("deps/picotls/include"));
     if (t.cpu.arch == .aarch64) {
-        picotls.addIncludePath(sse2neon_c.path("."));
+        picotls.root_module.addIncludePath(sse2neon_c.path("."));
     }
 
-    picotls.addCSourceFiles(.{
+    picotls.root_module.addCSourceFiles(.{
         .root = h2o_c.path("deps/picotls/lib"),
         .files = &.{
             "asn1.c",
@@ -310,12 +310,12 @@ pub fn build(b: *std.Build) !void {
     //     .optimize = optimize,
     // });
 
-    // ssl_conservatory.linkLibrary(openssl.artifact("ssl"));
-    // ssl_conservatory.linkLibC();
+    // ssl_conservatory.root_module.linkLibrary(openssl.artifact("ssl"));
+    // ssl_conservatory.root_module.link_libc = true;
 
-    // ssl_conservatory.addIncludePath(h2o_c.path("deps/ssl-conservatory/openssl"));
+    // ssl_conservatory.root_module.addIncludePath(h2o_c.path("deps/ssl-conservatory/openssl"));
 
-    // ssl_conservatory.addCSourceFiles(.{
+    // ssl_conservatory.root_module.addCSourceFiles(.{
     //     .root = h2o_c.path("deps/ssl-conservatory/openssl"),
     //     .files = &.{"openssl_hostname_validation.c"},
     // });
@@ -327,26 +327,26 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    h2o.linkLibrary(openssl.artifact("ssl"));
-    h2o.linkLibrary(openssl.artifact("crypto"));
-    h2o.linkLibrary(zlib.artifact("z"));
-    h2o.linkLibrary(libuv.artifact("libuv"));
-    // h2o.linkLibrary(cloexec);
-    // h2o.linkLibrary(klib);
-    h2o.linkLibrary(libgkc);
-    // h2o.linkLibrary(libyrmcds);
-    h2o.linkLibrary(picohttpparser);
-    h2o.linkLibrary(picotls);
-    // h2o.linkLibrary(ssl_conservatory);
-    h2o.linkLibC();
+    h2o.root_module.linkLibrary(openssl.artifact("ssl"));
+    h2o.root_module.linkLibrary(openssl.artifact("crypto"));
+    h2o.root_module.linkLibrary(zlib.artifact("z"));
+    h2o.root_module.linkLibrary(libuv.artifact("libuv"));
+    // h2o.root_module.linkLibrary(cloexec);
+    // h2o.root_module.linkLibrary(klib);
+    h2o.root_module.linkLibrary(libgkc);
+    // h2o.root_module.linkLibrary(libyrmcds);
+    h2o.root_module.linkLibrary(picohttpparser);
+    h2o.root_module.linkLibrary(picotls);
+    // h2o.root_module.linkLibrary(ssl_conservatory);
+    h2o.root_module.link_libc = true;
 
-    h2o.addIncludePath(h2o_c.path("deps/golombset"));
-    h2o.addIncludePath(h2o_c.path("deps/yoml"));
+    h2o.root_module.addIncludePath(h2o_c.path("deps/golombset"));
+    h2o.root_module.addIncludePath(h2o_c.path("deps/yoml"));
 
-    h2o.addIncludePath(h2o_c.path("include"));
-    h2o.addIncludePath(h2o_c.path("include/h2o"));
-    h2o.addIncludePath(h2o_c.path("include/h2o/socket"));
-    h2o.addIncludePath(h2o_c.path("deps/klib"));
+    h2o.root_module.addIncludePath(h2o_c.path("include"));
+    h2o.root_module.addIncludePath(h2o_c.path("include/h2o"));
+    h2o.root_module.addIncludePath(h2o_c.path("include/h2o/socket"));
+    h2o.root_module.addIncludePath(h2o_c.path("deps/klib"));
 
     h2o.root_module.addCMacro("H2O_NO_HTTP3", "");
     h2o.root_module.addCMacro("H2O_NO_REDIS", "");
@@ -358,7 +358,7 @@ pub fn build(b: *std.Build) !void {
         h2o.root_module.addCMacro("H2O_NO_UNIX_SOCKETS", "");
     }
 
-    h2o.addCSourceFiles(.{
+    h2o.root_module.addCSourceFiles(.{
         .root = h2o_c.path("lib"),
         .files = &.{
             "common/cache.c",

--- a/ext/h2o/build.zig.zon
+++ b/ext/h2o/build.zig.zon
@@ -17,8 +17,8 @@
             .path = "../curl",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
-            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
+            .url = "https://github.com/allyourcodebase/zlib/archive/d3b5519d3b73616a6bfece0712f080029d2a9244.tar.gz",
+            .hash = "zlib-1.3.2-ZZQ7lc8NAAAHm9MDfplvwoesXvk4tVm6VCsiI8KnIbT0",
         },
         .sse2neon = .{
             .url = "https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.5.1.tar.gz",

--- a/ext/libuv/build.zig
+++ b/ext/libuv/build.zig
@@ -15,10 +15,10 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    uv.linkLibC();
+    uv.root_module.link_libc = true;
 
-    uv.addIncludePath(uv_c.path("src"));
-    uv.addIncludePath(uv_c.path("include"));
+    uv.root_module.addIncludePath(uv_c.path("src"));
+    uv.root_module.addIncludePath(uv_c.path("include"));
 
     var uv_flags = std.array_list.Managed([]const u8).init(b.allocator);
     defer uv_flags.deinit();
@@ -65,7 +65,7 @@ pub fn build(b: *std.Build) !void {
         else => null,
     };
 
-    uv.addCSourceFiles(.{
+    uv.root_module.addCSourceFiles(.{
         .root = uv_c.path("src"),
         .files = switch (t.os.tag) {
             .macos => &uv_srcs_macos,
@@ -77,20 +77,20 @@ pub fn build(b: *std.Build) !void {
     });
 
     if (t.os.tag == .windows) {
-        uv.addCSourceFiles(.{
+        uv.root_module.addCSourceFiles(.{
             .files = &.{"patches/libuv/src/win/tty.c"},
             .flags = uv_flags.items,
         });
-        uv.addIncludePath(uv_c.path("src/win"));
+        uv.root_module.addIncludePath(uv_c.path("src/win"));
     }
 
     uv.installHeadersDirectory(uv_c.path("include"), "", .{});
 
     if (t.os.tag == .windows) {
-        uv.linkSystemLibrary("ole32"); // CoTaskMemFree
-        uv.linkSystemLibrary("dbghelp"); // MiniDumpWriteDump, SymGetOptions, SymSetOptions
-        uv.linkSystemLibrary("userenv"); // GetUserProfileDirectoryW
-        uv.linkSystemLibrary("iphlpapi"); // GetAdaptersAddresses, ConvertInterface*
+        uv.root_module.linkSystemLibrary("ole32", .{}); // CoTaskMemFree
+        uv.root_module.linkSystemLibrary("dbghelp", .{}); // MiniDumpWriteDump, SymGetOptions, SymSetOptions
+        uv.root_module.linkSystemLibrary("userenv", .{}); // GetUserProfileDirectoryW
+        uv.root_module.linkSystemLibrary("iphlpapi", .{}); // GetAdaptersAddresses, ConvertInterface*
     }
 
     b.installArtifact(uv);

--- a/ext/lmdb/build.zig
+++ b/ext/lmdb/build.zig
@@ -14,9 +14,9 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lmdb.linkLibC();
+    lmdb.root_module.link_libc = true;
 
-    lmdb.addIncludePath(lmdb_c.path("libraries/liblmdb"));
+    lmdb.root_module.addIncludePath(lmdb_c.path("libraries/liblmdb"));
 
     var flags = std.array_list.Managed([]const u8).init(b.allocator);
     defer flags.deinit();
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build) !void {
         "-Wuninitialized",
     });
 
-    lmdb.addCSourceFiles(.{
+    lmdb.root_module.addCSourceFiles(.{
         .root = lmdb_c.path("libraries/liblmdb"),
         .files = &.{ "midl.c", "mdb.c" },
         .flags = flags.items,

--- a/ext/murmur3/build.zig
+++ b/ext/murmur3/build.zig
@@ -10,9 +10,9 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    murmur3.linkLibC();
+    murmur3.root_module.link_libc = true;
 
-    murmur3.addIncludePath(b.path("."));
+    murmur3.root_module.addIncludePath(b.path("."));
 
     const common_flags = [_][]const u8{
         "-fno-sanitize=all",
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
         "-c",
     };
 
-    murmur3.addCSourceFiles(.{
+    murmur3.root_module.addCSourceFiles(.{
         .root = b.path("vendor"),
         .files = &.{"murmur3.c"},
         .flags = if (t.os.tag == .macos) &mac_flags else &common_flags,

--- a/ext/nasm/build.zig
+++ b/ext/nasm/build.zig
@@ -14,12 +14,12 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
-    exe.addIncludePath(b.path("include"));
-    exe.addIncludePath(b.path("asm"));
-    exe.addIncludePath(b.path("x86"));
-    exe.addIncludePath(b.path("output"));
+    exe.root_module.addIncludePath(b.path("include"));
+    exe.root_module.addIncludePath(b.path("asm"));
+    exe.root_module.addIncludePath(b.path("x86"));
+    exe.root_module.addIncludePath(b.path("output"));
 
-    exe.addConfigHeader(b.addConfigHeader(.{
+    exe.root_module.addConfigHeader(b.addConfigHeader(.{
         .style = .blank,
         .include_path = "version.h",
     }, .{
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) void {
     }));
 
     if (b.graph.host.result.os.tag == .windows) {
-        exe.addConfigHeader(b.addConfigHeader(.{
+        exe.root_module.addConfigHeader(b.addConfigHeader(.{
             .style = .{ .autoconf_undef = b.path("config/config.h.in") },
             .include_path = "config/config.h",
         }, .{
@@ -253,7 +253,7 @@ pub fn build(b: *std.Build) void {
             .vsnprintf = null,
         }));
     } else if (b.graph.host.result.os.tag.isDarwin()) {
-        exe.addConfigHeader(b.addConfigHeader(.{
+        exe.root_module.addConfigHeader(b.addConfigHeader(.{
             .style = .{ .autoconf_undef = b.path("config/config.h.in") },
             .include_path = "config/config.h",
         }, .{
@@ -505,7 +505,7 @@ pub fn build(b: *std.Build) void {
             .vsnprintf = null,
         }));
     } else if (b.graph.host.result.os.tag == .linux) {
-        exe.addConfigHeader(b.addConfigHeader(.{
+        exe.root_module.addConfigHeader(b.addConfigHeader(.{
             .style = .{ .autoconf_undef = b.path("config/config.h.in") },
             .include_path = "config/config.h",
         }, .{
@@ -819,11 +819,11 @@ pub fn build(b: *std.Build) void {
         "-std=c17",
         "-Wno-implicit-function-declaration",
     };
-    exe.addCSourceFiles(.{
+    exe.root_module.addCSourceFiles(.{
         .files = &files,
         .flags = &flags,
     });
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
     b.installArtifact(exe);
 }
 

--- a/ext/natpmp/build.zig
+++ b/ext/natpmp/build.zig
@@ -15,9 +15,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    lib.addIncludePath(dep_c.path("include"));
+    lib.root_module.addIncludePath(dep_c.path("include"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path(""),
         .files = &.{
             "natpmp.c",
@@ -39,6 +39,6 @@ pub fn build(b: *std.Build) void {
         lib.root_module.addCMacro("ENABLE_STRNATPMPERR", "");
     }
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
     b.installArtifact(lib);
 }

--- a/ext/nettle/build.zig
+++ b/ext/nettle/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     // SIZEOF_LONG / SIZEOF_SIZE_T are target-dependent (long is 4 bytes on
     // LLP64 Windows, 8 on LP64 unix), so they're derived from the target here
@@ -44,11 +44,11 @@ pub fn build(b: *std.Build) void {
     const has_malloc_h: u1 = if (is_windows) 1 else 0;
 
     // vendored config.h + version.h (see comment above)
-    lib.addIncludePath(b.path("gen"));
+    lib.root_module.addIncludePath(b.path("gen"));
     // nettle source root (nettle-types.h, sha2.h, macros.h, ...)
-    lib.addIncludePath(dep_c.path(""));
+    lib.root_module.addIncludePath(dep_c.path(""));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path(""),
         .flags = &.{
             "-O2",

--- a/ext/openssl/build.zig
+++ b/ext/openssl/build.zig
@@ -32,9 +32,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         if (macos_sdk != null) {
-            crypto.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-            crypto.addLibraryPath(macos_sdk.?.path("usr/lib"));
-            crypto.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+            crypto.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            crypto.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            crypto.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
         }
     }
 
@@ -72,14 +72,14 @@ fn libcrypto(
         else => lib.root_module.strip = true,
     }
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep.path("."));
-    lib.addIncludePath(dep.path("crypto"));
-    lib.addIncludePath(dep.path("crypto/ec/curve448/"));
-    lib.addIncludePath(dep.path("crypto/ec/curve448/arch_32/"));
-    lib.addIncludePath(dep.path("crypto/modes"));
-    lib.addIncludePath(dep.path("include"));
+    lib.root_module.addIncludePath(dep.path("."));
+    lib.root_module.addIncludePath(dep.path("crypto"));
+    lib.root_module.addIncludePath(dep.path("crypto/ec/curve448/"));
+    lib.root_module.addIncludePath(dep.path("crypto/ec/curve448/arch_32/"));
+    lib.root_module.addIncludePath(dep.path("crypto/modes"));
+    lib.root_module.addIncludePath(dep.path("include"));
 
     lib.root_module.addCMacro("L_ENDIAN", "");
     lib.root_module.addCMacro("OPENSSL_PIC", "");
@@ -127,9 +127,9 @@ fn libcrypto(
         lib.root_module.addCMacro("MD5_ASM", "");
         lib.root_module.addCMacro("RC4_ASM", "");
 
-        lib.addIncludePath(b.path("gen/windows-x86_64/include"));
-        lib.addIncludePath(b.path("gen/windows-x86_64/include/crypto"));
-        lib.addIncludePath(b.path("gen/windows-x86_64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/windows-x86_64/include"));
+        lib.root_module.addIncludePath(b.path("gen/windows-x86_64/include/crypto"));
+        lib.root_module.addIncludePath(b.path("gen/windows-x86_64/include/openssl"));
 
         const nasm_dep = b.dependency("nasm", .{
             .optimize = .ReleaseFast,
@@ -179,18 +179,18 @@ fn libcrypto(
             nasm_run.addArgs(&.{ "-f", "win64", "-g" });
 
             nasm_run.addArgs(&.{"-o"});
-            lib.addObjectFile(nasm_run.addOutputFileArg(output_basename));
+            lib.root_module.addObjectFile(nasm_run.addOutputFileArg(output_basename));
 
             nasm_run.addFileArg(b.path(input_file));
         }
     }
 
     if (t.os.tag.isDarwin() and t.cpu.arch.isAARCH64()) {
-        lib.addIncludePath(b.path("gen/macos-aarch64/include"));
-        lib.addIncludePath(b.path("gen/macos-aarch64/include/crypto"));
-        lib.addIncludePath(b.path("gen/macos-aarch64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/macos-aarch64/include"));
+        lib.root_module.addIncludePath(b.path("gen/macos-aarch64/include/crypto"));
+        lib.root_module.addIncludePath(b.path("gen/macos-aarch64/include/openssl"));
 
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/macos-aarch64/crypto"),
             .files = &.{
                 "aes/aesv8-armx.S",
@@ -211,11 +211,11 @@ fn libcrypto(
     }
 
     if (t.os.tag == .linux and t.cpu.arch.isAARCH64()) {
-        lib.addIncludePath(b.path("gen/linux-aarch64/include"));
-        lib.addIncludePath(b.path("gen/linux-aarch64/include/crypto"));
-        lib.addIncludePath(b.path("gen/linux-aarch64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/linux-aarch64/include"));
+        lib.root_module.addIncludePath(b.path("gen/linux-aarch64/include/crypto"));
+        lib.root_module.addIncludePath(b.path("gen/linux-aarch64/include/openssl"));
 
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/linux-aarch64/crypto"),
             .files = &.{
                 "aes/aesv8-armx.S",
@@ -241,11 +241,11 @@ fn libcrypto(
         lib.root_module.addCMacro("MD5_ASM", "");
         lib.root_module.addCMacro("RC4_ASM", "");
 
-        lib.addIncludePath(b.path("gen/macos-x86_64/include"));
-        lib.addIncludePath(b.path("gen/macos-x86_64/include/crypto"));
-        lib.addIncludePath(b.path("gen/macos-x86_64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/macos-x86_64/include"));
+        lib.root_module.addIncludePath(b.path("gen/macos-x86_64/include/crypto"));
+        lib.root_module.addIncludePath(b.path("gen/macos-x86_64/include/openssl"));
 
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/macos-x86_64"),
             .files = &.{
                 "crypto/aes/aesni-mb-x86_64.s",
@@ -288,11 +288,11 @@ fn libcrypto(
         lib.root_module.addCMacro("MD5_ASM", "");
         lib.root_module.addCMacro("RC4_ASM", "");
 
-        lib.addIncludePath(b.path("gen/linux-x86_64/include"));
-        lib.addIncludePath(b.path("gen/linux-x86_64/include/crypto"));
-        lib.addIncludePath(b.path("gen/linux-x86_64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/linux-x86_64/include"));
+        lib.root_module.addIncludePath(b.path("gen/linux-x86_64/include/crypto"));
+        lib.root_module.addIncludePath(b.path("gen/linux-x86_64/include/openssl"));
 
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = b.path("gen/linux-x86_64"),
             .files = &.{
                 "crypto/aes/aesni-mb-x86_64.s",
@@ -344,11 +344,11 @@ fn libcrypto(
             "ms/applink.c",
             "ms/uplink.c",
         });
-        lib.addIncludePath(dep.path("ms"));
-        lib.linkSystemLibrary("crypt32");
+        lib.root_module.addIncludePath(dep.path("ms"));
+        lib.root_module.linkSystemLibrary("crypt32", .{});
     }
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep.path(""),
         .files = switch (t.cpu.arch) {
             .arm, .aarch64 => &.{
@@ -375,7 +375,7 @@ fn libcrypto(
         .flags = cflags,
     });
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep.path(""),
         .files = srcs.items,
         .flags = cflags,
@@ -411,35 +411,35 @@ fn libssl(
         else => lib.root_module.strip = true,
     }
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep.path("."));
-    lib.addIncludePath(dep.path("openssl"));
-    lib.addIncludePath(dep.path("include"));
-    lib.addIncludePath(dep.path("include/internal"));
-    lib.addIncludePath(dep.path("include/openssl"));
+    lib.root_module.addIncludePath(dep.path("."));
+    lib.root_module.addIncludePath(dep.path("openssl"));
+    lib.root_module.addIncludePath(dep.path("include"));
+    lib.root_module.addIncludePath(dep.path("include/internal"));
+    lib.root_module.addIncludePath(dep.path("include/openssl"));
 
     if (t.os.tag.isDarwin() and t.cpu.arch.isAARCH64()) {
-        lib.addIncludePath(b.path("gen/macos-aarch64/include"));
-        lib.addIncludePath(b.path("gen/macos-aarch64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/macos-aarch64/include"));
+        lib.root_module.addIncludePath(b.path("gen/macos-aarch64/include/openssl"));
         lib.installHeadersDirectory(b.path("gen/macos-aarch64/include/openssl"), "openssl", .{});
     }
 
     if (t.os.tag == .linux and t.cpu.arch.isAARCH64()) {
-        lib.addIncludePath(b.path("gen/linux-aarch64/include"));
-        lib.addIncludePath(b.path("gen/linux-aarch64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/linux-aarch64/include"));
+        lib.root_module.addIncludePath(b.path("gen/linux-aarch64/include/openssl"));
         lib.installHeadersDirectory(b.path("gen/linux-aarch64/include/openssl"), "openssl", .{});
     }
 
     if (t.os.tag.isDarwin() and t.cpu.arch == .x86_64) {
-        lib.addIncludePath(b.path("gen/macos-x86_64/include"));
-        lib.addIncludePath(b.path("gen/macos-x86_64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/macos-x86_64/include"));
+        lib.root_module.addIncludePath(b.path("gen/macos-x86_64/include/openssl"));
         lib.installHeadersDirectory(b.path("gen/macos-x86_64/include/openssl"), "openssl", .{});
     }
 
     if (t.os.tag == .linux and t.cpu.arch == .x86_64) {
-        lib.addIncludePath(b.path("gen/linux-x86_64/include"));
-        lib.addIncludePath(b.path("gen/linux-x86_64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/linux-x86_64/include"));
+        lib.root_module.addIncludePath(b.path("gen/linux-x86_64/include/openssl"));
         lib.installHeadersDirectory(b.path("gen/linux-x86_64/include/openssl"), "openssl", .{});
     }
 
@@ -452,15 +452,15 @@ fn libssl(
         lib.root_module.addCMacro("OPENSSL_USE_APPLINK", "");
         lib.root_module.addCMacro("OPENSSL_SYS_WIN32", "");
 
-        lib.addIncludePath(b.path("gen/windows-x86_64/include"));
-        lib.addIncludePath(b.path("gen/windows-x86_64/include/openssl"));
+        lib.root_module.addIncludePath(b.path("gen/windows-x86_64/include"));
+        lib.root_module.addIncludePath(b.path("gen/windows-x86_64/include/openssl"));
         lib.installHeadersDirectory(b.path("gen/windows-x86_64/include/openssl"), "openssl", .{});
     }
 
     lib.root_module.addCMacro("OPENSSLDIR", "\"\"");
     lib.root_module.addCMacro("ENGINESDIR", "\"\"");
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep.path(""),
         .files = &.{
             "ssl/bio_ssl.c",

--- a/ext/pdjson/build.zig
+++ b/ext/pdjson/build.zig
@@ -9,11 +9,11 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(b.path("vendor"));
+    lib.root_module.addIncludePath(b.path("vendor"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = b.path("vendor"),
         .files = &.{"pdjson.c"},
         .flags = &.{

--- a/ext/sigsegv/build.zig
+++ b/ext/sigsegv/build.zig
@@ -21,13 +21,13 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         });
         if (macos_sdk != null) {
-            lib.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-            lib.addLibraryPath(macos_sdk.?.path("usr/lib"));
-            lib.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+            lib.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            lib.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            lib.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
         }
     }
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     lib.root_module.addCMacro("HAVE_CONFIG_H", &[_]u8{});
 
@@ -125,11 +125,11 @@ pub fn build(b: *std.Build) void {
         .HAVE_STACK_OVERFLOW_RECOVERY = 1,
     });
 
-    lib.addIncludePath(dep_c.path("src"));
-    lib.addConfigHeader(config_h);
-    lib.addConfigHeader(sigsegv_h);
+    lib.root_module.addIncludePath(dep_c.path("src"));
+    lib.root_module.addConfigHeader(config_h);
+    lib.root_module.addConfigHeader(sigsegv_h);
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("src"),
         .files = &.{
             "dispatcher.c",

--- a/ext/softblas/build.zig
+++ b/ext/softblas/build.zig
@@ -19,9 +19,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    lib.addIncludePath(dep_c.path("include"));
+    lib.root_module.addIncludePath(dep_c.path("include"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path(""),
         .files = &.{
             "src/softblas_state.c",
@@ -73,7 +73,7 @@ pub fn build(b: *std.Build) void {
 
     lib.installHeader(dep_c.path("include/softblas.h"), "softblas.h");
 
-    lib.linkLibC();
-    lib.linkLibrary(softfloat.artifact("softfloat"));
+    lib.root_module.link_libc = true;
+    lib.root_module.linkLibrary(softfloat.artifact("softfloat"));
     b.installArtifact(lib);
 }

--- a/ext/softfloat/build.zig
+++ b/ext/softfloat/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    lib.addIncludePath(dep_c.path("source/include"));
+    lib.root_module.addIncludePath(dep_c.path("source/include"));
 
     const flags = .{
         "-fno-sanitize=all",
@@ -24,9 +24,9 @@ pub fn build(b: *std.Build) void {
     };
 
     if (t.cpu.arch.isAARCH64()) {
-        lib.addIncludePath(dep_c.path("source/ARM-VFPv2"));
-        lib.addIncludePath(dep_c.path("build/Linux-ARM-VFPv2-GCC"));
-        lib.addCSourceFiles(.{
+        lib.root_module.addIncludePath(dep_c.path("source/ARM-VFPv2"));
+        lib.root_module.addIncludePath(dep_c.path("build/Linux-ARM-VFPv2-GCC"));
+        lib.root_module.addCSourceFiles(.{
             .root = dep_c.path(""),
             .files = &.{
                 "source/s_compare96M.c",
@@ -272,14 +272,14 @@ pub fn build(b: *std.Build) void {
         lib.installHeader(dep_c.path("build/Linux-ARM-VFPv2-GCC/platform.h"), "platform.h");
     }
     if (t.cpu.arch.isX86()) {
-        lib.addIncludePath(dep_c.path("source/8086-SSE"));
-        lib.addIncludePath(dep_c.path("build/Linux-x86_64-GCC"));
+        lib.root_module.addIncludePath(dep_c.path("source/8086-SSE"));
+        lib.root_module.addIncludePath(dep_c.path("build/Linux-x86_64-GCC"));
 
         lib.root_module.addCMacro("SOFTFLOAT_FAST_INT64", "");
         lib.root_module.addCMacro("SOFTFLOAT_FAST_DIV32TO16", "");
         lib.root_module.addCMacro("SOFTFLOAT_FAST_DIV64TO32", "");
 
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = dep_c.path(""),
             .files = &.{
                 "source/s_eq128.c",
@@ -603,7 +603,7 @@ pub fn build(b: *std.Build) void {
         .include_extensions = &.{".h"},
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     b.installArtifact(lib);
 }

--- a/ext/tracy/build.zig
+++ b/ext/tracy/build.zig
@@ -14,14 +14,14 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    tracy.linkLibC();
-    tracy.linkLibCpp();
+    tracy.root_module.link_libc = true;
+    tracy.root_module.link_libcpp = true;
 
     // Add Tracy include path
-    tracy.addIncludePath(tracy_src.path("public"));
+    tracy.root_module.addIncludePath(tracy_src.path("public"));
 
     // Add Tracy C++ client source
-    tracy.addCSourceFiles(.{
+    tracy.root_module.addCSourceFiles(.{
         .root = tracy_src.path("public"),
         .files = &.{"TracyClient.cpp"},
         .flags = &.{
@@ -35,13 +35,13 @@ pub fn build(b: *std.Build) void {
     // Platform-specific libraries
     const t = target.result;
     if (t.os.tag == .linux) {
-        tracy.linkSystemLibrary("pthread");
-        tracy.linkSystemLibrary("dl");
+        tracy.root_module.linkSystemLibrary("pthread", .{});
+        tracy.root_module.linkSystemLibrary("dl", .{});
     } else if (t.os.tag.isDarwin()) {
         // macOS might need additional frameworks
     } else if (t.os.tag == .windows) {
-        tracy.linkSystemLibrary("ws2_32");
-        tracy.linkSystemLibrary("dbghelp");
+        tracy.root_module.linkSystemLibrary("ws2_32", .{});
+        tracy.root_module.linkSystemLibrary("dbghelp", .{});
     }
 
     // Install Tracy headers for C API - install the entire public directory structure

--- a/ext/unwind/build.zig
+++ b/ext/unwind/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     lib.root_module.addCMacro("HAVE_CONFIG_H", "");
     lib.root_module.addCMacro("_GNU_SOURCE", "");
@@ -129,16 +129,16 @@ pub fn build(b: *std.Build) !void {
         .include_path = "libunwind-common.h",
     }, .{ .PKG_MAJOR = 1, .PKG_MINOR = 8, .PKG_EXTRA = 1 });
 
-    lib.addConfigHeader(config_h);
-    lib.addConfigHeader(libunwind_h);
-    lib.addConfigHeader(libunwind_i_h);
-    lib.addConfigHeader(libunwind_common_h);
-    lib.addIncludePath(dep_c.path("src"));
-    lib.addIncludePath(dep_c.path("include"));
+    lib.root_module.addConfigHeader(config_h);
+    lib.root_module.addConfigHeader(libunwind_h);
+    lib.root_module.addConfigHeader(libunwind_i_h);
+    lib.root_module.addConfigHeader(libunwind_common_h);
+    lib.root_module.addIncludePath(dep_c.path("src"));
+    lib.root_module.addIncludePath(dep_c.path("include"));
     if (t.cpu.arch.isAARCH64())
-        lib.addIncludePath(dep_c.path("include/tdep-aarch64"));
+        lib.root_module.addIncludePath(dep_c.path("include/tdep-aarch64"));
     if (t.cpu.arch == .x86_64)
-        lib.addIncludePath(dep_c.path("include/tdep-x86_64"));
+        lib.root_module.addIncludePath(dep_c.path("include/tdep-x86_64"));
 
     var srcs = std.array_list.Managed([]const u8).init(b.allocator);
     defer srcs.deinit();
@@ -236,7 +236,7 @@ pub fn build(b: *std.Build) !void {
             // "x86_64/siglongjmp.S",
         });
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("src"),
         .files = srcs.items,
         .flags = &.{

--- a/ext/urcrypt/build.zig
+++ b/ext/urcrypt/build.zig
@@ -19,24 +19,24 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.linkLibrary(libsecp256k1(b, target, optimize));
-    lib.linkLibrary(libargon2(b, target, optimize));
-    lib.linkLibrary(libblake3(b, target, optimize));
-    lib.linkLibrary(libed25519(b, target, optimize));
-    lib.linkLibrary(libge_additions(b, target, optimize));
-    lib.linkLibrary(libkeccak_tiny(b, target, optimize));
-    lib.linkLibrary(libmonocypher(b, target, optimize));
-    lib.linkLibrary(libscrypt(b, target, optimize));
+    lib.root_module.linkLibrary(libsecp256k1(b, target, optimize));
+    lib.root_module.linkLibrary(libargon2(b, target, optimize));
+    lib.root_module.linkLibrary(libblake3(b, target, optimize));
+    lib.root_module.linkLibrary(libed25519(b, target, optimize));
+    lib.root_module.linkLibrary(libge_additions(b, target, optimize));
+    lib.root_module.linkLibrary(libkeccak_tiny(b, target, optimize));
+    lib.root_module.linkLibrary(libmonocypher(b, target, optimize));
+    lib.root_module.linkLibrary(libscrypt(b, target, optimize));
 
-    lib.linkLibrary(libaes_siv(b, target, optimize));
+    lib.root_module.linkLibrary(libaes_siv(b, target, optimize));
     // SHA, RIPEMD160 and AES (ECB/CBC) now come from nettle instead of openssl
-    lib.linkLibrary(nettle.artifact("nettle"));
+    lib.root_module.linkLibrary(nettle.artifact("nettle"));
 
-    lib.addIncludePath(dep_c.path("urcrypt"));
+    lib.root_module.addIncludePath(dep_c.path("urcrypt"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("urcrypt"),
         .files = &.{
             "aes_cbc.c",
@@ -90,15 +90,15 @@ fn libaes_siv(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibrary(nettle.artifact("nettle"));
+    lib.root_module.linkLibrary(nettle.artifact("nettle"));
 
     const config_h = b.addConfigHeader(.{
         .style = .blank,
         .include_path = "config.h",
     }, .{});
-    lib.addConfigHeader(config_h);
-    lib.addIncludePath(dep_c.path("aes_siv"));
-    lib.addCSourceFiles(.{
+    lib.root_module.addConfigHeader(config_h);
+    lib.root_module.addIncludePath(dep_c.path("aes_siv"));
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("aes_siv"),
         .files = &.{
             "aes_siv.c",
@@ -112,7 +112,7 @@ fn libaes_siv(
 
     lib.installHeader(dep_c.path("aes_siv/aes_siv.h"), "aes_siv.h");
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     return lib;
 }
@@ -132,11 +132,11 @@ fn libsecp256k1(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep_c.path("src"));
+    lib.root_module.addIncludePath(dep_c.path("src"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("src"),
         .files = &.{
             "precomputed_ecmult.c",
@@ -197,7 +197,7 @@ fn libargon2(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     const flags = .{
         "-O2",
@@ -216,18 +216,18 @@ fn libargon2(
         "src/thread.c",
     };
 
-    lib.addIncludePath(dep_c.path("argon2/include"));
-    lib.addIncludePath(dep_c.path("argon2/src"));
-    lib.addIncludePath(dep_c.path("argon2/src/blake2"));
+    lib.root_module.addIncludePath(dep_c.path("argon2/include"));
+    lib.root_module.addIncludePath(dep_c.path("argon2/src"));
+    lib.root_module.addIncludePath(dep_c.path("argon2/src/blake2"));
 
     if (target.result.cpu.arch == .x86_64) {
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = dep_c.path("argon2"),
             .files = &(common_files ++ .{"src/opt.c"}),
             .flags = &flags,
         });
     } else {
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = dep_c.path("argon2"),
             .files = &(common_files ++ .{"src/ref.c"}),
             .flags = &flags,
@@ -257,7 +257,7 @@ fn libblake3(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
     const common_files = .{
         "blake3.c",
@@ -265,7 +265,7 @@ fn libblake3(
         "blake3_portable.c",
     };
 
-    lib.addIncludePath(dep_c.path("blake3"));
+    lib.root_module.addIncludePath(dep_c.path("blake3"));
 
     const unix_assembly = .{
         "blake3_sse2_x86-64_unix.S",
@@ -284,7 +284,7 @@ fn libblake3(
     const assembly_files = if (t.os.tag == .windows) windows_assembly else unix_assembly;
 
     if (target.result.cpu.arch == .x86_64) {
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = dep_c.path("blake3"),
             .files = &(common_files ++ assembly_files),
             .flags = &.{
@@ -294,7 +294,7 @@ fn libblake3(
             },
         });
     } else {
-        lib.addCSourceFiles(.{
+        lib.root_module.addCSourceFiles(.{
             .root = dep_c.path("blake3"),
             .files = &(common_files ++ .{"blake3_neon.c"}),
             .flags = &.{
@@ -327,11 +327,11 @@ fn libed25519(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep_c.path("ed25519/src"));
+    lib.root_module.addIncludePath(dep_c.path("ed25519/src"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("ed25519"),
         .files = &.{
             "src/add_scalar.c",
@@ -375,12 +375,12 @@ fn libge_additions(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep_c.path("ed25519/src"));
-    lib.addIncludePath(dep_c.path("ge-additions"));
+    lib.root_module.addIncludePath(dep_c.path("ed25519/src"));
+    lib.root_module.addIncludePath(dep_c.path("ge-additions"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("ge-additions"),
         .files = &.{"ge-additions.c"},
         .flags = &.{
@@ -412,11 +412,11 @@ fn libkeccak_tiny(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep_c.path("keccak-tiny"));
+    lib.root_module.addIncludePath(dep_c.path("keccak-tiny"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("keccak-tiny"),
         .files = &.{"keccak-tiny.c"},
         .flags = &.{
@@ -450,11 +450,11 @@ fn libmonocypher(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep_c.path("monocypher"));
+    lib.root_module.addIncludePath(dep_c.path("monocypher"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("monocypher"),
         .files = &.{"monocypher.c"},
         .flags = &.{
@@ -484,11 +484,11 @@ fn libscrypt(
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep_c.path("scrypt"));
+    lib.root_module.addIncludePath(dep_c.path("scrypt"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("scrypt"),
         .files = &.{
             "b64.c",

--- a/ext/wasm3/build.zig
+++ b/ext/wasm3/build.zig
@@ -20,9 +20,9 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    wasm3.linkLibC();
+    wasm3.root_module.link_libc = true;
 
-    wasm3.addIncludePath(wasm3_c.path("source/"));
+    wasm3.root_module.addIncludePath(wasm3_c.path("source/"));
 
     const common_flags = [_][]const u8{
         "-std=c99",
@@ -43,7 +43,7 @@ pub fn build(b: *std.Build) void {
         "-c",
     };
 
-    wasm3.addCSourceFiles(.{
+    wasm3.root_module.addCSourceFiles(.{
         .root = wasm3_c.path("source/"),
         .files = &.{
             "m3_bind.c",
@@ -84,7 +84,7 @@ pub fn build(b: *std.Build) void {
     wasm3.installHeader(wasm3_c.path("source/m3_rewrite.h"), "m3_rewrite.h");
     wasm3.installHeader(wasm3_c.path("source/m3_resume.h"), "m3_resume.h");
 
-    wasm3.linkLibrary(softfloat.artifact("softfloat"));
+    wasm3.root_module.linkLibrary(softfloat.artifact("softfloat"));
 
     b.installArtifact(wasm3);
 }

--- a/ext/whereami/build.zig
+++ b/ext/whereami/build.zig
@@ -14,11 +14,11 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    lib.linkLibC();
+    lib.root_module.link_libc = true;
 
-    lib.addIncludePath(dep_c.path("src"));
+    lib.root_module.addIncludePath(dep_c.path("src"));
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .root = dep_c.path("src"),
         .files = &.{"whereami.c"},
         .flags = &.{

--- a/pkg/c3/build.zig
+++ b/pkg/c3/build.zig
@@ -16,26 +16,26 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         });
         if (macos_sdk != null) {
-            pkg_c3.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-            pkg_c3.addLibraryPath(macos_sdk.?.path("usr/lib"));
-            pkg_c3.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+            pkg_c3.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            pkg_c3.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            pkg_c3.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
         }
     }
 
-    pkg_c3.linkLibC();
+    pkg_c3.root_module.link_libc = true;
 
-    pkg_c3.addIncludePath(b.path(""));
+    pkg_c3.root_module.addIncludePath(b.path(""));
 
-    pkg_c3.addCSourceFiles(.{
+    pkg_c3.root_module.addCSourceFiles(.{
         .root = b.path(""),
         .files = &.{"defs.c"},
         .flags = copts,
     });
 
     if (t.os.tag == .windows) {
-        pkg_c3.addIncludePath(b.path("platform/windows"));
+        pkg_c3.root_module.addIncludePath(b.path("platform/windows"));
         pkg_c3.installHeadersDirectory(b.path("platform/windows"), "", .{});
-        pkg_c3.addCSourceFiles(.{
+        pkg_c3.root_module.addCSourceFiles(.{
             .root = b.path(""),
             .files = &.{"platform/windows/compat.c"},
             .flags = copts,

--- a/pkg/ent/build.zig
+++ b/pkg/ent/build.zig
@@ -22,11 +22,11 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
     });
 
-    pkg_ent.linkLibC();
+    pkg_ent.root_module.link_libc = true;
 
-    pkg_ent.addIncludePath(b.path(""));
+    pkg_ent.root_module.addIncludePath(b.path(""));
 
-    pkg_ent.addCSourceFiles(.{
+    pkg_ent.root_module.addCSourceFiles(.{
         .root = b.path(""),
         .files = &.{"ent.c"},
         .flags = flags.items,
@@ -35,7 +35,7 @@ pub fn build(b: *std.Build) !void {
     pkg_ent.installHeader(b.path("ent.h"), "ent/ent.h");
 
     if (t.os.tag == .windows) {
-        pkg_ent.linkSystemLibrary("bcrypt");
+        pkg_ent.root_module.linkSystemLibrary("bcrypt", .{});
     }
 
     b.installArtifact(pkg_ent);

--- a/pkg/noun/build.zig
+++ b/pkg/noun/build.zig
@@ -34,9 +34,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         if (macos_sdk != null) {
-            pkg_noun.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-            pkg_noun.addLibraryPath(macos_sdk.?.path("usr/lib"));
-            pkg_noun.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+            pkg_noun.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            pkg_noun.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            pkg_noun.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
         }
     }
 
@@ -128,42 +128,42 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     }) else null;
 
-    pkg_noun.linkLibC();
+    pkg_noun.root_module.link_libc = true;
 
-    pkg_noun.linkLibrary(pkg_c3.artifact("c3"));
-    pkg_noun.linkLibrary(pkg_ent.artifact("ent"));
-    pkg_noun.linkLibrary(pkg_ur.artifact("ur"));
+    pkg_noun.root_module.linkLibrary(pkg_c3.artifact("c3"));
+    pkg_noun.root_module.linkLibrary(pkg_ent.artifact("ent"));
+    pkg_noun.root_module.linkLibrary(pkg_ur.artifact("ur"));
 
-    pkg_noun.linkLibrary(backtrace.artifact("backtrace"));
-    pkg_noun.linkLibrary(gmp.artifact("gmp"));
+    pkg_noun.root_module.linkLibrary(backtrace.artifact("backtrace"));
+    pkg_noun.root_module.linkLibrary(gmp.artifact("gmp"));
 
-    pkg_noun.linkLibrary(murmur3.artifact("murmur3"));
-    pkg_noun.linkLibrary(openssl.artifact("ssl"));
-    pkg_noun.linkLibrary(pdjson.artifact("pdjson"));
+    pkg_noun.root_module.linkLibrary(murmur3.artifact("murmur3"));
+    pkg_noun.root_module.linkLibrary(openssl.artifact("ssl"));
+    pkg_noun.root_module.linkLibrary(pdjson.artifact("pdjson"));
     if (t.os.tag != .windows) {
-        pkg_noun.linkLibrary(sigsegv.artifact("sigsegv"));
+        pkg_noun.root_module.linkLibrary(sigsegv.artifact("sigsegv"));
     }
-    pkg_noun.linkLibrary(softblas.artifact("softblas"));
-    pkg_noun.linkLibrary(softfloat.artifact("softfloat"));
+    pkg_noun.root_module.linkLibrary(softblas.artifact("softblas"));
+    pkg_noun.root_module.linkLibrary(softfloat.artifact("softfloat"));
     if (t.os.tag == .linux)
-        pkg_noun.linkLibrary(unwind.artifact("unwind"));
-    pkg_noun.linkLibrary(urcrypt.artifact("urcrypt"));
-    pkg_noun.linkLibrary(whereami.artifact("whereami"));
-    pkg_noun.linkLibrary(zlib.artifact("z"));
-    pkg_noun.linkLibrary(wasm3.artifact("wasm3"));
+        pkg_noun.root_module.linkLibrary(unwind.artifact("unwind"));
+    pkg_noun.root_module.linkLibrary(urcrypt.artifact("urcrypt"));
+    pkg_noun.root_module.linkLibrary(whereami.artifact("whereami"));
+    pkg_noun.root_module.linkLibrary(zlib.artifact("z"));
+    pkg_noun.root_module.linkLibrary(wasm3.artifact("wasm3"));
 
     if (tracy_enabled) {
-        pkg_noun.linkLibrary(tracy.?.artifact("tracy"));
-        pkg_noun.addIncludePath(tracy.?.path(""));
+        pkg_noun.root_module.linkLibrary(tracy.?.artifact("tracy"));
+        pkg_noun.root_module.addIncludePath(tracy.?.path(""));
     }
 
-    pkg_noun.addIncludePath(b.path(""));
+    pkg_noun.root_module.addIncludePath(b.path(""));
     if (t.os.tag.isDarwin())
-        pkg_noun.addIncludePath(b.path("platform/darwin"));
+        pkg_noun.root_module.addIncludePath(b.path("platform/darwin"));
     if (t.os.tag == .linux)
-        pkg_noun.addIncludePath(b.path("platform/linux"));
+        pkg_noun.root_module.addIncludePath(b.path("platform/linux"));
     if (t.os.tag == .windows)
-        pkg_noun.addIncludePath(b.path("platform/windows"));
+        pkg_noun.root_module.addIncludePath(b.path("platform/windows"));
 
     var flags = std.array_list.Managed([]const u8).init(b.allocator);
     defer flags.deinit();
@@ -173,14 +173,14 @@ pub fn build(b: *std.Build) !void {
     });
     try flags.appendSlice(copts);
 
-    pkg_noun.addCSourceFiles(.{
+    pkg_noun.root_module.addCSourceFiles(.{
         .root = b.path(""),
         .files = &c_source_files,
         .flags = flags.items,
     });
 
     if (t.os.tag == .windows) {
-        pkg_noun.addCSourceFiles(.{
+        pkg_noun.root_module.addCSourceFiles(.{
             .root = b.path("platform/windows"),
             .files = &.{ "veh_handler.c", "rsignal.c", "setjmp.c" },
             .flags = flags.items,

--- a/pkg/noun/build.zig.zon
+++ b/pkg/noun/build.zig.zon
@@ -51,8 +51,8 @@
             .path = "../../ext/whereami",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
-            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
+            .url = "https://github.com/allyourcodebase/zlib/archive/d3b5519d3b73616a6bfece0712f080029d2a9244.tar.gz",
+            .hash = "zlib-1.3.2-ZZQ7lc8NAAAHm9MDfplvwoesXvk4tVm6VCsiI8KnIbT0",
         },
         .wasm3 = .{
             .path = "../../ext/wasm3",

--- a/pkg/past/build.zig
+++ b/pkg/past/build.zig
@@ -18,9 +18,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         if (macos_sdk != null) {
-            pkg_past.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-            pkg_past.addLibraryPath(macos_sdk.?.path("usr/lib"));
-            pkg_past.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+            pkg_past.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            pkg_past.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            pkg_past.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
         }
     }
 
@@ -41,11 +41,11 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    pkg_past.linkLibC();
+    pkg_past.root_module.link_libc = true;
 
-    pkg_past.linkLibrary(pkg_c3.artifact("c3"));
-    pkg_past.linkLibrary(pkg_noun.artifact("noun"));
-    pkg_past.linkLibrary(gmp.artifact("gmp"));
+    pkg_past.root_module.linkLibrary(pkg_c3.artifact("c3"));
+    pkg_past.root_module.linkLibrary(pkg_noun.artifact("noun"));
+    pkg_past.root_module.linkLibrary(gmp.artifact("gmp"));
 
     var flags = std.array_list.Managed([]const u8).init(b.allocator);
     defer flags.deinit();
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) !void {
     });
     try flags.appendSlice(copts);
 
-    pkg_past.addCSourceFiles(.{
+    pkg_past.root_module.addCSourceFiles(.{
         .root = b.path(""),
         .files = &c_source_files,
         .flags = flags.items,

--- a/pkg/past/build.zig.zon
+++ b/pkg/past/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "past",
+    .name = .past,
+    .fingerprint = 0x5014418727220854,
     .version = "0.0.1",
     .dependencies = .{
         .macos_sdk = .{

--- a/pkg/ur/build.zig
+++ b/pkg/ur/build.zig
@@ -17,11 +17,11 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    pkg_ur.linkLibC();
-    pkg_ur.linkLibrary(murmur3.artifact("murmur3"));
+    pkg_ur.root_module.link_libc = true;
+    pkg_ur.root_module.linkLibrary(murmur3.artifact("murmur3"));
 
-    pkg_ur.addIncludePath(b.path(""));
-    pkg_ur.addCSourceFiles(.{
+    pkg_ur.root_module.addIncludePath(b.path(""));
+    pkg_ur.root_module.addCSourceFiles(.{
         .root = b.path(""),
         .files = &.{
             "bitstream.c",

--- a/pkg/ur/build.zig.zon
+++ b/pkg/ur/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ur,
-    .fingeprint = 0xad9a8f5c919f2264,
+    .fingerprint = 0xad9a8f5c919f2264,
     .version = "0.0.1",
     .dependencies = .{
         .murmur3 = .{

--- a/pkg/vere/build.zig
+++ b/pkg/vere/build.zig
@@ -20,9 +20,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         if (macos_sdk != null) {
-            pkg_vere.addSystemIncludePath(macos_sdk.?.path("usr/include"));
-            pkg_vere.addLibraryPath(macos_sdk.?.path("usr/lib"));
-            pkg_vere.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
+            pkg_vere.root_module.addSystemIncludePath(macos_sdk.?.path("usr/include"));
+            pkg_vere.root_module.addLibraryPath(macos_sdk.?.path("usr/lib"));
+            pkg_vere.root_module.addFrameworkPath(macos_sdk.?.path("System/Library/Frameworks"));
         }
     }
 
@@ -136,32 +136,32 @@ pub fn build(b: *std.Build) !void {
         break :blk try output.toOwnedSlice();
     });
 
-    pkg_vere.addIncludePath(pace_h.getDirectory());
-    pkg_vere.addIncludePath(version_h.getDirectory());
-    pkg_vere.addIncludePath(b.path(""));
-    pkg_vere.addIncludePath(b.path("ivory"));
-    pkg_vere.addIncludePath(b.path("ca_bundle"));
+    pkg_vere.root_module.addIncludePath(pace_h.getDirectory());
+    pkg_vere.root_module.addIncludePath(version_h.getDirectory());
+    pkg_vere.root_module.addIncludePath(b.path(""));
+    pkg_vere.root_module.addIncludePath(b.path("ivory"));
+    pkg_vere.root_module.addIncludePath(b.path("ca_bundle"));
 
     if (t.os.tag == .linux) {
-        pkg_vere.linkLibrary(avahi.artifact("dns-sd"));
+        pkg_vere.root_module.linkLibrary(avahi.artifact("dns-sd"));
     }
-    pkg_vere.linkLibrary(natpmp.artifact("natpmp"));
-    pkg_vere.linkLibrary(curl.artifact("curl"));
+    pkg_vere.root_module.linkLibrary(natpmp.artifact("natpmp"));
+    pkg_vere.root_module.linkLibrary(curl.artifact("curl"));
 
-    pkg_vere.linkLibrary(gmp.artifact("gmp"));
+    pkg_vere.root_module.linkLibrary(gmp.artifact("gmp"));
 
-    pkg_vere.linkLibrary(h2o.artifact("h2o"));
-    pkg_vere.linkLibrary(libuv.artifact("libuv"));
-    pkg_vere.linkLibrary(lmdb.artifact("lmdb"));
-    pkg_vere.linkLibrary(openssl.artifact("ssl"));
-    pkg_vere.linkLibrary(urcrypt.artifact("urcrypt"));
-    pkg_vere.linkLibrary(zlib.artifact("z"));
-    pkg_vere.linkLibrary(pkg_c3.artifact("c3"));
-    pkg_vere.linkLibrary(pkg_ent.artifact("ent"));
-    pkg_vere.linkLibrary(pkg_ur.artifact("ur"));
-    pkg_vere.linkLibrary(pkg_noun.artifact("noun"));
-    pkg_vere.linkLibrary(pkg_past.artifact("past"));
-    pkg_vere.linkLibC();
+    pkg_vere.root_module.linkLibrary(h2o.artifact("h2o"));
+    pkg_vere.root_module.linkLibrary(libuv.artifact("libuv"));
+    pkg_vere.root_module.linkLibrary(lmdb.artifact("lmdb"));
+    pkg_vere.root_module.linkLibrary(openssl.artifact("ssl"));
+    pkg_vere.root_module.linkLibrary(urcrypt.artifact("urcrypt"));
+    pkg_vere.root_module.linkLibrary(zlib.artifact("z"));
+    pkg_vere.root_module.linkLibrary(pkg_c3.artifact("c3"));
+    pkg_vere.root_module.linkLibrary(pkg_ent.artifact("ent"));
+    pkg_vere.root_module.linkLibrary(pkg_ur.artifact("ur"));
+    pkg_vere.root_module.linkLibrary(pkg_noun.artifact("noun"));
+    pkg_vere.root_module.linkLibrary(pkg_past.artifact("past"));
+    pkg_vere.root_module.link_libc = true;
 
     var files = std.array_list.Managed([]const u8).init(b.allocator);
     defer files.deinit();
@@ -181,7 +181,7 @@ pub fn build(b: *std.Build) !void {
     }
 
     if (t.os.tag == .windows) {
-        pkg_vere.addIncludePath(b.path("platform/windows"));
+        pkg_vere.root_module.addIncludePath(b.path("platform/windows"));
         try files.appendSlice(&.{
             "platform/windows/ptty.c",
             "platform/windows/ctrlc.c",
@@ -196,7 +196,7 @@ pub fn build(b: *std.Build) !void {
     });
     try flags.appendSlice(copts);
 
-    pkg_vere.addCSourceFiles(.{
+    pkg_vere.root_module.addCSourceFiles(.{
         .root = b.path(""),
         .files = files.items,
         .flags = flags.items,

--- a/pkg/vere/build.zig.zon
+++ b/pkg/vere/build.zig.zon
@@ -51,8 +51,8 @@
             .path = "../../ext/urcrypt",
         },
         .zlib = .{
-            .url = "https://github.com/allyourcodebase/zlib/archive/61e7df7e996ec5a5f13a653db3c419adb340d6ef.tar.gz",
-            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
+            .url = "https://github.com/allyourcodebase/zlib/archive/d3b5519d3b73616a6bfece0712f080029d2a9244.tar.gz",
+            .hash = "zlib-1.3.2-ZZQ7lc8NAAAHm9MDfplvwoesXvk4tVm6VCsiI8KnIbT0",
         },
     },
     .paths = .{


### PR DESCRIPTION
Bumping to latest Zig also fixes compiling for [macOS Tahoe 26.4 or later](https://codeberg.org/ziglang/zig/issues/31669).

Update: Putting this into DRAFT mode due to [optimization regressions](https://github.com/llvm/llvm-project/issues/186922) thanks to Zig 0.16.0's use of LLVM 21.

Note: For those on macOS Tahoe 26.4 or later, install [Xcode 26.3 Command Line Tools](https://download.developer.apple.com/Developer_Tools/Command_Line_Tools_for_Xcode_26.3/Command_Line_Tools_for_Xcode_26.3.dmg) (you may need to login with an Apple Developer account) workaround to fix Zig 0.15.2 builds. After downloading, install the `.dmg` file, run `sudo xcode-select --switch /Library/Developer/CommandLineTools`, and confirm `clang --version` reports version `17.0.0`. If you don't see this version, you may need to update your `PATH` (via `~/.zshrc` or elsewhere) to ensure you're not overriding the LLVM version with a Homebrew version or similar. Finally, you can use `zvm use 0.15.2` (or however you manage your Zig installations) to switch back to `0.15.2` (if you'd switched to `0.16.0` previously), and try re-compiling Vere.  