### PR TITLE
ml/64 mig debugging

### DIFF
--- a/pkg/noun/copy_migrate.h
+++ b/pkg/noun/copy_migrate.h
@@ -1,7 +1,12 @@
 /* copy_migrate.h: template for full-noun-copy migrations.
 **
 **   Each copying migration in pkg/past/ shares the same skeleton:
-**     - verstable dedup map keyed by old noun
+**     - verstable dedup map keyed by old noun; the map RETAINS every new
+**       noun it records, and releases them all in _done().  Without that,
+**       any free during the walk (a cache table evicting past max_w, or a
+**       put replacing an entry whose key compares equal) would leave the
+**       map pointing at dead nouns, and the next dedup hit would gain a
+**       freed box (bail: foul) or worse.
 **     - iterative DFS descent over the source noun with a frame stack
 **     - HAMT walker that copies key/val pairs into the target loom
 **
@@ -256,7 +261,7 @@ U3C_SYM(_next)(U3C_SYM(_ctx) *cop_u, U3C_OLD_NOUN old)
 
     if ( c3n == U3C_OLD_IS_CELL(old) ) {
       u3_atom new = U3C_SYM(_atom)(old);
-      vit_u = vt_insert(&(cop_u->map_u), old, new);
+      vit_u = vt_insert(&(cop_u->map_u), old, U3C_NEW_A_GAIN(new));
       u3_assert( !vt_is_end(vit_u) );
       return new;
     }
@@ -295,7 +300,7 @@ U3C_SYM(_noun)(U3C_SYM(_ctx) *cop_u, U3C_OLD_NOUN old)
     }
     else {
       new = U3C_NEW_I_CELL(top_u->hed, new);
-      vit_u = vt_insert(&(cop_u->map_u), top_u->cel, new);
+      vit_u = vt_insert(&(cop_u->map_u), top_u->cel, U3C_NEW_A_GAIN(new));
       u3_assert( !vt_is_end(vit_u) );
       cop_u->len_w--;
     }
@@ -326,6 +331,19 @@ U3C_SYM(_init)(U3C_SYM(_ctx) *cop_u)
 static void
 U3C_SYM(_done)(U3C_SYM(_ctx) *cop_u)
 {
+  //  release the map's references; anything displaced during the walk
+  //  is freed here, after every dedup lookup is over.
+  //
+  {
+    U3C_ITR_TY vit_u;
+    for ( vit_u = vt_first(&(cop_u->map_u));
+          !vt_is_end(vit_u);
+          vit_u = vt_next(vit_u) )
+    {
+      U3C_NEW_A_LOSE(vit_u.data->val);
+    }
+  }
+
   vt_cleanup(&(cop_u->map_u));
   c3_free(cop_u->tac);
 }

--- a/pkg/noun/migrate.c
+++ b/pkg/noun/migrate.c
@@ -91,8 +91,13 @@ u3_migrate_d(c3_d eve_d)
   u3h_walk_with_h(u3R_h->jed.cod_p, _copy_32_hamt, &cop_u);
   cop_u.ham_p = u3R->cax.per_p;
   u3h_walk_with_h(u3R_h->cax.per_p, _copy_32_hamt, &cop_u);
-  cop_u.ham_p = u3R->cax.for_p;
-  u3h_walk_with_h(u3R_h->cax.for_p, _copy_32_hamt, &cop_u);
+  //  NB: for_p was introduced after v5; a snapshot that predates it holds 0
+  //  here, and walking post 0 would read the home struct as a HAMT root.
+  //
+  if ( u3R_h->cax.for_p ) {
+    cop_u.ham_p = u3R->cax.for_p;
+    u3h_walk_with_h(u3R_h->cax.for_p, _copy_32_hamt, &cop_u);
+  }
 
   //  NB: pave does *not* allocate hot_p
   //
@@ -185,8 +190,10 @@ u3_migrate_h(c3_d eve_d)
   u3h_walk_with_d(u3R_d->jed.cod_p, _copy_64_hamt, &cop_u);
   cop_u.ham_p = u3R->cax.per_p;
   u3h_walk_with_d(u3R_d->cax.per_p, _copy_64_hamt, &cop_u);
-  cop_u.ham_p = u3R->cax.for_p;
-  u3h_walk_with_d(u3R_d->cax.for_p, _copy_64_hamt, &cop_u);
+  if ( u3R_d->cax.for_p ) {
+    cop_u.ham_p = u3R->cax.for_p;
+    u3h_walk_with_d(u3R_d->cax.for_p, _copy_64_hamt, &cop_u);
+  }
 
   //  NB: pave does *not* allocate hot_p
   //


### PR DESCRIPTION
Resolves @mopfel-winrux's `bail:foul` and similar 32 -> 64-bit migration crashes. See below stacktrace for reference:

```
root@nativeplanet:/home/nativeplanet# docker logs dacrex-sanneb -f
BOOT SHIP
Running with no STDIN
urbit -t -p 30032 --http-port 22947 --loom 33 --snap-time 60 dacrex-sanneb
Probing pier with urbit -Lx...
~
urbit 4.6-44cf010
boot: home is /urbit/dacrex-sanneb
loom: mapped 16384MB
lite: arvo formula 4ce68411
lite: core 641296f
lite: final state 641296f
disk: loaded epoch 0i1026150615
loom: mapped 8192MB
loom: 0x2200000000 fid_i 17 len 3898572800
loom: mapped 8192MB
boot: protected loom
live: mapped: GB/3.898.572.800
loom: 32->64 migration running...

bail: foul
home: bailing out

Stacktrace:
0   u3m_stacktrace                      pkg/noun/manage.c:901
1   u3m_bail                            pkg/noun/manage.c:0
2   u3a_gain                            pkg/noun/allocate.c:0
3   _copy_32_noun                       pkg/noun/copy_migrate.h:294
4   _copy_32_hamt                       pkg/noun/copy_migrate.h:312
5   _ch_walk_node_h                     pkg/noun/hashtable.c:930
6   _ch_walk_node_h                     pkg/noun/hashtable.c:938
7   u3h_walk_with_h                     pkg/noun/hashtable.c:962
8   u3_migrate_d                        pkg/noun/migrate.c:93
9   _disk_migrate_loom                  pkg/vere/disk.c:1819
10  _disk_epoc_load                     pkg/vere/disk.c:2044
11  u3_disk_load                        pkg/vere/disk.c:2321
12  u3_mars_load                        pkg/vere/mars.c:1466
13  _cw_work                            pkg/vere/main.c:3112
14  _cw_utils                           pkg/vere/main.c:3207
15  main                                pkg/vere/main.c:3233
16  libc_start_main_stage2              /home/runner/work/_temp/abc83e4f-167e-415d-9e4e-5beaec47c0c4/zig-x86_64-linux-0.15.2/lib/libc/musl/src/env/__libc_start_main.c:
```
