### PR TITLE
Add lts release train

### DIFF
--- a/.github/workflows/lts.yml
+++ b/.github/workflows/lts.yml
@@ -1,0 +1,29 @@
+name: Push to lts
+
+on:
+  push:
+    branches:
+      - lts
+    paths:
+      - 'build.zig'
+      - 'build.zig.zon'
+      - 'ext/**'
+      - '!ext/**.md'
+      - 'pkg/**'
+      - '.github/workflows/**.yml'
+      - '*.sh'
+
+jobs:
+  urbit:
+    uses: ./.github/workflows/shared.yml
+    with:
+      pace: 'lts'
+      upload: true
+      fake_tests: false
+    secrets: inherit
+
+  docker:
+    uses: ./.github/workflows/docker-shared.yml
+    with:
+      pace: 'lts'
+    secrets: inherit

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -78,10 +78,11 @@ jobs:
 
       - name: Build binaries
         run: |
-          if [[ "${{ inputs.pace }}" == "live" ]]; then
+          if [[ "${{ inputs.pace }}" == "live" || "${{ inputs.pace }}" == "lts" ]]; then
             zig build                  \
               -Dall                    \
               -Drelease                \
+              -Dpace=${{inputs.pace}}  \
               --summary all
           else
             zig build                  \
@@ -172,10 +173,10 @@ jobs:
             fi
 
             args=""
-            # We never overwrite a binary deployed to the "live" train, but we do
-            # overwrite same-versioned binaries deployed to the "soon" and "edge"
-            # trains.
-            if [[ "${{ inputs.pace }}" == "live" ]]; then
+            # We never overwrite a binary deployed to the "live" or "lts"
+            # trains, but we do overwrite same-versioned binaries deployed to
+            # the "soon" and "edge" trains.
+            if [[ "${{ inputs.pace }}" == "live" || "${{ inputs.pace }}" == "lts" ]]; then
               gsutil cp -n "${urbit_static}" "$dest"
             else
               gsutil cp "${urbit_static}" "$dest"
@@ -205,7 +206,7 @@ jobs:
       - name: Upload latest deployed version string to GCP
         run: |
           echo "${{ inputs.pace }}" > ./PACE
-          if [ "${{ inputs.pace }}" == "live" ]; then
+          if [ "${{ inputs.pace }}" == "live" ] || [ "${{ inputs.pace }}" == "lts" ]; then
             sed -nr 's/const VERSION = "(.*)"\;/\1/p' build.zig > ./VERSION
           else
             printf "$(sed -nr 's/const VERSION = "(.*)"\;/\1/p' build.zig)-%.7s" "$(git rev-parse HEAD)" > ./VERSION

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,6 +89,7 @@ Supported values:
 - live
 - soon
 - edge
+- lts
 
 #### `-Dcopt=[list]`
 Provide additional compiler flags. These propagate to all build artifacts.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,11 +14,16 @@ reliably ship code. It's also simple to reason about.
 The branches and their corresponding trains that comprise the stages of the
 release pipeline are:
 
-| Branch    | Train  | Target audience    |
-|-----------|--------|--------------------|
-| `develop` | `edge` | Runtime developers |
-| `release` | `soon` | Early adopters     |
-| `master`  | `live` | Everyone else      |
+| Branch    | Train  | Target audience             |
+|-----------|--------|-----------------------------|
+| `develop` | `edge` | Runtime developers          |
+| `release` | `soon` | Early adopters              |
+| `master`  | `live` | Everyone else               |
+| `lts`     | `lts`  | Long-term support subscribers |
+
+The `lts` branch sits outside the three-stage pipeline: it is branched from
+`master` at an LTS release point and receives only backported fixes (see
+[LTS Releases](#lts-releases) below).
 
 `develop` is the default branch in the repo, which means that all new pull
 requests target it by default. The general flow of a new feature or bug fix
@@ -54,6 +59,14 @@ For `master`, each binary is given a version of the form `{version number}`,
 where `{version number}` is simply the version number listed in the
 [version file in the root of this repo][version].
 
+For `lts`, each binary is likewise given a bare `{version number}` (no commit
+SHA), but the version number is three-part: `{major}.{minor}.{patch}`, where
+`{major}.{minor}` is the `live` version the LTS line was cut from and
+`{patch}` increments with each backport release (e.g. `4.6.1`, `4.6.2`).
+Since the runtime's update check compares version strings for exact equality
+against its own train only, LTS version numbers never conflict with `live`
+version numbers.
+
 Each time a release is cut (i.e. `develop` is merged into `release` to kick off
 a release), the version number should be bumped on `develop` in anticipation of
 the next release.
@@ -68,10 +81,11 @@ is built from, and `{P}` is one of `linux-aarch64`, `linux-x86_64`,
 - https://bootstrap.urbit.org/vere/edge/v{VN}-{CS}/vere-v{VN}-{CS}-{P}
 - https://bootstrap.urbit.org/vere/soon/v{VN}-{CS}/vere-v{VN}-{CS}-{P}
 - https://bootstrap.urbit.org/vere/live/v{VN}/vere-v{VN}-{P}
+- https://bootstrap.urbit.org/vere/lts/v{VN}/vere-v{VN}-{P}
 
 The most recently deployed version of a given train (pace) is uploaded to
 https://bootstrap.urbit.org/vere/{T}/last, where `{T}` is one of `edge`, `soon`,
-and `live`.
+`live`, and `lts`.
 
 ### `next/kelvin/*` Endpoints
 
@@ -141,6 +155,59 @@ the "General" channel of the [Urbit Community group][urbit-community].
 [urbit-community]: https://urbit.org/groups/~bitbet-bolbel/urbit-community
 [urbit-dev]: https://groups.google.com/a/urbit.org/g/dev
 [version]: https://github.com/urbit/vere/tree/develop/VERSION
+
+## LTS Releases
+
+The `lts` branch is a long-term support line: it is cut from `master` at a
+`live` release and thereafter receives only backported fixes, never new
+features or Kelvin changes. Because the LTS line freezes the runtime's
+supported Kelvin stack, LTS binaries remain compatible with LTS-era Arvo
+indefinitely; LTS ships should also source their `%base` OTAs from an
+LTS distribution so they are not offered a Kelvin-decrementing OS update
+the runtime cannot support.
+
+### Cutting a new LTS line
+
+- [ ] Reset the `lts` branch to the `master` release commit being designated
+      as the LTS base.
+- [ ] Ensure https://bootstrap.urbit.org/vere/lts/last exists before any ship
+      is switched to the `lts` train. The `next` subcommand treats a missing
+      `last` file as a hard error, and the `runtime-version` thread would
+      misread an error body as an available update. Pushing to `lts` uploads
+      it automatically; to seed it by hand:
+      `gsutil cp gs://bootstrap.urbit.org/vere/live/last gs://bootstrap.urbit.org/vere/lts/last`
+
+### Cutting an LTS point release
+
+- [ ] Cherry-pick the fixes onto the `lts` branch via a PR targeting `lts`.
+- [ ] Bump the version number on `lts` to the next patch version (e.g. `4.6`
+      to `4.6.1`), following the same process used to bump the version on
+      `develop`.
+- [ ] Tag the release `vere-v{version}` (e.g. `vere-v4.6.1`) and push the tag.
+- [ ] Merging to `lts` triggers deployment of the `lts` binaries and Docker
+      images (`tloncorp/vere:lts`), exactly as pushing to `master` deploys
+      `live`.
+- [ ] Create a GitHub release following the same checklist as a `live`
+      release, but do **not** check "Set as the latest release", and download
+      the binaries from the `lts` deploy endpoint instead of `live`.
+- [ ] Create a placeholder pill for the new version:
+      `gsutil cp gs://bootstrap.urbit.org/urbit-vOLD.pill gs://bootstrap.urbit.org/urbit-v{version}.pill`
+- [ ] If the fix also applies to the mainline, land it on `develop` through
+      the normal pipeline; the `lts` branch is never merged back into
+      `develop`, `release`, or `master`.
+
+### Switching a ship between trains
+
+A pier records its train in `<pier>/.bin/pace`. The runtime writes this file
+once when a binary docks and never overwrites it, so switching an existing
+ship to (or from) the LTS train is a manual, documented edit while the ship
+is not running:
+
+```console
+$ echo lts > <pier>/.bin/pace
+```
+
+Subsequent `urbit next` invocations will then follow the `lts` train.
 
 ## Updating Infrastructure Ships
 

--- a/build.zig
+++ b/build.zig
@@ -126,7 +126,7 @@ pub fn build(b: *std.Build) !void {
     const release = b.option(bool, "release", "Build for release") orelse false;
     if (release) optimize = .ReleaseFast;
 
-    const Pace = enum { once, live, soon, edge };
+    const Pace = enum { once, live, soon, edge, lts };
     const pace = @tagName(b.option(
         Pace,
         "pace",


### PR DESCRIPTION
# Add an `lts` release train

This PR adds a long-term support (LTS) release train to vere, alongside the
existing `edge`/`soon`/`live` trains. The LTS line is cut from `master` at a
`live` release (the current `master`, vere-v4.6, is the first LTS base) and
thereafter receives only backported fixes — no new features and no Kelvin
changes. This PR targets both `master` and the `lts` branch.

## How the pace machinery works (background)

The release channel ("pace") is baked into the binary at compile time via the
`-Dpace` build option, which becomes `U3_VERE_PACE` in a generated `pace.h`.
Each pier records its train in `<pier>/.bin/pace`, written once when a binary
docks and never overwritten. `urbit next` reads that file and checks
`https://bootstrap.urbit.org/vere/<pace>/last` (exact string comparison
against the running version), then downloads
`.../vere/<pace>/v<ver>/vere-v<ver>-<arch>`. The runtime reports
`[%vere <pace> ~.<version> ~]` to Arvo via `%wyrd` on boot; the pace flows
through Arvo and Landscape as an opaque string, so no OS-side changes are
needed for the update flow to work on a new train.

Because the update check is per-train and equality-based, LTS version numbers
(`4.6.1`) never conflict with `live` version numbers (`4.7`), and ships only
ever see releases from their own train.

## Changes

- **`build.zig`**: add `lts` to the `Pace` enum (the only hard validation of
  pace values in the codebase).
- **`.github/workflows/lts.yml`** (new): mirrors `master.yml` — pushing to the
  `lts` branch builds and deploys with `pace: lts`, including Docker images
  (`tloncorp/vere:lts` plus a version tag).
- **`.github/workflows/shared.yml`**: extend the three `live`-only special
  cases to also cover `lts`, so LTS releases get release-grade treatment:
  - build with `-Drelease` (bare version string, no `-{sha}` suffix); an
    explicit `-Dpace=lts` is passed since `-Drelease` alone defaults the pace
    to `live`;
  - `gsutil cp -n` (never overwrite an already-deployed binary);
  - upload a bare `VERSION` (no `-{sha}`) as the train's `last` file.
- **`INSTALL.md`**: document the new `-Dpace` value.
- **`MAINTAINERS.md`**: add the `lts` branch/train to the pipeline table,
  document the three-part LTS version scheme, add the `lts` deploy endpoints,
  and add an "LTS Releases" section covering cutting an LTS line, cutting a
  point release, and switching a ship between trains.

## Versioning

LTS point releases use a three-part version: `{major}.{minor}.{patch}`, where
`{major}.{minor}` is the `live` version the line was cut from and `{patch}`
increments per backport release (first LTS is `4.6`; its first point release
will be `4.6.1`). Versions are free-form strings throughout the runtime and
the deploy pipeline, so the third component requires no code changes. Tags
follow the existing convention: `vere-v4.6.1`.

## Kelvin compatibility

The LTS line freezes the runtime's supported Kelvin stack (currently
zuse 408 / lull 320 / arvo 234 / hoon 135 / nock 4). Arvo's `%wyrd`
negotiation only blocks an upgrade when a Kelvin decrements, and by
definition that never happens within an LTS line, so LTS runtimes and
LTS-era Arvo remain mutually compatible indefinitely. LTS ships should
source their `%base` OTAs from an LTS distribution so a mainline
Kelvin-decrementing OTA is never offered to a runtime that cannot support
it (which would surface as the "runtime out of date" state).

## Deployment prerequisites (before ships switch to `lts`)

- [ ] `gs://bootstrap.urbit.org/vere/lts/last` must exist **before** any ship
      is on the `lts` train: `urbit next` treats a missing `last` file as a
      hard error, and the `runtime-version` thread would misread an error
      body as an available update. The first push to `lts` uploads it; to
      seed it by hand:
      `gsutil cp gs://bootstrap.urbit.org/vere/live/last gs://bootstrap.urbit.org/vere/lts/last`
- [ ] Each LTS point release needs a boot pill at
      `gs://bootstrap.urbit.org/urbit-v{version}.pill` (the placeholder-pill
      copy step from the existing release checklist).
- [ ] Designate/stand up the LTS OTA source for `%base` and document the
      `|ota` target for LTS ships.

## Switching an existing ship to LTS

`<pier>/.bin/pace` is write-once by the runtime, so moving an existing ship
onto (or off of) the LTS train is the already-documented manual edit while
the ship is down: `echo lts > <pier>/.bin/pace`. Fresh boots with an
lts-built binary dock onto the `lts` train automatically.

## Notes

- `docker-shared.yml` needs no changes: the existing non-`live` path already
  pushes `tloncorp/vere:lts` and a version tag. As with `live`'s `latest`
  image, the Docker build doesn't use `-Drelease`, so the image's version
  tag carries a `-{sha}` suffix; this matches existing behavior for all
  trains.
- The `lts` branch is never merged back into `develop`/`release`/`master`;
  fixes that apply to the mainline land there through the normal pipeline.