### PR TITLE
vere: refcount fixes

### DIFF
--- a/pkg/noun/jets/b/skid.c
+++ b/pkg/noun/jets/b/skid.c
@@ -22,25 +22,20 @@ u3qb_skid(u3_noun a, u3_noun b)
 
     do {
       i = u3k(u3k(u3h(a)));
+
+      if ( c3y == u3x_loob(u3j_gate_slam(&sit_u, i)) ) {
+        *lef = u3i_defcons(&hed, &tel);
+        *hed = i;
+        lef  = tel;
+      }
+      else {
+        *rig = u3i_defcons(&hed, &tel);
+        *hed = i;
+        rig  = tel;
+      }
+      
       t = u3k(u3t(a));
       u3z(a), a = t;
-
-      switch ( u3j_gate_slam(&sit_u, i) ) {
-        case c3y: {
-          *lef = u3i_defcons(&hed, &tel);
-          *hed = i;
-          lef  = tel;
-        } break;
-
-        case c3n: {
-          *rig = u3i_defcons(&hed, &tel);
-          *hed = i;
-          rig  = tel;
-        } break;
-
-        default: u3m_bail(c3__exit);
-      }
-
     }
     while ( u3_nul != a );
 

--- a/pkg/noun/jets/b/skid.c
+++ b/pkg/noun/jets/b/skid.c
@@ -21,26 +21,26 @@ u3qb_skid(u3_noun a, u3_noun b)
     u3k(a);
 
     do {
-      i = u3h(a);
+      i = u3k(u3k(u3h(a)));
+      t = u3k(u3t(a));
+      u3z(a), a = t;
 
-      switch ( u3j_gate_slam(&sit_u, u3k(i)) ) {
+      switch ( u3j_gate_slam(&sit_u, i) ) {
         case c3y: {
           *lef = u3i_defcons(&hed, &tel);
-          *hed = u3k(i);
+          *hed = i;
           lef  = tel;
         } break;
 
         case c3n: {
           *rig = u3i_defcons(&hed, &tel);
-          *hed = u3k(i);
+          *hed = i;
           rig  = tel;
         } break;
 
         default: u3m_bail(c3__exit);
       }
 
-      t = u3k(u3t(a));
-      u3z(a), a = t;
     }
     while ( u3_nul != a );
 

--- a/pkg/noun/jets/b/skim.c
+++ b/pkg/noun/jets/b/skim.c
@@ -20,22 +20,23 @@ u3qb_skim(u3_noun a, u3_noun b)
     u3k(a);
 
     do {
-      i = u3h(a);
+      i = u3k(u3k(u3h(a)));
+      t = u3k(u3t(a));
+      u3z(a), a = t;
 
-      switch ( u3j_gate_slam(&sit_u, u3k(i)) ) {
+      switch ( u3j_gate_slam(&sit_u, i) ) {
         case c3y: {
           *lit = u3i_defcons(&hed, &tel);
-          *hed = u3k(i);
+          *hed = i;
           lit  = tel;
         } break;
 
-        case c3n: break;
+        case c3n: {
+          u3z(i);
+        } break;
 
         default: u3m_bail(c3__exit);
       }
-
-      t = u3k(u3t(a));
-      u3z(a), a = t;
     }
     while ( u3_nul != a );
 

--- a/pkg/noun/jets/b/skim.c
+++ b/pkg/noun/jets/b/skim.c
@@ -21,22 +21,18 @@ u3qb_skim(u3_noun a, u3_noun b)
 
     do {
       i = u3k(u3k(u3h(a)));
+
+      if ( c3y == u3x_loob(u3j_gate_slam(&sit_u, i)) ) {
+        *lit = u3i_defcons(&hed, &tel);
+        *hed = i;
+        lit  = tel;
+      }
+      else {
+        u3z(i);
+      }
+      
       t = u3k(u3t(a));
       u3z(a), a = t;
-
-      switch ( u3j_gate_slam(&sit_u, i) ) {
-        case c3y: {
-          *lit = u3i_defcons(&hed, &tel);
-          *hed = i;
-          lit  = tel;
-        } break;
-
-        case c3n: {
-          u3z(i);
-        } break;
-
-        default: u3m_bail(c3__exit);
-      }
     }
     while ( u3_nul != a );
 

--- a/pkg/noun/jets/b/skip.c
+++ b/pkg/noun/jets/b/skip.c
@@ -20,22 +20,23 @@ u3qb_skip(u3_noun a, u3_noun b)
     u3k(a);
 
     do {
-      i = u3h(a);
+      i = u3k(u3k(u3h(a)));
+      t = u3k(u3t(a));
+      u3z(a), a = t;
 
-      switch ( u3j_gate_slam(&sit_u, u3k(i)) ) {
-        case c3y: break;
+      switch ( u3j_gate_slam(&sit_u, i) ) {
+        case c3y: {
+          u3z(i);
+        } break;
 
         case c3n: {
           *lit = u3i_defcons(&hed, &tel);
-          *hed = u3k(i);
+          *hed = i;
           lit  = tel;
         } break;
 
         default: u3m_bail(c3__exit);
       }
-
-      t = u3k(u3t(a));
-      u3z(a), a = t;
     }
     while ( u3_nul != a );
 

--- a/pkg/noun/jets/b/skip.c
+++ b/pkg/noun/jets/b/skip.c
@@ -21,22 +21,18 @@ u3qb_skip(u3_noun a, u3_noun b)
 
     do {
       i = u3k(u3k(u3h(a)));
+
+      if ( c3y == u3x_loob(u3j_gate_slam(&sit_u, i)) ) {
+        u3z(i);
+      }
+      else {
+        *lit = u3i_defcons(&hed, &tel);
+        *hed = i;
+        lit  = tel;
+      }
+      
       t = u3k(u3t(a));
       u3z(a), a = t;
-
-      switch ( u3j_gate_slam(&sit_u, i) ) {
-        case c3y: {
-          u3z(i);
-        } break;
-
-        case c3n: {
-          *lit = u3i_defcons(&hed, &tel);
-          *hed = i;
-          lit  = tel;
-        } break;
-
-        default: u3m_bail(c3__exit);
-      }
     }
     while ( u3_nul != a );
 

--- a/pkg/noun/jets/d/by_all.c
+++ b/pkg/noun/jets/d/by_all.c
@@ -12,16 +12,23 @@ _by_all(u3_noun a, u3j_site* sit_u)
     return c3y;
   }
   else {
-    u3_noun n_a, l_a, r_a;
+    u3_noun n_a, l_a, r_a, q_n_a;
     u3x_trel(a, &n_a, &l_a, &r_a);
+    u3x_cell(n_a, NULL, &q_n_a);
+    u3k(l_a); u3k(r_a); u3k(q_n_a);
+    u3z(a);
 
-    switch ( u3j_gate_slam(sit_u, u3k(u3t(n_a))) ) {
+    switch ( u3j_gate_slam(sit_u, q_n_a) ) {
       case c3y: break;
-      case c3n: return c3n;
+      case c3n: {
+        u3z(l_a); u3z(r_a); 
+        return c3n;
+      }
       default:  return u3m_bail(c3__exit);
     }
 
     if ( c3n == _by_all(l_a, sit_u) ) {
+      u3z(r_a); 
       return c3n;
     }
 
@@ -36,7 +43,7 @@ u3qdb_all(u3_noun a, u3_noun b)
   u3j_site sit_u;
 
   u3j_gate_prep(&sit_u, u3k(b));
-  pro = _by_all(a, &sit_u);
+  pro = _by_all(u3k(a), &sit_u);
   u3j_gate_lose(&sit_u);
 
   return pro;

--- a/pkg/noun/jets/d/by_any.c
+++ b/pkg/noun/jets/d/by_any.c
@@ -12,16 +12,23 @@ _by_any(u3_noun a, u3j_site* sit_u)
     return c3n;
   }
   else {
-    u3_noun n_a, l_a, r_a;
+    u3_noun n_a, l_a, r_a, q_n_a;
     u3x_trel(a, &n_a, &l_a, &r_a);
+    u3x_cell(n_a, NULL, &q_n_a);
+    u3k(l_a); u3k(r_a); u3k(q_n_a);
+    u3z(a);
 
-    switch ( u3j_gate_slam(sit_u, u3k(u3t(n_a))) ) {
-      case c3y: return c3y;
+    switch ( u3j_gate_slam(sit_u, q_n_a) ) {
+      case c3y: {
+        u3z(l_a); u3z(r_a); 
+        return c3y;
+      }
       case c3n: break;
       default:  return u3m_bail(c3__exit);
     }
 
     if ( c3y == _by_any(l_a, sit_u) ) {
+      u3z(r_a); 
       return c3y;
     }
 
@@ -36,7 +43,7 @@ u3qdb_any(u3_noun a, u3_noun b)
   u3j_site sit_u;
 
   u3j_gate_prep(&sit_u, u3k(b));
-  pro = _by_any(a, &sit_u);
+  pro = _by_any(u3k(a), &sit_u);
   u3j_gate_lose(&sit_u);
 
   return pro;

--- a/pkg/noun/retrieve.c
+++ b/pkg/noun/retrieve.c
@@ -38,6 +38,10 @@ u3r_hext(u3_noun  a,
          u3_noun* f,
          u3_noun* g);
 
+/* u3r_cat: assert direct atom
+*/
+u3_atom u3r_cat(u3_noun a);
+
 /* _frag_word(): fast fragment/branch prediction for top word.
 */
 static u3_weak

--- a/pkg/noun/retrieve.h
+++ b/pkg/noun/retrieve.h
@@ -105,6 +105,14 @@
           else return c3n;
         }
 
+      /* u3r_cat: assert direct atom
+      */
+        inline u3_atom
+        u3r_cat(u3_noun a)
+        {
+          return ( c3y == u3a_is_cat(a) ) ? a : u3m_bail(c3__fail);
+        }
+
       /* u3r_at(): fragment `a` of `b`, or u3_none.
       */
         u3_weak

--- a/pkg/vere/dawn.c
+++ b/pkg/vere/dawn.c
@@ -169,7 +169,7 @@ static void
 _dawn_fail(u3_noun who, u3_noun rac, u3_noun sas)
 {
   u3_noun how = u3dc("scot", 'p', u3k(who));
-  c3_c* how_c = u3r_string(u3k(how));
+  c3_c* how_c = u3r_string(how);
 
   c3_c* rac_c;
 
@@ -260,7 +260,7 @@ _dawn_sponsor(u3_noun who, u3_noun rac, u3_noun pot)
   u3_noun uni = u3dc("sponsor:dawn", u3k(who), u3k(pot));
 
   if ( c3n == u3h(uni) ) {
-    _dawn_fail(who, rac, u3nc(u3t(uni), u3_nul));
+    _dawn_fail(who, rac, u3nc(u3k(u3t(uni)), u3_nul));
     return u3_none;
   }
 

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -806,6 +806,7 @@ u3_ames_decode_lane(u3_atom lan) {
   c3_d lan_d;
 
   if ( c3n == u3r_safe_chub(lan, &lan_d) || (lan_d >> 48) != 0 ) {
+    u3z(lan);
     return (u3_lane){0, 0};
   }
 
@@ -1745,6 +1746,7 @@ _fine_hunk_scry_cb(void* vod_p, u3_noun nun)
       _ames_pact_free(pac_u);
 
       u3z(nun);
+      u3z(pax);
       return;
     }
 

--- a/pkg/vere/io/cttp.c
+++ b/pkg/vere/io/cttp.c
@@ -563,7 +563,7 @@ _cttp_creq_new(u3_cttp* ctp_u, c3_l num_l, u3_noun hes)
   //
   u3_noun unit_pul = u3do("de-purl:html", u3k(url));
 
-  if ( c3n == u3du(unit_pul) ) {
+  if ( u3_nul == unit_pul ) {
     c3_c* url_c = u3r_string(url);
     u3l_log("cttp: unable to parse url:\n    %s", url_c);
     c3_free(url_c);

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -1171,6 +1171,7 @@ _http_scry_respond(u3_hreq* req_u, u3_noun nun)
       h2o_send_error_generic(rec_u, 400, msg_c, msg_c, 0);
     }
     else {
+      u3z(req);
       h2o_send_error_500(rec_u, "Internal Server Error", "scry failed", 0);
     }
   }

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -842,6 +842,7 @@ u3_mesa_decode_lane(u3_atom lan) {
   c3_d lan_d;
 
   if ( c3n == u3r_safe_chub(lan, &lan_d) || (lan_d >> 48) != 0 ) {
+    u3z(lan);
     return adr_u;
   }
 
@@ -1900,6 +1901,7 @@ _mesa_hear_bail(u3_ovum* egg_u, u3_noun lud)
     u3_pier_punt_goof("crud", u3k(u3h(u3t(lud))));
   }
   u3_ovum_free(egg_u);
+  u3z(lud);
 }
 
 static void
@@ -2039,6 +2041,7 @@ _mesa_veri_scry_cb(void* vod_p, u3_noun nun)
   u3_mesa_cb_data* ver_u = vod_p;
   u3_pend_req* req_u = _mesa_get_request(ver_u->sam_u, &ver_u->nam_u);
   if ( !req_u ) {
+    u3z(nun);
     return;
   }
   else if ( c3y == nun ) {  // XX
@@ -2053,6 +2056,7 @@ _mesa_veri_scry_cb(void* vod_p, u3_noun nun)
     u3l_log("mesa: %%veri returned strange value");
   }
   c3_free(ver_u);
+  u3z(nun);
 }
 
 static void
@@ -2458,6 +2462,7 @@ _mesa_poke_bail_cb(u3_ovum* egg_u, u3_noun lud)
 {
   // XX failure stuff here
   u3l_log("mesa: poke failure");
+  u3z(lud);
 }
 
 static void

--- a/pkg/vere/io/term.c
+++ b/pkg/vere/io/term.c
@@ -1090,11 +1090,11 @@ _term_it_put_value(c3_w*   lin_w,
                    u3_atom val)
 {
   c3_c str_c[4];
+  if ( c3n == u3a_is_cat(val) ) u3m_bail(c3__fail);
   c3_w len = snprintf(str_c, 4, "%d", val % 256);
   for ( c3_w i_w = 0; i_w < len; i_w++ ) {
     lin_w[i_w] = str_c[i_w];
   }
-  u3z(val);
   return len;
 }
 
@@ -1634,7 +1634,7 @@ _term_io_talk(u3_auto* car_u)
  *    Parses a text string which contains a decimal number. In practice, this
  *    number is always '1'.
  */
-static u3_noun
+static c3_o
 _reck_orchid(u3_noun fot, u3_noun txt, c3_l* tid_l)
 {
   c3_c* str = u3r_string(txt);
@@ -1690,7 +1690,7 @@ _term_io_kick(u3_auto* car_u, u3_noun wir, u3_noun cad)
 
     if (  (c3n == u3r_cell(pud, &p_pud, &q_pud))
        || (u3_nul != q_pud)
-       || (c3n == _reck_orchid(c3__ud, u3k(p_pud), &tid_l)) )
+       || (c3n == _reck_orchid(c3__ud, p_pud, &tid_l)) )
     {
       u3l_log("term: bad tire");
       ret_o = c3n;

--- a/pkg/vere/io/unix.c
+++ b/pkg/vere/io/unix.c
@@ -106,7 +106,7 @@ struct _u3_ufil;
   } u3_unix;
 
 void
-u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, u3_noun all);
+u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, c3_o all_o);
 
 /* u3_unix_cane(): true iff (unix) path is canonical.
 */
@@ -149,7 +149,7 @@ u3_unix_cane(const c3_c* pax_c)
 static c3_t
 _unix_sane_ta(u3_unix* unx_u, u3_atom pat)
 {
-  return _(u3n_slam_on(u3k(unx_u->sat), pat));
+  return _(u3x_loob(u3n_slam_on(u3k(unx_u->sat), pat)));
 }
 
 /* u3_readdir_r():
@@ -446,7 +446,7 @@ _unix_write_file_hard(c3_c* pax_c, u3_noun mim)
     return 0;
   }
 
-  siz_w = u3h(u3t(mim));
+  siz_w = u3r_cat(u3h(u3t(mim)));
   len_w = u3r_met(3, dat);
   dat_y = c3_calloc(siz_w);
 
@@ -1139,7 +1139,7 @@ _unix_update_node(u3_unix* unx_u, u3_unod* nod_u)
 /* _unix_update_mount(): update mount point
 */
 static void
-_unix_update_mount(u3_unix* unx_u, u3_umon* mon_u, u3_noun all)
+_unix_update_mount(u3_unix* unx_u, u3_umon* mon_u, c3_o all_o)
 {
   if ( c3n == mon_u->dir_u.dry ) {
     u3_noun  can = u3_nul;
@@ -1154,7 +1154,7 @@ _unix_update_mount(u3_unix* unx_u, u3_umon* mon_u, u3_noun all)
       u3_noun wir = u3nt(c3__sync,
                         u3dc("scot", c3__uv, unx_u->sev_l),
                         u3_nul);
-      u3_noun cad = u3nq(c3__into, _unix_string_to_knot(mon_u->nam_c), all,
+      u3_noun cad = u3nq(c3__into, _unix_string_to_knot(mon_u->nam_c), all_o,
                          can);
 
       u3_auto_plan(&unx_u->car_u, u3_ovum_init(0, c3__c, wir, cad));
@@ -1372,7 +1372,7 @@ _unix_sync_change(u3_unix* unx_u, u3_udir* dir_u, u3_noun pax, u3_noun mim)
   }
   else if ( c3n == u3du(u3t(pax)) ) {
     u3l_log("can't sync out file as top-level, strangely");
-    u3z(pax); u3z(mim);
+    u3z(mim);
   }
   else {
     u3_noun i_pax = u3h(pax);
@@ -1478,7 +1478,7 @@ u3_unix_ef_hill(u3_unix* unx_u, u3_noun hil)
 /* u3_unix_ef_look(): update the root of a specific mount point.
 */
 void
-u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, u3_noun all)
+u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, c3_o all_o)
 {
   if ( c3y == unx_u->dyr ) {
     c3_c* nam_c = _unix_knot_to_string(mon);
@@ -1490,7 +1490,7 @@ u3_unix_ef_look(u3_unix* unx_u, u3_noun mon, u3_noun all)
     }
     c3_free(nam_c);
     if ( mon_u ) {
-      _unix_update_mount(unx_u, mon_u, all);
+      _unix_update_mount(unx_u, mon_u, all_o);
     }
   }
   u3z(mon);

--- a/pkg/vere/king.c
+++ b/pkg/vere/king.c
@@ -236,7 +236,7 @@ _king_prop()
 void
 _king_fake(u3_noun ship, u3_noun pill, u3_noun path)
 {
-  u3_noun vent = u3nc(c3__fake, u3k(ship));
+  u3_noun vent = u3nc(c3__fake, ship);
 
   //  XX pass kelvin
   //
@@ -255,6 +255,7 @@ _king_fake(u3_noun ship, u3_noun pill, u3_noun path)
 void
 _king_come(u3_noun star, u3_noun pill, u3_noun path)
 {
+  u3z(star);
   _king_dawn(u3_dawn_come(), pill, path);
 }
 
@@ -729,7 +730,7 @@ _boothack_key(u3_noun kef)
          (c3n == u3r_sing(ship, u3t(whu))) )
     {
       u3_noun how = u3dc("scot", 'p', u3k(ship));
-      c3_c* how_c = u3r_string(u3k(how));
+      c3_c* how_c = u3r_string(how);
       u3l_log("dawn: mismatch between -w %s and -K %s",
               u3_Host.ops_u.who_c, how_c);
 

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -209,7 +209,7 @@ _lord_plea_foul(u3_lord* god_u, c3_m mot_m, u3_noun dat)
   //  XX can't unconditionally print
   //
   // u3m_p("plea", dat);
-
+  u3z(dat);
   _lord_bail(god_u);
 }
 
@@ -240,6 +240,7 @@ _lord_plea_ripe(u3_lord* god_u, u3_noun dat)
   if ( c3y == god_u->liv_o ) {
     fprintf(stderr, "lord: received unexpected %%ripe\n");
     _lord_bail(god_u);
+    u3z(dat);
     return;
   }
 
@@ -632,7 +633,7 @@ _lord_writ_make(u3_lord* god_u, u3_writ* wit_u)
 
     case u3_writ_quiz: {
       msg = u3nt(c3__quiz, wit_u->qiz_u.qiz_m, u3_nul);
-    }
+    } break;
 
     case u3_writ_exit: {
       msg = u3nc(c3__exit, u3_nul);
@@ -1341,6 +1342,7 @@ u3_lord_boot(c3_c* pax_c,
       fprintf(stderr, "spawn: %s: %s\r\n", arg_c[0], uv_strerror(err_i));
       //  XX return error code, or defer and invoke cb
       //
+      u3z(msg);
       return;
     }
   }

--- a/pkg/vere/lord.c
+++ b/pkg/vere/lord.c
@@ -209,7 +209,6 @@ _lord_plea_foul(u3_lord* god_u, c3_m mot_m, u3_noun dat)
   //  XX can't unconditionally print
   //
   // u3m_p("plea", dat);
-  u3z(dat);
   _lord_bail(god_u);
 }
 
@@ -240,7 +239,6 @@ _lord_plea_ripe(u3_lord* god_u, u3_noun dat)
   if ( c3y == god_u->liv_o ) {
     fprintf(stderr, "lord: received unexpected %%ripe\n");
     _lord_bail(god_u);
-    u3z(dat);
     return;
   }
 

--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -651,6 +651,7 @@ _mars_work(u3_mars* mar_u, u3_noun jar)
       }
 
       mar_u->sat_e = u3_mars_save_e;
+      u3z(jar);
     } break;
 
     //  $%  [%live ?(%meld %pack) ~] :: XX rename

--- a/pkg/vere/pier.c
+++ b/pkg/vere/pier.c
@@ -1452,6 +1452,7 @@ u3_pier_punt_ovum(const c3_c* cap_c, u3_noun wir, u3_noun tag)
   c3_free(tag_c);
   c3_free(wir_c);
   u3z(riw);
+  u3z(tag);
 }
 
 /* u3_pier_sway(): print trace.


### PR DESCRIPTION
Contains refcount fixes found in #1059 separately, so that #1059 only contains only refcount annotations.

Depends on #1079

---

List of fixes:
- `by_all`/`by_any` jets slammed the gate while keeping uncounted references to `l_a` and `r_a`
- `skid`/`skim`/`skip` held uncounted reference to `i` during slam.
- `ames.c` missing `u3z` in some branches
- `http.c` missing `u3z` in some branches, callbacks retained instead of transferring, which seems to be the protocol for callbacks
- `term.c`: leak fixes (`_reck_orchid` retains), direct atom assertion
- `unix.c` direct atom assertions
- `dawn.c` u3r_string retains, u3nc transfers (although not a big deal right now as dawn_fail is noreturn)
- `king.c` helpers transfer
- `lord.c` missing break in switch!
- `mars.c` `jar` leak
- `pier.c` `tag` is transferred (probably left from u3r_string transferring long time ago)