### PR TITLE
conn: make chan teardown idempotent and stop re-entering bail on a dead pipe

### DIFF
--- a/pkg/vere/io/conn.c
+++ b/pkg/vere/io/conn.c
@@ -288,6 +288,12 @@ _conn_close_chan(u3_shan* san_u, u3_chan* can_u)
   u3_chan*  inn_u;
   u3_cran*  ran_u;
 
+  //  already closing; teardown is idempotent.
+  //
+  if ( uv_is_closing((uv_handle_t*)&can_u->mor_u.pyp_u) ) {
+    return;
+  }
+
   //  unset chan on all pending requests.
   //
   for ( ran_u = can_u->ran_u; ran_u; ran_u = ran_u->nex_u ) {
@@ -335,12 +341,24 @@ _conn_moor_bail(void* ptr_v, ssize_t err_i, const c3_c* err_c)
   u3_chan*  can_u = (u3_chan*)ptr_v;
   u3_shan*  san_u = can_u->san_u;
 
+  //  already closing; freed from the close callback.
+  //
+  if ( uv_is_closing((uv_handle_t*)&can_u->mor_u.pyp_u) ) {
+    return;
+  }
+
   if ( err_i != UV_EOF ) {
     u3l_log("conn: moor bail %zd %s", err_i, err_c);
+
+    //  notify the client, unless it's already gone: writing to a dead
+    //  pipe fails again and re-enters here.
+    //
     if ( _(can_u->liv_o) ) {
-      _conn_send_noun(can_u, u3nq(0, c3__bail, u3i_half(err_i),
-                      u3i_string(err_c)));
       can_u->liv_o = c3n;
+      if ( (UV_EPIPE != err_i) && (UV_ECONNRESET != err_i) ) {
+        _conn_send_noun(can_u, u3nq(0, c3__bail, u3i_half(err_i),
+                        u3i_string(err_c)));
+      }
     }
   }
 

--- a/pkg/vere/newt.c
+++ b/pkg/vere/newt.c
@@ -387,7 +387,16 @@ u3_newt_mojo_stop(u3_mojo* moj_u, u3_moor_bail bal_f)
 void
 u3_newt_send(u3_mojo* moj_u, c3_d len_d, c3_y* byt_y)
 {
-  n_req* req_u = c3_malloc(sizeof(*req_u));
+  n_req* req_u;
+
+  //  a closing stream will never deliver this.
+  //
+  if ( uv_is_closing((uv_handle_t*)&moj_u->pyp_u) ) {
+    c3_free(byt_y);
+    return;
+  }
+
+  req_u = c3_malloc(sizeof(*req_u));
   req_u->moj_u = moj_u;
   req_u->buf_y = byt_y;
 


### PR DESCRIPTION
### Description

Resolves #1100.

A `conn.sock` client that disconnects while the king still owes it replies can take the ship down. Channel teardown was not idempotent, and the error path re-entered itself:

1. A reply write fails with `EPIPE` → `_newt_write_cb` → `_conn_moor_bail`.
2. `_conn_moor_bail` tries to *send* a `[0 %bail ...]` noun to the client that just went away. That write goes to the same broken pipe. `u3_newt_send` calls `bal_f` directly when `uv_write` fails synchronously, so `_conn_moor_bail` re-enters — and it re-enters before `liv_o` is cleared, so it sends again.
3. Separately, the read side seeing EOF and each queued write failing all call `_conn_moor_bail` for the same chan. Every call ran `_conn_close_chan`, which called `u3_newt_moat_stop` → `uv_close` on handles that were already closing and queued another `%done` to khan, while the chan is freed from the first close callback.

Changes:

- `_conn_close_chan`: return early if the chan's pipe is already closing, making teardown idempotent.
- `_conn_moor_bail`: return early if already closing; clear `liv_o` *before* the courtesy `%bail` write; and skip that write entirely on `EPIPE`/`ECONNRESET`, where the peer is provably gone and the write can only fail and re-enter.
- `u3_newt_send`: drop the write (freeing the buffer) if the stream is already closing rather than submitting it and reporting the inevitable failure through `bal_f` into a teardown already in progress. `_newt_write_cb` already treats writes on a closing handle as canceled; this makes the submit side agree.

### Testing

Both binaries built from this tree with zig 0.15.2 (`zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux-musl`), run against the *same* fake ship pier with the same script: pipeline N peeks over one conn.sock connection, then close the socket without reading any replies.

The crash needs enough pipelined replies to exceed the socket send buffer, so writes are still queued when the client goes away. Below that threshold the ship never sees EPIPE at all. On unpatched `dbc562a`:

| requests | `conn: moor bail` lines | result |
|---|---|---|
| 2, 10, 40, 100, 200 | 0 | survives |
| 300 | 465,775 | dies, SIGSEGV (exit 139) |
| 400 | 465,757 | dies, SIGSEGV (exit 139) |

A client that sends a single command and closes — the case c0a35c6f63 addresses — is unaffected on develop. Several hundred pipelined requests whose replies are never read is not.

With this branch, 400 requests three times in a row: 3 `conn: moor bail` lines total, one per run, ship still answering. There is no `loom: external fault` stack trace on develop; the process simply takes SIGSEGV after the bail storm.

A self-contained reproducer (python3 only, no helpers) is in the PR comments.

### Related

#490 — same symptom, could not be reproduced at the time. The reproducer in #1100 hits it reliably.