### PR TITLE
u3_none fixes + some more refcount fixes

### DIFF
--- a/pkg/noun/jets/e/bytestream.c
+++ b/pkg/noun/jets/e/bytestream.c
@@ -166,7 +166,7 @@ u3we_bytestream_cat_octs(u3_noun cor) {
 
 }
 
-u3_noun
+u3_weak
 _qe_bytestream_can_octs(u3_noun octs_list) {
 
   if (u3_nul == octs_list) {
@@ -190,7 +190,6 @@ _qe_bytestream_can_octs(u3_noun octs_list) {
 
   u3_noun octs_list_start = octs_list;
   u3_noun octs;
-  // Last non-zero octs
 
   while (octs_list != u3_nul) {
 
@@ -899,7 +898,7 @@ _qe_bytestream_fuse_extract(u3_noun sea, u3_noun rac)
   }
 
   u3_noun lad = u3kb_flop(dal);
-  u3_noun data = _qe_bytestream_can_octs(lad);
+  u3_weak data = _qe_bytestream_can_octs(lad);
   u3z(lad);
   if ( u3_none == data ) {
     return u3_none;

--- a/pkg/noun/jets/e/bytestream.c
+++ b/pkg/noun/jets/e/bytestream.c
@@ -189,9 +189,8 @@ _qe_bytestream_can_octs(u3_noun octs_list) {
   c3_d tot_d = 0;
 
   u3_noun octs_list_start = octs_list;
-  u3_noun octs = u3_none;
+  u3_noun octs;
   // Last non-zero octs
-  u3_noun last_octs = u3_none;
 
   while (octs_list != u3_nul) {
 
@@ -902,6 +901,9 @@ _qe_bytestream_fuse_extract(u3_noun sea, u3_noun rac)
   u3_noun lad = u3kb_flop(dal);
   u3_noun data = _qe_bytestream_can_octs(lad);
   u3z(lad);
+  if ( u3_none == data ) {
+    return u3_none;
+  }
 
   new_sea = u3nc(u3i_word(pos_w), u3k(octs));
 

--- a/pkg/noun/jets/e/crc.c
+++ b/pkg/noun/jets/e/crc.c
@@ -51,7 +51,10 @@ u3we_crc32(u3_noun cor)
 {
   u3_noun a = u3r_at(u3x_sam, cor);
 
-  if ( (u3du(a) == c3y) && (u3ud(u3h(a)) == c3y) && (u3ud(u3t(a)) == c3y) ) {
+  if ( (u3_none != a)
+  && (u3du(a) == c3y)
+  && (u3ud(u3h(a)) == c3y)
+  && (u3ud(u3t(a)) == c3y) ) {
     return u3qe_crc32(a);
   } else {
     return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/loss.c
+++ b/pkg/noun/jets/e/loss.c
@@ -244,7 +244,7 @@
   {
     while ( u3_nul != loc_u->hel ) {
       u3_noun i_hel = u3h(loc_u->hel);
-      u3_noun guy   = u3kdb_get(u3k(loc_u->sev), u3k(i_hel));
+      u3_weak guy   = u3kdb_get(u3k(loc_u->sev), u3k(i_hel));
 
       if ( u3_none != guy ) {
         u3_noun gay = u3kb_flop(guy);

--- a/pkg/noun/jets/e/parse.c
+++ b/pkg/noun/jets/e/parse.c
@@ -12,8 +12,8 @@
   _puq(u3_noun vex)
   {
     u3_weak pro = u3r_at(14, vex);
-    c3_dessert(u3_none != pro);
-    return (u3_noun)pro;
+    if ( u3_none == pro ) return u3m_bail(c3__fail);
+    return pro;
   }
 
   // get q.u.q.vex from an $edge, assumes that the unit is non-empty
@@ -23,8 +23,8 @@
   _quq(u3_noun vex)
   {
     u3_weak pro = u3r_at(15, vex);
-    c3_dessert(u3_none != pro);
-    return (u3_noun)pro;
+    if ( u3_none == pro ) return u3m_bail(c3__fail);
+    return pro;
   }
 
   #define   _p    u3h

--- a/pkg/noun/jets/e/rd.c
+++ b/pkg/noun/jets/e/rd.c
@@ -205,9 +205,9 @@
   u3_noun
   u3wer_sqt(u3_noun cor)
   {
-    u3_noun a;
+    u3_weak a;
 
-    if ( c3n == (a = u3r_at(u3x_sam, cor)) ||
+    if ( u3_none == (a = u3r_at(u3x_sam, cor)) ||
          c3n == u3ud(a) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/rh.c
+++ b/pkg/noun/jets/e/rh.c
@@ -205,9 +205,9 @@
   u3_noun
   u3wes_sqt(u3_noun cor)
   {
-    u3_noun a;
+    u3_weak a;
 
-    if ( c3n == (a = u3r_at(u3x_sam, cor)) ||
+    if ( u3_none == (a = u3r_at(u3x_sam, cor)) ||
          c3n == u3ud(a) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/rq.c
+++ b/pkg/noun/jets/e/rq.c
@@ -234,9 +234,9 @@
   u3_noun
   u3weq_sqt(u3_noun cor)
   {
-    u3_noun a;
+    u3_weak a;
 
-    if ( c3n == (a = u3r_at(u3x_sam, cor)) ||
+    if ( u3_none == (a = u3r_at(u3x_sam, cor)) ||
          c3n == u3ud(a) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/rs.c
+++ b/pkg/noun/jets/e/rs.c
@@ -205,9 +205,9 @@
   u3_noun
   u3wet_sqt(u3_noun cor)
   {
-    u3_noun a;
+    u3_weak a;
 
-    if ( c3n == (a = u3r_at(u3x_sam, cor)) ||
+    if ( u3_none == (a = u3r_at(u3x_sam, cor)) ||
          c3n == u3ud(a) )
     {
       return u3m_bail(c3__exit);

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -1448,7 +1448,8 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
     {
       c3_d f_idx_d;
       m3_SuspendStackPop64(sat_u->wasm_module->runtime, &f_idx_d);
-      u3_noun frame = _pop_list(&sat_u->susp_list);
+      u3_weak frame = _pop_list(&sat_u->susp_list);
+      if ( u3_none == frame ) u3m_bail(c3__fail);
       if (lst_call != u3h(frame))
       {
         printf(ERR("wrong frame: call"));
@@ -1528,7 +1529,8 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
     {
       if (1 != u3h(sat_u->resolution))
       {
-        u3_noun frame = _pop_list(&sat_u->susp_list);
+        u3_weak frame = _pop_list(&sat_u->susp_list);
+        if ( u3_none == frame ) u3m_bail(c3__fail);
         if (lst_try != u3h(frame))
         {
           printf(ERR("wrong frame: try"));
@@ -1563,7 +1565,8 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
     {
       if (1 != u3h(sat_u->resolution))
       {
-        u3_noun frame = _pop_list(&sat_u->susp_list);
+        u3_weak frame = _pop_list(&sat_u->susp_list);
+        if ( u3_none == frame ) u3m_bail(c3__fail);
         if (lst_catch_try != u3h(frame))
         {
           printf(ERR("wrong frame: catch-try"));
@@ -1608,7 +1611,8 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
               printf(ERR("catch-err tag mismatch: %"PRIc3_d), tag);
               u3m_bail(c3__fail);
             }
-            u3_noun frame1 = _pop_list(&sat_u->susp_list);
+            u3_weak frame1 = _pop_list(&sat_u->susp_list);
+            if ( u3_none == frame1 ) u3m_bail(c3__fail);
             if (lst_catch_err != u3h(frame1))
             {
               printf(ERR("wrong frame: catch-err"));
@@ -1654,7 +1658,8 @@ _resume_callback(M3Result result_m3, IM3Runtime runtime)
     {
       if (1 != u3h(sat_u->resolution))
       {
-        u3_noun frame = _pop_list(&sat_u->susp_list);
+        u3_weak frame = _pop_list(&sat_u->susp_list);
+        if ( u3_none == frame ) u3m_bail(c3__fail);
         if (lst_catch_err != u3h(frame))
         {
           printf(ERR("wrong frame: catch-err"));

--- a/pkg/noun/jets/e/urwasm.c
+++ b/pkg/noun/jets/e/urwasm.c
@@ -2116,7 +2116,8 @@ _apply_diff(u3_noun input_tag, u3_noun p_input, lia_state* sat_u)
         while (u3h(yil) == 0 && sat_u->queue != u3_nul)
         {
           u3z(yil);
-          u3_noun deferred_script = _pop_list(&sat_u->queue);
+          u3_weak deferred_script = _pop_list(&sat_u->queue);
+          if ( u3_none == deferred_script ) return u3m_bail(c3__fail);
           yil = _reduce_monad(deferred_script, sat_u);
         }
       }

--- a/pkg/noun/jets/e/zlib.c
+++ b/pkg/noun/jets/e/zlib.c
@@ -188,13 +188,13 @@ u3qe_decompress_zlib(u3_atom pos, u3_noun octs)
   return _decompress(pos, octs, 15);
 }
 
-u3_noun
+u3_weak
 u3we_decompress_gzip(u3_noun cor)
 {
   u3_atom pos;
   u3_noun octs;
 
-  u3_noun a = u3r_at(u3x_sam, cor);
+  u3_noun a = u3x_at(u3x_sam, cor);
   u3x_cell(a, &pos, &octs);
 
   if(_(u3a_is_atom(pos)) && _(u3a_is_cell(octs))) {
@@ -206,13 +206,13 @@ u3we_decompress_gzip(u3_noun cor)
   }
 }
 
-u3_noun
+u3_weak
 u3we_decompress_zlib(u3_noun cor)
 {
   u3_atom pos;
   u3_noun octs;
 
-  u3_noun a = u3r_at(u3x_sam, cor);
+  u3_noun a = u3x_at(u3x_sam, cor);
   u3x_cell(a, &pos, &octs);
 
   if(_(u3a_is_atom(pos)) && _(u3a_is_cell(octs))) {

--- a/pkg/noun/jets/f/ut_mint.c
+++ b/pkg/noun/jets/f/ut_mint.c
@@ -20,7 +20,8 @@ u3wfu_mint(u3_noun cor)
   }
   else {
     c3_m  fun_m = 141 + c3__mint;
-    u3_noun vet = u3r_at(u3qfu_van_vet, van);
+    u3_weak vet = u3r_at(u3qfu_van_vet, van);
+    if ( u3_none == vet ) return u3m_bail(c3__fail);
     u3_noun key = u3z_key_5(fun_m, vet, sut, gol, gen, bat);
     u3_weak pro = u3z_find(u3z_memo_toss, key);
 

--- a/pkg/noun/jets/w.h
+++ b/pkg/noun/jets/w.h
@@ -320,8 +320,8 @@
     u3_noun u3wes_gth(u3_noun);
 
     u3_noun u3we_crc32(u3_noun);
-    u3_noun u3we_decompress_zlib(u3_noun);
-    u3_noun u3we_decompress_gzip(u3_noun);
+    u3_weak u3we_decompress_zlib(u3_noun);
+    u3_weak u3we_decompress_gzip(u3_noun);
 
     u3_noun u3we_lia_run_v1(u3_noun);
     u3_noun u3we_lia_run_once(u3_noun);

--- a/pkg/vere/io/ames.c
+++ b/pkg/vere/io/ames.c
@@ -2878,6 +2878,7 @@ u3_ames_io_init(u3_pier* pir_u)
   u3_noun who = u3i_chubs(2, sam_u->pir_u->who_d);
   u3_noun rac = u3do("clan:title", who);
   sam_u->sat_u.for_o = ( c3__czar == rac ) ? c3y : c3n;
+  u3z(rac);
 
   // hashtable for scry cache
   //

--- a/pkg/vere/io/http.c
+++ b/pkg/vere/io/http.c
@@ -868,7 +868,7 @@ _get_beam(u3_hreq* req_u, c3_c* txt_c, c3_w len_w, c3_o* las_o)
   //  get beak
   //
   for ( c3_w i_w = 0; i_w < 3; ++i_w ) {
-    u3_noun* wer;
+    u3_weak* wer;
     if ( 0 == i_w ) {
       wer = &bem.who;
     }
@@ -2546,7 +2546,7 @@ _http_serv_start_all(u3_httd* htd_u)
   u3_pier*  pir_u = htd_u->car_u.pir_u;
   c3_s      por_s;
   u3_noun   sec = u3_nul;
-  u3_noun   non = u3_none;
+  u3_weak   non = u3_none;
   u3_noun   dis;
   u3_form*  for_u = htd_u->fig_u.for_u;
 

--- a/pkg/vere/io/mesa.c
+++ b/pkg/vere/io/mesa.c
@@ -2683,7 +2683,7 @@ _mesa_io_talk(u3_auto* car_u)
   uv_send_buffer_size((uv_handle_t*)&u3_Host.wax_u, &rec_i);
 
   sam_u->car_u.liv_o = c3y;
-  //u3z(rac); u3z(who);
+  u3z(rac); u3z(who);
 }
 
 static void _mesa_clear_pit(uv_timer_t *tim_u)

--- a/pkg/vere/main.c
+++ b/pkg/vere/main.c
@@ -1353,7 +1353,6 @@ _cw_eval(c3_i argc, c3_c* argv[])
       exit(1);
     }
     c3_c* pre_c;
-    u3k(som);
     //  if input is jammed khan output
     if ( c3y == kan_o ) {
       u3_noun cop, uid, mar, res, tan;
@@ -1362,10 +1361,9 @@ _cw_eval(c3_i argc, c3_c* argv[])
       if ( c3n == res ) {
         //  pretty-print tang to stderr and output only header
         u3_Host.ops_u.dem = c3y;
-        u3_pier_punt_goof("eval", tan);
+        u3_pier_punt_goof("eval", u3k(tan));
         cop = som;
-        som = u3i_trel(uid, mar, res);
-        u3k(som);
+        som = u3i_trel(u3k(uid), u3k(mar), u3k(res));
         u3z(cop);
       }
     }


### PR DESCRIPTION
Cherrypicked from #1059.

I added u3_none treatment in the linter per @joemfb's request, found some omitted checks.

Also extended the linter to check functions that neither take nor return nouns (common for callbacks for external code), found some leaks as well. Refcount action in eval in main.c was very confusing, I refactored it.