### PR TITLE
Downgrade detection for ford HAMT

### DIFF
--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -315,6 +315,8 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
     U3_W(S) for_p;                                    \
   } cax;
 
+  //  If the last field of the road struct (including nested sub-struct helpers)
+  //  changes, this value should also change.
   #define U3A_ROAD_LAST_FIELD cax.for_p
 
       U3_DEFINE_PAIR(u3a_road, U3A_ROAD_BODY);

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -313,11 +313,8 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
     U3_W(S) har_p;                                    \
     U3_W(S) per_p;                                    \
     U3_W(S) for_p;                                    \
-  } cax;
-
-  //  If the last field of the road struct (including nested sub-struct helpers)
-  //  changes, this value should also change.
-  #define U3A_ROAD_LAST_FIELD cax.for_p
+  } cax;                                              \
+  c3_y end_y[0];
 
       U3_DEFINE_PAIR(u3a_road, U3A_ROAD_BODY);
       typedef u3a_road u3_road;

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -5,6 +5,7 @@
 #include "manage.h"
 #include "rsignal.h"
 #include "c3/c3.h"
+#include <stddef.h>
 
   /**  Constants.
   **/
@@ -313,8 +314,10 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
     U3_W(S) har_p;                                    \
     U3_W(S) per_p;                                    \
     U3_W(S) for_p;                                    \
-  } cax;                                              \
-  c3_y end_y[0];
+    /* road struct terminator: no data after it, no */\
+    /* padding between the last real field and it   */\
+    c3_y end_y[0];                                    \
+  } cax;
 
       U3_DEFINE_PAIR(u3a_road, U3A_ROAD_BODY);
       typedef u3a_road u3_road;
@@ -532,6 +535,11 @@ typedef struct {
       /// Current road (thread-local).
       extern u3_road* u3a_Road;
 #       define u3R  u3a_Road
+
+      static_assert(
+        offsetof(u3a_road, cax.end_y) == offsetof(u3a_road, cax.for_p)
+                                       + sizeof(u3R->cax.for_p),
+      "no padding between the last real field of u3_road and end marker");
 
     /* u3_Code: memory code.
     */

--- a/pkg/noun/allocate.h
+++ b/pkg/noun/allocate.h
@@ -315,6 +315,8 @@ STATIC_ASSERT( u3a_vits <= u3a_min_log,
     U3_W(S) for_p;                                    \
   } cax;
 
+  #define U3A_ROAD_LAST_FIELD cax.for_p
+
       U3_DEFINE_PAIR(u3a_road, U3A_ROAD_BODY);
       typedef u3a_road u3_road;
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -646,6 +646,16 @@ _find_home(void)
     u3_assert(!u3R->fut_w[i_w] && "loom: downgrade detected");
   }
 
+  {
+    //  Check if we downgraded to a version before e.g. cax.for_p was added:
+    //  bytes between the end of the u3v_home struct and the bottom of the heap
+    //  should normally be set to 0.
+    c3_w* byt_w = (c3_w*)u3_Loom;
+    for (c3_w i_w = sizeof(u3v_home); i_w < ((c3_w)1) << u3a_page; i_w++) {
+      u3_assert(!byt_w[i_w] && "loom: downgrade detected");
+    }
+  }
+
   //  check for obvious corruption
   //
   {

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -575,7 +575,7 @@ _pave_home(void)
   u3_post bot_p = ((c3_w)1) << u3a_page;
 
   u3H = u3to(u3v_home, 0);
-  memset(u3H, 0, sizeof(u3v_home));
+  memset(u3H, 0, (c3_z)bot_p * sizeof(c3_w));
   u3H->ver_d = U3V_VERLAT;
   u3H->pam_d = _pave_params();
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -652,10 +652,12 @@ _find_home(void)
     //  should normally be set to 0.
     c3_y* byt_y = (c3_y*)u3_Loom;
     c3_w off_w = offsetof(u3v_home, rod_u.cax.end_y);
-    c3_w byte_top_w = (((c3_w)1) << u3a_page) * sizeof(c3_w);
-    for (c3_w i_w = off_w; i_w < byte_top_w; i_w++) {
-      u3_assert(!byt_y[i_w] && "loom: downgrade detected");
+    c3_w byte_bot_w = (((c3_w)1) << u3a_page) * sizeof(c3_w);
+    c3_t acc_y = 0;
+    for (c3_w i_w = off_w; i_w < byte_bot_w; i_w++) {
+      acc_y |= byt_y[i_w];
     }
+    u3_assert(!acc_y && "loom: downgrade detected");
   }
 
   //  check for obvious corruption

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -651,7 +651,7 @@ _find_home(void)
     //  bytes between the end of the u3v_home struct and the bottom of the heap
     //  should normally be set to 0.
     c3_y* byt_y = (c3_y*)u3_Loom;
-    c3_w off_w = offsetof(u3v_home, rod_u.end_y);
+    c3_w off_w = offsetof(u3v_home, rod_u.cax.end_y);
     c3_w byte_top_w = (((c3_w)1) << u3a_page) * sizeof(c3_w);
     for (c3_w i_w = off_w; i_w < byte_top_w; i_w++) {
       u3_assert(!byt_y[i_w] && "loom: downgrade detected");

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -651,7 +651,8 @@ _find_home(void)
     //  bytes between the end of the u3v_home struct and the bottom of the heap
     //  should normally be set to 0.
     c3_w* byt_w = (c3_w*)u3_Loom;
-    for (c3_w i_w = sizeof(u3v_home); i_w < ((c3_w)1) << u3a_page; i_w++) {
+    c3_w off_w = offsetof(u3v_home, rod_u.cax.for_p) + sizeof(u3v_Home->rod_u.cax.for_p);
+    for (c3_w i_w = off_w; i_w < ((c3_w)1) << u3a_page; i_w++) {
       u3_assert(!byt_w[i_w] && "loom: downgrade detected");
     }
   }

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -650,10 +650,12 @@ _find_home(void)
     //  Check if we downgraded to a version before e.g. cax.for_p was added:
     //  bytes between the end of the u3v_home struct and the bottom of the heap
     //  should normally be set to 0.
-    c3_w* byt_w = (c3_w*)u3_Loom;
-    c3_w off_w = offsetof(u3v_home, rod_u.cax.for_p) + sizeof(u3v_Home->rod_u.cax.for_p);
-    for (c3_w i_w = off_w; i_w < ((c3_w)1) << u3a_page; i_w++) {
-      u3_assert(!byt_w[i_w] && "loom: downgrade detected");
+    c3_y* byt_y = (c3_y*)u3_Loom;
+    c3_w off_w = offsetof(u3v_home, rod_u.U3A_ROAD_LAST_FIELD)
+               + sizeof(u3v_Home->rod_u.U3A_ROAD_LAST_FIELD);
+    c3_w byte_top_w = (((c3_w)1) << u3a_page) * sizeof(c3_w);
+    for (c3_w i_w = off_w; i_w < byte_top_w; i_w++) {
+      u3_assert(!byt_y[i_w] && "loom: downgrade detected");
     }
   }
 

--- a/pkg/noun/manage.c
+++ b/pkg/noun/manage.c
@@ -651,8 +651,7 @@ _find_home(void)
     //  bytes between the end of the u3v_home struct and the bottom of the heap
     //  should normally be set to 0.
     c3_y* byt_y = (c3_y*)u3_Loom;
-    c3_w off_w = offsetof(u3v_home, rod_u.U3A_ROAD_LAST_FIELD)
-               + sizeof(u3v_Home->rod_u.U3A_ROAD_LAST_FIELD);
+    c3_w off_w = offsetof(u3v_home, rod_u.end_y);
     c3_w byte_top_w = (((c3_w)1) << u3a_page) * sizeof(c3_w);
     for (c3_w i_w = off_w; i_w < byte_top_w; i_w++) {
       u3_assert(!byt_y[i_w] && "loom: downgrade detected");


### PR DESCRIPTION
#953 introduced `cax.for_p` at the end of the road struct, which happened to not need a full migration at the time because the loom is zero-initialized, the HAMT post was put at the end of the struct etc. A pseudo-migration was added which checked `cax.for_p` for being equal to zero, initializing it if that was the case.

Similarly to the issue addressed in #975, a downgrade would cause the allocations owned by that HAMT to get orphaned, so they would get e.g. freed by `|mass`. During the upgrade back to the version of Vere with `cax.for_p` the null check for cax.for_p would fail, leaving the possibly bogus value in place.

If I understand correctly, the layout of the loom is:

```
[ver_d][pam_d][arv_u][lom_u]...................V##################V
       (page_size - sizeof u3v_home) ^         ^ rut_p            ^ mat_p
```

and nothing should normally be put in between of the `u3v_home` struct and the bottom of the home road heap. So we will check if those bytes are actually equal to zero.